### PR TITLE
add helpful error message for loading the berkshelf plugin

### DIFF
--- a/generator_files/Vagrantfile.erb
+++ b/generator_files/Vagrantfile.erb
@@ -1,13 +1,15 @@
 begin
-  require 'berkshelf/vagrant'
+  require 'berkshelf/vagrantx'
 rescue LoadError
-  puts "Berkshelf not found in your Vagrant's RubyGems!"
+  puts "[WARNING] Berkshelf not found in your Vagrant's RubyGems but your Vagrantfile is attempting"
+  puts "[WARNING] to require the Berkshelf Vagrant plugin! Install the Berkshelf Vagrant plugin or"
+  puts "[WARNING] remove the 'require \"berkshelf/vagrant\"' line from the top of your Vagrantfile."
   puts ""
   puts "If you installed Vagrant by RubyGems:"
   puts "  Install Berkshelf by running: \"gem install berkshelf\""
   puts "If you installed Vagrant by one of the pre-packaged installers:"
   puts "  Install Berkshelf by running: \"vagrant gem install berkshelf\""
-  exit(1)
+  puts ""
 end
 
 Vagrant::Config.run do |config|


### PR DESCRIPTION
this should help eliminate confusion for users who have installed Vagrant via the pre-packaged installer. This information will be updated when Vagrant 1.2 comes out with the new gem install command (plugin install). The rubygems bit should be removed when 1.2 comes out as well since Vagrant will no longer be packaged as a gem.
