### PR TITLE
Ignore Bundler binstub-generated directories

### DIFF
--- a/generator_files/gitignore.erb
+++ b/generator_files/gitignore.erb
@@ -1,6 +1,5 @@
 .vagrant
 Berksfile.lock
-Gemfile.lock
 *~
 *#
 .#*
@@ -8,6 +7,12 @@ Gemfile.lock
 .*.sw[a-z]
 *.un~
 /cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
 <% if options[:scmversion] -%>
 VERSION
 <% end -%>


### PR DESCRIPTION
I run my `bundle install` commands with the `--binstubs` option so no `bundle exec` is required.  This commit ensures the generated directories are properly git ignored in generated cookbooks.
