### PR TITLE
Don't checksum the file if it's a broken symlink.

### DIFF
--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -59,7 +59,7 @@ module Berkshelf
       #   a checksum that can be used to uniquely identify the file understood
       #   by a Chef Server.
       def checksum(filepath)
-        Chef::ChecksumCache.generate_md5_checksum_for_file(filepath)
+        Chef::ChecksumCache.generate_md5_checksum_for_file(filepath) if File.exist?(filepath)
       end
     end
 


### PR DESCRIPTION
This was the root of the error that was previously causing Berksfile not found errors to fire. 

This is another case where emacs created broken symlinks to keep track of who opened a file and caused Berkshelf to blow up.
