### PR TITLE
Disable default bridged networking

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -86,7 +86,7 @@ module Berkshelf
       default: Hash.new
     attribute 'vagrant.vm.network.bridged',
       type: Boolean,
-      default: true
+      default: false
     attribute 'vagrant.vm.network.hostonly',
       type: String,
       default: '33.33.33.10'


### PR DESCRIPTION
Bridged networking on by default in the Vagrantfile leads to a prompting about which interface to bridge.

https://gist.github.com/ccda950d3fdd234f725d

Disabling.
