### PR TITLE
lock required ruby version to >= 1.9.1

### DIFF
--- a/knife_cookbook_dependencies.gemspec
+++ b/knife_cookbook_dependencies.gemspec
@@ -3,20 +3,19 @@
 require File.expand_path('../lib/kcd/version', __FILE__)
 
 Gem::Specification.new do |s|
-  # TODO FIXME need to modify all of these
-  s.authors       = ["Josiah Kiehl", "Jamie Winsor", "Erik Hollensbe"]
-  s.email         = ["josiah@skirmisher.net", "jamie@vialstudios.com", "erik@hollensbe.org"]
-  s.description   = %q{Resolves cookbook dependencies}
-  s.summary       = s.description
-  s.homepage      = "https://github.com/RiotGames/knife_cookbook_dependencies"
-  s.files         = `git ls-files`.split($\)
-  s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
-  s.name          = "knife_cookbook_dependencies"
-  s.require_paths = ["lib"]
-  s.version       = KnifeCookbookDependencies::VERSION
-  
-  # FIXME will want to adjust this later
+  s.authors               = ["Josiah Kiehl", "Jamie Winsor", "Erik Hollensbe"]
+  s.email                 = ["josiah@skirmisher.net", "jamie@vialstudios.com", "erik@hollensbe.org"]
+  s.description           = %q{Resolves cookbook dependencies}
+  s.summary               = s.description
+  s.homepage              = "https://github.com/RiotGames/knife_cookbook_dependencies"
+  s.files                 = `git ls-files`.split($\)
+  s.executables           = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  s.test_files            = s.files.grep(%r{^(test|spec|features)/})
+  s.name                  = "knife_cookbook_dependencies"
+  s.require_paths         = ["lib"]
+  s.version               = KnifeCookbookDependencies::VERSION
+  s.required_ruby_version = ">= 1.9.1"
+
   s.add_runtime_dependency 'dep_selector'
   s.add_runtime_dependency 'chef',            '~> 0.10.0'
   s.add_runtime_dependency 'minitar'


### PR DESCRIPTION
Per our discussion in IRC. Do we want to take a stand and be iOS 5 or do we want to be Android 4?
