### PR TITLE
Add rvmrc

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm 1.9.3-p286@berkshelf --create


### PR DESCRIPTION
There's already an rbenv-version file. I know you guys may personally use rbenv, but other devs and contributors may use RVM, so there should be some consistency in Ruby version.
