### PR TITLE
Touch metadata.rb before berk init

### DIFF
--- a/spec/unit/berkshelf/init_generator_spec.rb
+++ b/spec/unit/berkshelf/init_generator_spec.rb
@@ -45,6 +45,8 @@ module Berkshelf
 
     context "with a metadata entry in the Berksfile" do
       before do
+        Dir.mkdir target
+        File.write target.join("metadata.rb"), ""
         generator = subject.new([target], metadata_entry: true)
         capture(:stdout) { generator.invoke_all }
       end


### PR DESCRIPTION
Should fix failing CI tests :checkered_flag:
