### PR TITLE
Make git clones happen into a stable subfolder, and don't reclone if it exists

### DIFF
--- a/lib/berkshelf/locations/git_location.rb
+++ b/lib/berkshelf/locations/git_location.rb
@@ -13,8 +13,6 @@ module Berkshelf
     alias_method :ref, :branch
     alias_method :tag, :branch
 
-    @@tmpdir = Dir.mktmpdir
-
     # @param [#to_s] name
     # @param [Solve::Constraint] version_constraint
     # @param [Hash] options
@@ -81,13 +79,19 @@ module Berkshelf
     end
 
     private
+      class << self
+        def tmpdir
+          @tmpdir = Dir.mktmpdir unless defined? @tmpdir
+          @tmpdir
+        end
+      end
 
       def git
         @git ||= Berkshelf::Git.new(uri)
       end
 
       def clone
-        tmp_clone = @@tmpdir + '/' + uri.gsub(/[\/:]/,'-')
+        tmp_clone = self.class.tmpdir + '/' + uri.gsub(/[\/:]/,'-')
         ::Berkshelf::Git.clone(uri, tmp_clone) unless File.exists?(tmp_clone)
         tmp_clone
       end


### PR DESCRIPTION
We have three large repositories with cookbooks in each, which currently get downloaded one time for each cookbook. To keep large multi-cookbook repos from getting needlessly recloned, establish a (per-run) stable path for that cookbook, and assume that the path is valid if it exists (later failures will quickly notify in the incredibly unlikely chance that it both exists, and contains the wrong thing).
