### PR TITLE
Specifying -c or --config during `berks upload` does nothing...

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -7,8 +7,6 @@ module Berkshelf
     FILENAME = "config.json".freeze
 
     class << self
-      attr_writer :path
-
       # @return [String]
       def path
         @path ||= File.join(Berkshelf.berkshelf_path, FILENAME)


### PR DESCRIPTION
The only way to upload a cookbook to Chef Server is to continuously overwrite the `~/.berkshelf/config.json` file. This is not very feasible when working with multiple Chef Server installations.

It always reads the `~/.berkshelf/config.json`, regardless of the flag being specified.
