### PR TITLE
Allow config file to set ssl.verify usefully

### DIFF
--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -160,7 +160,7 @@ module Berkshelf
       desc: "Upload all cookbooks even if a frozen one exists on the target Chef Server"
     option :ssl_verify,
       type: :boolean,
-      default: true,
+      default: nil,
       desc: "Disable/Enable SSL verification when uploading cookbooks"
     desc "upload", "Upload the Cookbooks specified by a Berksfile or a Berksfile.lock to a Chef Server"
     def upload
@@ -183,7 +183,7 @@ module Berkshelf
         client_name: Berkshelf::Config.instance.chef.node_name,
         client_key: Berkshelf::Config.instance.chef.client_key,
         ssl: {
-          verify: (options[:ssl_verify] || Berkshelf::Config.instance.ssl.verify)
+          verify: (options[:ssl_verify] || Berkshelf::Config.instance.ssl.verify || true)
         }
       )
     rescue Ridley::Errors::ClientKeyFileNotFound => e


### PR DESCRIPTION
The `--ssl_verify` flag has a default of true, which means it always overrides the `ssl.verify` config file option, even if it isn't selected. Making it default to nil, and adding the default further down the chain (in case neither cli nor config file expresses an opinion).
