### PR TITLE
Adds support for the 'frozen' flag on 'berks upload'

### DIFF
--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -92,6 +92,7 @@ module Berkshelf
     #       ...
     #     }
     attr_reader :manifest
+    attr_accessor :frozen
 
     def_delegator :@metadata, :version
 
@@ -111,6 +112,7 @@ module Berkshelf
         providers: Array.new,
         root_files: Array.new
       )
+      @frozen = false
 
       load_files
     end
@@ -205,7 +207,7 @@ module Berkshelf
     def to_json(*a)
       result = self.to_hash
       result['json_class'] = chef_json_class
-      result['frozen?'] = false
+      result['frozen?'] = frozen
       result.to_json(*a)
     end
 

--- a/lib/berkshelf/uploader.rb
+++ b/lib/berkshelf/uploader.rb
@@ -50,6 +50,7 @@ module Berkshelf
     #
     # @return [Boolean]
     def upload(cookbook, options = {})
+      cookbook.frozen = options[:freeze] if options[:freeze]
       cookbook.validate! unless options[:skip_syntax_check]
       mutex     = Mutex.new
       checksums = cookbook.checksums.dup


### PR DESCRIPTION
fixes #320
Created a frozen attribute in CachedCookbook (to remove the hardcoded value)

Ran into a few problems:
'thor gem:installed' against master installed correctly, but I was unable to run 'berks upload'

This patch was created of off 1.1.2 (but should merge clean)

Is this a correct approach to fix this?
Is the current master stable (i'm guessing the problem is on my end, but I'll ask before digging in) ?

I'll see about adding a test as well...
