### PR TITLE
Revert "ENV["TMPDIR"] is really important for people who don't want to u...

### DIFF
--- a/lib/kcd/cookbook.rb
+++ b/lib/kcd/cookbook.rb
@@ -7,7 +7,7 @@ module KnifeCookbookDependencies
     attr_reader :name, :version_constraints, :groups
     attr_accessor :locked_version
 
-    DOWNLOAD_LOCATION = ::KCD::TMP_DIRECTORY || ENV["TMPDIR"] || '/tmp'
+    DOWNLOAD_LOCATION = ::KCD::TMP_DIRECTORY || '/tmp'
 
     def initialize(*args)
       @options = args.last.is_a?(Hash) ? args.pop : {}


### PR DESCRIPTION
...se "/tmp", and is a standard."

This reverts commit 5e31030b0cb093be098b4dfead0bd2a614acfab1.
