### PR TITLE
Remove unnecessary hard dependency on $HOME being set

### DIFF
--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -27,7 +27,6 @@ require 'thor/monkies'
 Chef::Config[:cache_options][:path] = Dir.mktmpdir
 
 module Berkshelf
-  DEFAULT_STORE_PATH = '~/.berkshelf'.freeze
   DEFAULT_FILENAME = 'Berksfile'.freeze
 
   autoload :BaseGenerator, 'berkshelf/base_generator'


### PR DESCRIPTION
There's no reason to try expanding '~' if BERKSHELF_PATH is set

It's an annoyance when using berkshelf to bootstrap chef-solo in an environment like an init script or chroot
