### PR TITLE
Use :rubygems symbol in generated Gemfile

### DIFF
--- a/generator_files/Gemfile.erb
+++ b/generator_files/Gemfile.erb
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source :rubygems
 
 gem 'berkshelf'
 <% if options[:foodcritic] -%>


### PR DESCRIPTION
I just like it, feel free to reject. End result is identical.
