### PR TITLE
remove alias commands from Knife command files

### DIFF
--- a/lib/chef/knife/cookbook_dependencies_clean.rb
+++ b/lib/chef/knife/cookbook_dependencies_clean.rb
@@ -18,8 +18,4 @@ module KnifeCookbookDependencies
       exit e.status_code
     end
   end
-  
-  class CookbookDepsClean < CookbookDependenciesClean
-    banner "knife cookbook deps clean"
-  end
 end

--- a/lib/chef/knife/cookbook_dependencies_init.rb
+++ b/lib/chef/knife/cookbook_dependencies_init.rb
@@ -26,8 +26,4 @@ module KnifeCookbookDependencies
       exit e.status_code
     end
   end
-
-  class CookbookDepsInit < CookbookDependenciesInit
-    banner "knife cookbook deps init [PATH]"
-  end
 end

--- a/lib/chef/knife/cookbook_dependencies_install.rb
+++ b/lib/chef/knife/cookbook_dependencies_install.rb
@@ -24,8 +24,4 @@ module KnifeCookbookDependencies
       exit e.status_code
     end
   end
-  
-  class CookbookDepsInstall < CookbookDependenciesInstall
-    banner "knife cookbook deps install (options)"
-  end
 end

--- a/lib/chef/knife/cookbook_dependencies_update.rb
+++ b/lib/chef/knife/cookbook_dependencies_update.rb
@@ -20,8 +20,4 @@ module KnifeCookbookDependencies
       exit e.status_code
     end
   end
-  
-  class CookbookDepsUpdate < CookbookDependenciesUpdate
-    banner "knife cookbook deps update"
-  end
 end

--- a/lib/chef/knife/cookbook_dependencies_upload.rb
+++ b/lib/chef/knife/cookbook_dependencies_upload.rb
@@ -36,8 +36,4 @@ module KnifeCookbookDependencies
       exit e.status_code
     end
   end
-  
-  class CookbookDepsUpload < CookbookDependenciesUpload
-    banner "knife cookbook deps upload (options)"
-  end
 end


### PR DESCRIPTION
these are not treated as aliases to Knife, they are treated as
their own separate commands. Because of this they are both loaded
into the list of commands and runtime evaluated attributes about
the commands, like lazy loading dependencies, is not inherited
within the 'aliases'
