### PR TITLE
Dir.glob does not support backslash as a File separator, even on Windows...

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -34,7 +34,10 @@ module Berkshelf
         cookbooks.each do |cb|
           dest = File.join(scratch, cb.cookbook_name, "/")
           FileUtils.mkdir_p(dest)
-          FileUtils.cp_r(Dir.glob(File.join(cb.path, "*")), dest)
+
+          # Dir.glob does not support backslash as a File separator
+          src = cb.path.to_s.gsub('\\', '/')
+          FileUtils.cp_r(Dir.glob(File.join(src, "*")), dest)
         end
 
         FileUtils.remove_dir(path, force: true)


### PR DESCRIPTION
....  See http://www.ruby-forum.com/topic/2016734.  My cookbooks directory is C:\Users\jdutton, so I can't run Vagrant without this fix.

I made the most simple patch that fixes the direct problem.  If you want to refactor or generalize this more (as with FileUtils.mv), I will gladly test your revised fix :-)
