### PR TITLE
If relative path provided, generate relative

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -232,7 +232,7 @@ module Berkshelf
 
       options[:constraint] = constraint
 
-      @sources[name] = CookbookSource.new(name, options)
+      @sources[name] = CookbookSource.new(name, {:berksfile_path => filepath}.merge(options))
     end
 
     # @param [#to_s] source

--- a/lib/berkshelf/cookbook_source.rb
+++ b/lib/berkshelf/cookbook_source.rb
@@ -2,7 +2,7 @@ module Berkshelf
   # @author Jamie Winsor <jamie@vialstudios.com>
   class CookbookSource
     class << self
-      @@valid_options = [:constraint, :locations, :group, :locked_version]
+      @@valid_options = [:constraint, :locations, :group, :locked_version, :berksfile_path]
       @@location_keys = Hash.new
 
       # Returns an array of valid options to pass to the initializer
@@ -103,6 +103,8 @@ module Berkshelf
     #    same as ref
     #  @option options [String] :tag
     #    same as tag
+    #  @option options [String] :berksfile_path
+    #    path to berksfile in use
     #  @option options [String] :locked_version
     def initialize(name, options = {})
       @name = name


### PR DESCRIPTION
I was following along with this pull request: https://github.com/RiotGames/berkshelf/pull/310

I was thinking about the '~' issue and what could be done to get expected behavior from what is really a relative path. So instead of just returning the relative path that is provided, what about expanding the relative path, and then generating a new relative path to the expanded path based on the location of the Berksfile? This would ensure that relative paths provided are always usable.
