### PR TITLE
Adds travis testing to docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+rvm:
+  - 1.9.3
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+script: 'jekyll --no-auto --no-server'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gem 'jekyll', '~> 0.11'


### PR DESCRIPTION
Perfoms setup of jekyll and executes the docs generation to static files.

Because my previous pull #217 failed, decided to see if we can't have testing on docs, too.
