### PR TITLE
Loading berkshelf sets locale to C

### DIFF
--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -4,13 +4,21 @@ require 'chef/cookbook/metadata'
 require 'chef/cookbook_version'
 require 'chef/knife'
 
+# Fix for Facter < 1.7.0 changing LANG to C
+# https://github.com/puppetlabs/facter/commit/f77584f4
+begin
+  old_lang = ENV['LANG']
+  require 'ridley'
+ensure
+  ENV['LANG'] = old_lang
+end
+
 require 'chozo/core_ext'
 require 'active_support/core_ext'
 require 'archive/tar/minitar'
 require 'forwardable'
 require 'hashie'
 require 'pathname'
-require 'ridley'
 require 'solve'
 require 'thor'
 require 'tmpdir'


### PR DESCRIPTION
On OS X 10.8.2 I have installed Ruby 1.9.3p327 and Berkshelf 1.1.0. When I load Berkshelf in a ruby script, the locale in the script's environment changes from my default of en_US.UTF-8 to C.

$ cat berkshelf_locale.rb 
# !/usr/bin/env ruby

puts 'Before loading berkshelf'
puts `locale`
require 'berkshelf'
puts 'After loading berkshelf'
puts `locale`

$ ./berkshelf_locale.rb 
Before loading berkshelf
LANG="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_CTYPE="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_ALL=
After loading berkshelf
LANG="C"
LC_COLLATE="C"
LC_CTYPE="C"
LC_MESSAGES="C"
LC_MONETARY="C"
LC_NUMERIC="C"
LC_TIME="C"
LC_ALL=
