### PR TITLE
Omit unnecessary actions with vagrant up/reload --no-provision/--provision-with

### DIFF
--- a/lib/berkshelf/vagrant/action/install.rb
+++ b/lib/berkshelf/vagrant/action/install.rb
@@ -14,7 +14,8 @@ module Berkshelf
         end
 
         def call(env)
-          if Berkshelf::Vagrant.chef_solo?(env[:vm].config)
+          if Berkshelf::Vagrant.chef_solo?(env[:vm].config) && env['provision.enabled'] &&
+            (!env['provision.types'] || env['provision.types'].include?('chef_solo'))
             configure_cookbooks_path(env)
             install(env)
           end

--- a/lib/berkshelf/vagrant/action/upload.rb
+++ b/lib/berkshelf/vagrant/action/upload.rb
@@ -11,7 +11,8 @@ module Berkshelf
         end
 
         def call(env)
-          if Berkshelf::Vagrant.chef_client?(env[:vm].config)
+          if Berkshelf::Vagrant.chef_client?(env[:vm].config) && env['provision.enabled'] &&
+            (!env['provision.types'] || env['provision.types'].include?('chef_client'))
             upload(env)
           end
 


### PR DESCRIPTION
I'm using berkshelf with vagrant. It's very nice.

I added some filters to omit unnecessary actions as same as what vagrant does.
