### PR TITLE
Copy Cookbook Dir Contents Instead of Cookbook Dir Itself

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -32,7 +32,9 @@ module Berkshelf
         
         scratch = Berkshelf.mktmpdir
         cookbooks.each do |cb|
-          FileUtils.cp_r(cb.path, File.join(scratch, cb.cookbook_name))
+          dest = File.join(scratch, cb.cookbook_name, "/")
+          FileUtils.mkdir_p(dest)
+          FileUtils.cp_r(Dir.glob("#{cb.path}/*"), dest)
         end
 
         FileUtils.remove_dir(path, force: true)


### PR DESCRIPTION
I like the idea of keeping my cookbook and all its test deps separate from anything else on my system, so want to use **_ENV["BERKSHELF_PATH"] = ".berkshelf"**_ and keep the .berkshelf dir in my project.

Only problem is that, when one does that, the recursive copy of the cookbook dir throws an exception for trying to copy a directory to itself. There are probably better means to work around this, but globbing the directory contents instead seems to be one option to allow it to work.
