### PR TITLE
Fix syntax on group example

### DIFF
--- a/_includes/index.md
+++ b/_includes/index.md
@@ -327,7 +327,7 @@ Groups can be defined via blocks:
 
 Groups can also be defined inline as an option:
     
-    cookbook 'riot_base', :group 'solo'
+    cookbook 'riot_base', group: 'solo'
 
 To exclude the groups when installing or updating just add the `--without` flag.
 


### PR DESCRIPTION
Could also be `:group => 'solo'`.
