### PR TITLE
Further cleanup on options[:ssl_verify] and Berkshelf::Config.instance.ssl.verify

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -131,6 +131,7 @@ module Berkshelf
       default: 'chef_solo'
     attribute 'ssl.verify',
       type: Boolean,
-      default: true
+      default: true,
+      required: true
   end
 end


### PR DESCRIPTION
Further inspection shows this still isn't quite right. `ssl.verify` doesn't need both default and required, and I need to actually test `options[:ssl_verify]` for nil (`false || foo` still becomes `foo`, duh).
