### PR TITLE
`berks upload` should read the knife.rb, if present

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -16,7 +16,21 @@ module Berkshelf
 
       # @return [String]
       def chef_config_path
-        @chef_config_path ||= File.expand_path(ENV["BERKSHELF_CHEF_CONFIG"] || "~/.chef/knife.rb")
+        @chef_config_path ||= begin
+          # List taken from: http://wiki.opscode.com/display/chef/Chef+Configuration+Settings
+          # Listed in order of preferred preference
+          possible_locations = [
+            ENV['BERKSHELF_CHEF_CONFIG'],
+            './.chef/knife.rb',
+            '~/.chef/knife.rb',
+            '/etc/chef/solr.rb',
+            '/etc/chef/solo.rb',
+            '/etc/chef/client.rb'
+          ].compact # compact in case ENV['BERKSHELF_CHEF_CONFIG'] is nil
+
+          location = possible_locations.find{ |location| File.exists?( File.expand_path(location) ) }
+          File.expand_path(location)
+        end
       end
 
       # @param [String] value


### PR DESCRIPTION
The `berks configure` should only be necessary if operating Berkshelf with different parameters than those specified in the `knife.rb` file. Why doesn't Berkshelf just read that as a default? It seems silly to manage multiple configurations for the same chef repo.
