### PR TITLE
Capture errors that occur during berksfile eval to prevent being inadver...

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -209,7 +209,11 @@ module Berkshelf
     #
     # @return [Berksfile]
     def load(content)
-      instance_eval(content)
+      begin
+        instance_eval(content)
+      rescue => e
+        raise BerksfileReadError.new(e), "An error occurred while reading the Berksfile: #{e.message}"
+      end
       self
     end
 

--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -60,4 +60,5 @@ module Berkshelf
 
   class ConstraintNotSatisfied < BerkshelfError; status_code(111); end
   class InvalidChefAPILocation < BerkshelfError; status_code(112); end
+  class BerksfileReadError < BerkshelfError; status_code(113); end
 end


### PR DESCRIPTION
...tantly caught by higher level rescues

This is mostly so errors are not incorrectly labeled. FileNotFound errors would previously be caught by the Berksfile not found error rescue block.
