### PR TITLE
Set metadata name if metadata name is not set

### DIFF
--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -26,6 +26,7 @@ module Berkshelf
         end
 
         name = metadata.name.empty? ? File.basename(path) : metadata.name
+        metadata.name name if metadata.name.empty?
 
         new(name, path, metadata)
       end
@@ -48,6 +49,8 @@ module Berkshelf
         rescue IOError
           raise CookbookNotFound, "No 'metadata.rb' file found at: '#{path}'"
         end
+        
+        metadata.name cached_name if metadata.name.empty?
 
         new(cached_name, path, metadata)
       end


### PR DESCRIPTION
I was running into a situation uploading to erchef where cookbooks would fail on upload if the metadata name was not set. Error generated from the server:

```
INFO req_id=vTB2AqxNiz/FvgnzlxT4Sg==; status=400; method=PUT; path=/cookbooks/openssl/1.0.0; user=croberts; msg={ej_invalid,string_match,<<"metadata.name">>,<<>>,string,string,<<"Malformed cookbook name. Must only contain A-Z, a-z, 0-9, _ or -">>}; req_time=3
```

Setting the name in the metadata if it was missing resolved the issue.
