### PR TITLE
when relative paths are specified with :path, they should also be relative in the lock file

### DIFF
--- a/lib/berkshelf/cookbook_source/path_location.rb
+++ b/lib/berkshelf/cookbook_source/path_location.rb
@@ -17,8 +17,16 @@ module Berkshelf
       def initialize(name, version_constraint, options = {})
         @name = name
         @version_constraint = version_constraint
-        @path = File.expand_path(options[:path])
+        @path = PathLocation.normalize_path(options[:path])
         set_downloaded_status(true)
+      end
+
+      def self.normalize_path(path)
+        if (path[0] == "~") || Pathname.new(path).absolute?
+          File.expand_path(path)
+        else
+           path
+        end
       end
 
       # @param [#to_s] destination


### PR DESCRIPTION
This would allow easy integration with, for example, the ironfan way of doing things.
