### PR TITLE
generated Gemfile should not include Vagrant dependency

### DIFF
--- a/generator_files/Gemfile.erb
+++ b/generator_files/Gemfile.erb
@@ -7,6 +7,3 @@ gem 'thor-foodcritic'
 <% if options[:scmversion] -%>
 gem 'thor-scmversion'
 <% end -%>
-<% unless options[:skip_vagrant] -%>
-gem 'vagrant', '~> 1.0.5'
-<% end -%>


### PR DESCRIPTION
#368 see https://github.com/RiotGames/berkshelf/blob/master/generator_files/Gemfile.erb#L10-L12
