### PR TITLE
Add 'test/*' to chefignore generator file.

### DIFF
--- a/generator_files/chefignore
+++ b/generator_files/chefignore
@@ -38,6 +38,7 @@ a.out
 .rspec
 spec/*
 spec/fixtures/*
+test/*
 features/*
 
 ## SCM


### PR DESCRIPTION
For completeness, it would be nice to also exclude `test/*` unless there is some other reason not to.

Cheers!
