### PR TITLE
Adding :rel to :git resource, for repositories where cookbook is not in the repo root

### DIFF
--- a/lib/berkshelf/locations/git_location.rb
+++ b/lib/berkshelf/locations/git_location.rb
@@ -48,10 +48,11 @@ module Berkshelf
         self.branch = ::Berkshelf::Git.rev_parse(tmp_clone)
       end
 
-      tmp_path = "#{tmp_clone}/#{rel}"
+      tmp_path = rel ? File.join(tmp_clone, rel) : tmp_clone
       unless File.chef_cookbook?(tmp_path)
         msg = "Cookbook '#{name}' not found at git: #{uri}"
         msg << " with branch '#{branch}'" if branch
+        msg << " at path '#{rel}'" if rel
         raise CookbookNotFound, msg
       end
 


### PR DESCRIPTION
This should address #88, and will probably obviate the need for #89; the Ironfan way is likely to shift, once we understand all the implications of using Berkshelf.
