### PR TITLE
BERKSHELF-112 ignore temporary editor files

### DIFF
--- a/generator_files/gitignore.erb
+++ b/generator_files/gitignore.erb
@@ -1,6 +1,12 @@
 .vagrant
 Berksfile.lock
 Gemfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
 /cookbooks
 <% if options[:scmversion] -%>
 VERSION


### PR DESCRIPTION
ignore temporary files for popular editors vi and emacs
closes https://github.com/RiotGames/berkshelf/issues/112
