### PR TITLE
Using FileUtils.mv rather than File.rename fixes RiotGames/berkshelf#209

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -41,7 +41,7 @@ module Berkshelf
         end
 
         FileUtils.remove_dir(path, force: true)
-        File.rename(scratch, path)
+        FileUtils.mv(scratch, path)
 
         path
       end


### PR DESCRIPTION
fix for #209
