### PR TITLE
http_proxy environment variable support for downloading cookbooks

### DIFF
--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -23,6 +23,11 @@ require 'berkshelf/errors'
 require 'thor/monkies'
 
 Chef::Config[:cache_options][:path] = Dir.mktmpdir
+Chef::Config[:http_proxy] = ENV['http_proxy']
+Chef::Config[:https_proxy] = ENV['https_proxy']
+Chef::Config[:http_proxy_user] = ENV['https_proxy_user']
+Chef::Config[:http_proxy_pass] = ENV['https_proxy_pass']
+Chef::Config[:no_proxy] = ENV['no_proxy']
 
 JSON.create_id = nil
 


### PR DESCRIPTION
This is a simple path to add support for http_proxy environment variables.

Berkshelf uses the rest functionality of the chef gem which does support proxies when configured in your chef config. However, it does not appear that the chef config is loaded when downloading cookbooks.
