### PR TITLE
fix issue when caching git sources with an aliased ref

### DIFF
--- a/lib/berkshelf/cookbook_source/git_location.rb
+++ b/lib/berkshelf/cookbook_source/git_location.rb
@@ -39,7 +39,7 @@ module Berkshelf
           raise CookbookNotFound, msg
         end
 
-        cb_path = File.join(destination, "#{self.name}-#{self.branch}")
+        cb_path = File.join(destination, "#{self.name}-#{Git.rev_parse(tmp_clone)}")
         FileUtils.mv(tmp_clone, cb_path, force: true)
                 
         cached = CachedCookbook.from_store_path(cb_path)

--- a/spec/unit/berkshelf/cookbook_source/git_location_spec.rb
+++ b/spec/unit/berkshelf/cookbook_source/git_location_spec.rb
@@ -16,7 +16,7 @@ module Berkshelf
       end
     end
 
-    subject { CookbookSource::GitLocation.new("nginx", complacent_constraint, git: "git://github.com/opscode-cookbooks/nginx.git") }
+    subject { CookbookSource::GitLocation.new("artifact", complacent_constraint, git: "git://github.com/RiotGames/artifact-cookbook.git") }
 
     describe "#download" do
       it "returns an instance of Berkshelf::CachedCookbook" do
@@ -24,12 +24,10 @@ module Berkshelf
       end
 
       it "downloads the cookbook to the given destination" do
-        subject.download(tmp_path)
-        # have to set outside of custom rspec matcher block
-        name, branch = subject.name, subject.branch
+        cached_cookbook = subject.download(tmp_path)
 
         tmp_path.should have_structure {
-          directory "#{name}-#{branch}" do
+          directory "#{cached_cookbook.cookbook_name}-#{Git.rev_parse(cached_cookbook.path)}" do
             file "metadata.rb"
           end
         }
@@ -83,6 +81,27 @@ module Berkshelf
           lambda {
             subject.download(tmp_path)
           }.should raise_error(ConstraintNotSatisfied)
+        end
+      end
+
+      context "given a value for ref that is a tag or branch and not a commit hash" do
+        subject do
+          CookbookSource::GitLocation.new("artifact", 
+            complacent_constraint,
+            git: "git://github.com/RiotGames/artifact-cookbook.git",
+            ref: "0.9.8"
+          )
+        end
+
+        let(:commit_hash) { "d7be334b094f497f5cce4169a8b3012bf7b27bc3" }
+
+        before(:each) { Git.should_receive(:rev_parse).and_return(commit_hash) }
+
+        it "returns a cached cookbook with a path that contains the commit hash it is pointing to" do
+          cached_cookbook = subject.download(tmp_path)
+          expected_path = tmp_path.join("#{cached_cookbook.cookbook_name}-#{commit_hash}")
+
+          cached_cookbook.path.should eql(expected_path)
         end
       end
     end


### PR DESCRIPTION
git sources cached with an alias instead of a commit hash would not
be stored and retrieved properly
