### PR TITLE
Add debugging output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,12 @@ server, so be sure to configure a server safe for this task.
 
 See [here](https://github.com/tdegrunt/vagrant-chef-server-bootstrap) for a
 quick way to get a testing chef server up.
+
+### Debugging Issues
+By default, Berkshelf will only give you the top-level output from a failed command. If you're working deep inside the core, an error like:
+
+    Berkshelf Error: wrong number of arguments (2 for 1)
+
+isn't exactly helpful...
+
+Specify the `BERKSHELF_DEBUG` flag when running your command to see a full stack trace and other helpful debugging information.

--- a/bin/berks
+++ b/bin/berks
@@ -6,8 +6,10 @@ begin
   Berkshelf::Cli.start
 rescue Berkshelf::BerkshelfError => e
   Berkshelf.ui.error e
+  Berkshelf.ui.error "\t" + e.backtrace.join("\n\t") if ENV['BERKSHELF_DEBUG']
   exit e.status_code
 rescue Ridley::Errors::RidleyError => e
   Berkshelf.ui.error "#{e.class} #{e}"
+  Berkshelf.ui.error "\t" + e.backtrace.join("\n\t") if ENV['BERKSHELF_DEBUG']
   exit 47
 end


### PR DESCRIPTION
This was removed in the revert, but it's very helpful when working on Berkshelf features locally to backtrace errors.
