### PR TITLE
Allowing Berkshelf::Config.path override

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -11,7 +11,7 @@ module Berkshelf
 
       # @return [String]
       def path
-        File.join(Berkshelf.berkshelf_path, FILENAME)
+        @path || File.join(Berkshelf.berkshelf_path, FILENAME)
       end
 
       # @return [String]


### PR DESCRIPTION
The path method was only returning the default, and ignoring the local variable set when the --config flag is thrown. This fixes that issue.
