### PR TITLE
Use :ssh as the default github option

### DIFF
--- a/lib/berkshelf/locations/github_location.rb
+++ b/lib/berkshelf/locations/github_location.rb
@@ -1,7 +1,7 @@
 module Berkshelf
   # @author Josiah Kiehl <josiah@skirmisher.net>
   class GithubLocation < GitLocation
-    DEFAULT_PROTOCOL = :git
+    DEFAULT_PROTOCOL = :ssh
 
     set_location_key :github
     set_valid_options :protocol
@@ -11,7 +11,7 @@ module Berkshelf
 
     # Wraps GitLocation allowing the short form GitHub repo identifier
     # to be used in place of the complete repo url.
-    # 
+    #
     # @see GitLocation#initialize for parameter documentation
     #
     # @option options [String] :github


### PR DESCRIPTION
This is a bit opinionated, and I won't be offended if rejected. I feel like the majority of users already have a github account, so there's no advantage in using the `git://` url as the default.

As outlined in #236, you have to specify the protocol as `:ssh` if using the github shortcut syntax, which IMO defeats the purpose of the shortcut.
- :warning: Breaking change
- Fixes #236
