### PR TITLE
Add 'Chef' directive

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -168,6 +168,29 @@ module Berkshelf
       @@active_group = nil
     end
 
+    # Require a specific version of Chef locally - similar to bundler's "ruby" directive.
+    #
+    # @example lock to a specific chef version
+    #   chef '10.20.0'
+    #
+    # @example require higher than Chef 9
+    #   chef '> 0.9.0'
+    #
+    # @example pessimistic lock
+    #   chef '~> 11.2.0'
+    def chef(constraint)
+      # Require chef/version (so this still functions after removing Chef as a dependency)
+      require 'chef/version'
+
+      unless Solve::Constraint.new(constraint).satisfies?(Chef::VERSION)
+        raise Berkshelf::InvalidChefVersion,
+          "You have requested Chef '#{constraint}', but the local Chef version is " +
+          "'#{Chef::VERSION}'. Please update your Gemfile."
+      end
+    rescue LoadError
+      raise LoadError, "Could not load 'chef/version'. Is Chef in your Gemfile?"
+    end
+
     # Use a Cookbook metadata file to determine additional cookbook sources to retrieve. All
     # sources found in the metadata will use the default locations set in the Berksfile (if any are set)
     # or the default locations defined by Berkshelf.

--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -121,4 +121,5 @@ module Berkshelf
   class CommandUnsuccessful < BerkshelfError; status_code(118); end
   class InsufficientPrivledges < BerkshelfError; status_code(119); end
   class ExplicitCookbookNotFound < BerkshelfError; status_code(120); end
+  class InvalidChefVersion < BerkshelfError; status_code(121); end
 end

--- a/spec/unit/berkshelf/berksfile_spec.rb
+++ b/spec/unit/berkshelf/berksfile_spec.rb
@@ -119,6 +119,28 @@ EOF
       end
     end
 
+    describe '#chef' do
+      before do
+        stub_const 'Chef::VERSION', '10.20.0'
+      end
+
+      context 'with an unsatisfied constraint' do
+        it 'raises an exception' do
+          expect {
+            subject.chef('>= 11.0.0')
+          }.to raise_error Berkshelf::InvalidChefVersion
+        end
+      end
+
+      context 'with an satisfied constraint' do
+        it 'does not raise an exception' do
+          expect {
+            subject.chef('10.20.0')
+          }.to_not raise_error
+        end
+      end
+    end
+
     describe "#metadata" do
       let(:cb_path) { fixtures_path.join('cookbooks/example_cookbook') }
       subject { Berksfile.new(cb_path.join("Berksfile")) }


### PR DESCRIPTION
Given the timeline to eventually remove Chef as a dependency in Berkshelf, this PR introduces the 'chef' directive in the Berksfile, which checks for a specified Chef version on the local machine. You could argue that bundle should take care of this, but I think it makes sense to have this requirement in Berkshelf as well.
