### PR TITLE
Like bundler, berks should default do berks install

### DIFF
--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -37,7 +37,6 @@ module Berkshelf
     map 'ver'       => :version
     map 'book'      => :cookbook
 
-    # Make `install` the default task (so berks -> berks install)
     default_task :install
 
     class_option :config,


### PR DESCRIPTION
The default command for berks (with no args) should be `install`
