### PR TITLE
Refactoring Downloader

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -80,50 +80,50 @@ module Berkshelf
 
     private
 
-    # Searches locations for a CookbookSource. If the source does not contain a
-    # value for {CookbookSource#location}, the default locations of this
-    # downloader will be used to attempt to retrieve the source.
-    #
-    # @param [CookbookSource] source
-    #   the source to download
-    #
-    # @return [Array]
-    #   an array containing the downloaded CachedCookbook and the Location used
-    #   to download the cookbook
-    def search_locations(source)
-      cached_cookbook = nil
-      location = nil
+      # Searches locations for a CookbookSource. If the source does not contain a
+      # value for {CookbookSource#location}, the default locations of this
+      # downloader will be used to attempt to retrieve the source.
+      #
+      # @param [CookbookSource] source
+      #   the source to download
+      #
+      # @return [Array]
+      #   an array containing the downloaded CachedCookbook and the Location used
+      #   to download the cookbook
+      def search_locations(source)
+        cached_cookbook = nil
+        location = nil
 
-      locations.each do |loc|
-        location = Location.init(
-          source.name,
-          source.version_constraint,
-          loc[:options].merge(loc[:type] => loc[:value])
-        )
-        begin
-          cached_cookbook = location.download(storage_path)
-          break
-        rescue
-          cached_cookbook, location = nil
-          next
+        locations.each do |loc|
+          location = Location.init(
+            source.name,
+            source.version_constraint,
+            loc[:options].merge(loc[:type] => loc[:value])
+          )
+          begin
+            cached_cookbook = location.download(storage_path)
+            break
+          rescue
+            cached_cookbook, location = nil
+            next
+          end
         end
+
+        if cached_cookbook.nil?
+          raise CookbookNotFound, "Cookbook '#{source.name}' not found in any of the default locations"
+        end
+
+        [ cached_cookbook, location ]
       end
 
-      if cached_cookbook.nil?
-        raise CookbookNotFound, "Cookbook '#{source.name}' not found in any of the default locations"
+
+      # Validates that a source is an instance of CookbookSource
+      #
+      # @param [CookbookSource] source
+      #
+      # @return [Boolean]
+      def validate_source(source)
+        source.is_a?(Berkshelf::CookbookSource)
       end
-
-      [ cached_cookbook, location ]
-    end
-
-
-    # Validates that a source is an instance of CookbookSource
-    #
-    # @param [CookbookSource] source
-    #
-    # @return [Boolean]
-    def validate_source(source)
-      source.is_a?(Berkshelf::CookbookSource)
-    end
   end
 end


### PR DESCRIPTION
- Split up a large method
- Use #any instead of #empty where it makes sense
