### PR TITLE
Raise a Berkshelf::CookbookNotFound error when trying to update a cookbook that is not in any of the sources

### DIFF
--- a/features/update_command.feature
+++ b/features/update_command.feature
@@ -12,7 +12,7 @@ Feature: update
       """
       cookbook 'artifact', :locked_version => '0.1.0'
       """
-    When I run `berks update`
+    When I successfully run `berks update`
     Then the file "Berksfile.lock" should contain exactly:
       """
       cookbook 'artifact', :locked_version => '0.10.0'
@@ -29,9 +29,27 @@ Feature: update
       cookbook 'artifact', :locked_version => '0.10.0'
       cookbook 'build-essential', :locked_version => '1.1.0'
       """
-    When I run `berks update build-essential`
+    When I successfully run `berks update build-essential`
     Then the file "Berksfile.lock" should contain exactly:
       """
       cookbook 'artifact', :locked_version => '0.10.0'
       cookbook 'build-essential', :locked_version => '1.1.2'
       """
+
+  Scenario: knife berkshelf update a cookbook that isn't in the Berksfile
+    Given I write to "Berksfile" with:
+      """
+      cookbook "artifact", "0.10.0"
+      cookbook "build-essential", "~> 1.1.0"
+      """
+    Given I write to "Berksfile.lock" with:
+      """
+      cookbook 'artifact', :locked_version => '0.10.0'
+      cookbook 'build-essential', :locked_version => '1.1.0'
+      """
+    When I run `berks update foo`
+    Then the output should contain:
+      """
+      Could not find cookbooks 'foo' in any of the sources. Is it in your Berksfile?
+      """
+    And the CLI should exit with the status code for error "CookbookNotFound"

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -378,8 +378,13 @@ module Berkshelf
         sources: sources(options)
       )
 
-      cookbooks = resolver.resolve
-      sources   = resolver.sources
+      cookbooks         = resolver.resolve
+      sources           = resolver.sources
+      missing_cookbooks = (options[:cookbooks] - cookbooks.map(&:cookbook_name))
+
+      unless missing_cookbooks.empty?
+        raise Berkshelf::CookbookNotFound, "Could not find cookbooks #{missing_cookbooks.collect{|cookbook| "'#{cookbook}'"}.join(', ')} in any of the sources. #{missing_cookbooks.size == 1 ? 'Is it' : 'Are they' } in your Berksfile?"
+      end
 
       update_lockfile(sources)
 


### PR DESCRIPTION
- Fixes #247
