### PR TITLE
Use Chef::Cookbook::Metadata for handling metadata.rb files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cookbooks
 *.tar*
 \#*
 ^Cookbookfile*
+*.sw[op]

--- a/lib/kcd/dependency_reader.rb
+++ b/lib/kcd/dependency_reader.rb
@@ -8,11 +8,7 @@ module KnifeCookbookDependencies
     end
 
     def read
-      Dir.chdir(@cookbook.full_path) do
-        # XXX this filename is required because it sets __FILE__, which is
-        # used for README.md parsing among other things in metadata.rb files
-        instance_eval(@cookbook.metadata_file, @cookbook.metadata_filename)
-      end
+      @cookbook.metadata.dependencies.each { |name, constraint| depends(name, constraint) }
       @dependency_list
     end
     
@@ -29,17 +25,6 @@ module KnifeCookbookDependencies
 
     def get_dependency(name)
       @dependency_list.select { |c| c.name == name }.first
-    end
-
-    def method_missing(method, *args)
-      # Don't blow up when other metadata DSL methods are called, we
-      # only care about #depends.
-    end
-
-    def name(the_name)
-      # Module#name is defined, so method_missing won't catch it
-      # when running instance_eval on a metadata.rb that overrides
-      # the name
     end
   end
 end

--- a/spec/lib/kcd/cookbook_spec.rb
+++ b/spec/lib/kcd/cookbook_spec.rb
@@ -47,17 +47,9 @@ module KnifeCookbookDependencies
       end
     end
 
-    describe '#version_from_metadata_file' do
-      it "should be able to handle single quoted strings" do
-        Cookbook.any_instance.stub(:metadata_file).and_return(%Q{version '1.2.3'})
-
-        subject.version_from_metadata_file.should == DepSelector::Version.new('1.2.3')
-      end
-
-      it "should be able to handle double quoted strings" do
-        Cookbook.any_instance.stub(:metadata_file).and_return(%Q{version "1.2.3"})
-
-        subject.version_from_metadata_file.should == DepSelector::Version.new('1.2.3')
+    describe '#version_from_metadata' do
+      it "should return the correct version" do
+        subject.version_from_metadata.should == DepSelector::Version.new('1.1.8')
       end
     end
 


### PR DESCRIPTION
This change uses Chef::Cookbook::Metadata.from_file to parse the metadata.rb file.  This way we don't have to instance_eval or manually parse it.
