### PR TITLE
Fixing Git support for sha, tag, branch

### DIFF
--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -37,6 +37,30 @@ module Berkshelf
     end
   end
   class PrivateGitRepo < GitError; end
+  class AmbiguousGitRef < GitError
+    attr_reader :ref
+
+    def initialize(ref)
+      @ref = ref
+    end
+
+    def to_s
+      out = "An error occurred during Git execution:\n"
+      out << "Ambiguous Git ref: #{ref}"
+    end
+  end
+  class InvalidGitRef < GitError
+    attr_reader :ref
+
+    def initialize(ref)
+      @ref = ref
+    end
+
+    def to_s
+      out = "An error occurred during Git execution:\n"
+      out << "Invalid Git ref: #{ref}"
+    end
+  end
 
   class DuplicateSourceDefined < BerkshelfError; status_code(105); end
   class NoSolution < BerkshelfError; status_code(106); end

--- a/lib/berkshelf/git.rb
+++ b/lib/berkshelf/git.rb
@@ -54,7 +54,7 @@ module Berkshelf
       #   reference to checkout
       def checkout(repo_path, ref)
         Dir.chdir repo_path do
-          git("checkout", "-q", ref)
+          git("checkout", "-qf", revision_from_ref(repo_path, ref))
         end
       end
 
@@ -62,6 +62,54 @@ module Berkshelf
       def rev_parse(repo_path)
         Dir.chdir repo_path do
           git("rev-parse", "HEAD")
+        end
+      end
+
+      # Return the sha revision for the given reference in the given repository
+      #
+      # @param [String] repo_path
+      #   path to a Git repo on disk
+      # @param [String] ref
+      #   reference to show
+      #
+      # @return [String]
+      #   the sha revision for the given ref
+      #
+      # @raise [AmbiguousGitRef] if the ref could refer to more than one revision
+      def show_ref(repo_path, ref)
+        Dir.chdir repo_path do
+          lines = git('show-ref', "'#{ref}'").lines.to_a
+
+          raise AmbiguousGitRef, ref if lines.size > 1
+
+          lines.first.chomp.split(/\s/).first
+        end
+      end
+
+      # Return the sha revision for the given reference or revision in the given repository
+      #
+      # This method is useful when you have either a sha revision, tag, or branch and
+      # you'd like to end up with a sha revision.
+      #
+      # @param [String] repo_path
+      #   path to a Git repo on disk
+      # @param [String] ref
+      #   reference to show
+      #
+      # @return [String]
+      #   the sha revision for the given ref
+      #
+      # @raise [InvalidGitRef] if the ref could not be found
+      def revision_from_ref(repo_path, ref)
+        begin
+          show_ref(repo_path, ref)
+        rescue GitError
+          begin
+            git('rev-parse', ref)
+            ref
+          rescue GitError
+            raise InvalidGitRef, ref
+          end
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,14 +123,21 @@ Spork.prefork do
           run "git commit -am '#{tag} content'"
           run "git tag '#{tag}' 2> /dev/null"
         end if options.has_key? :tags
+        options[:branches].each do |branch|
+          run! "git checkout -b #{branch} master 2> /dev/null"
+          run! "echo '#{branch}' > content_file"
+          run! "git add content_file"
+          run "git commit -am '#{branch} content'"
+          run "git checkout master 2> /dev/null"
+        end if options.has_key? :branches
       end
     end
     path
   end
 
-  def git_sha_for_tag(repo, tag)
+  def git_sha_for_ref(repo, ref)
     Dir.chdir local_git_origin_path_for(repo) do
-      run!("git show-ref '#{tag}'").chomp.split(/\s/).first
+      run!("git show-ref '#{ref}'").chomp.split(/\s/).first
     end
   end
 

--- a/spec/unit/berkshelf/git_spec.rb
+++ b/spec/unit/berkshelf/git_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Berkshelf::Git do
   describe "ClassMethods" do
     subject { Berkshelf::Git }
+    let(:git) { Berkshelf::Git }
 
     describe "::find_git" do
       it "should find git" do
@@ -33,16 +34,60 @@ describe Berkshelf::Git do
     describe "::checkout" do
       let(:repo_path) { clone_target_for('nginx') }
       let(:repo) { 
-        origin_uri = git_origin_for('nginx', tags: ['1.0.1'])
-        subject.clone(origin_uri, repo_path)
+        origin_uri = git_origin_for('nginx', tags: ['1.0.1', '1.0.2'], branches: ['topic', 'next_topic'])
+        git.clone(origin_uri, repo_path)
       }
-      let(:tag) { "1.0.1" }
 
-      it "checks out the specified path of the given repository" do
-        subject.checkout(repo, tag)
+      shared_examples "able to checkout git ref" do |test_ref|
+        it "checks out the specified ref of the given repository" do
+          git.checkout(repo, ref)
 
-        Dir.chdir repo_path do
-          %x[git rev-parse #{tag}].should == %x[git rev-parse HEAD]
+          Dir.chdir repo_path do
+            test_ref ||= ref
+            %x[git rev-parse #{test_ref}].should == %x[git rev-parse HEAD]
+          end
+        end
+      end
+
+      context 'with sha commit id' do
+        let(:ref) { git_sha_for_ref('nginx', '1.0.1') }
+
+        it_behaves_like 'able to checkout git ref'
+      end
+
+      context 'with tags' do
+        let(:ref) { "1.0.1" }
+
+        it_behaves_like 'able to checkout git ref'
+
+        context 'after checking out another tag' do
+          let(:other_tag) { '1.0.2' }
+          before do
+            git.checkout(repo, other_tag)
+            Dir.chdir repo_path do
+              run! "echo 'uncommitted change' >> content_file"
+            end
+          end
+
+          it_behaves_like 'able to checkout git ref'
+        end
+      end
+
+      context 'with branches' do
+        let(:ref) { 'topic' }
+
+        it_behaves_like 'able to checkout git ref', 'origin/topic'
+
+        context 'after checking out another branch' do
+          let(:other_branch) { 'next_topic' }
+          before do
+            git.checkout(repo, other_branch)
+            Dir.chdir repo_path do
+              run! "echo 'uncommitted change' >> content_file"
+            end
+          end
+
+          it_behaves_like 'able to checkout git ref', 'origin/topic'
         end
       end
     end
@@ -52,11 +97,76 @@ describe Berkshelf::Git do
       before(:each) do |example|
         origin_uri = git_origin_for('nginx', tags: ['1.1.1'])
         subject.clone(origin_uri, repo_path)
-        subject.checkout(repo_path, git_sha_for_tag('nginx', '1.1.1'))
+        subject.checkout(repo_path, git_sha_for_ref('nginx', '1.1.1'))
       end
 
       it "returns the ref for HEAD" do
-        expect(subject.rev_parse(repo_path)).to eql(git_sha_for_tag('nginx', '1.1.1'))
+        expect(subject.rev_parse(repo_path)).to eql(git_sha_for_ref('nginx', '1.1.1'))
+      end
+    end
+
+    describe "::show_ref" do
+      let(:repo_path) { clone_target_for('nginx') }
+      let(:tags) { ['1.0.1'] }
+      let(:branches) { ['topic'] }
+      let!(:repo) {
+        origin_uri = git_origin_for('nginx', tags: tags, branches: branches)
+        git.clone(origin_uri, repo_path)
+      }
+
+      it 'returns the commit id for the given tag' do
+        git.show_ref(repo_path, '1.0.1').should == git_sha_for_ref('nginx', '1.0.1')
+      end
+
+      it 'returns the commit id for the given branch' do
+        git.show_ref(repo_path, 'topic').should == git_sha_for_ref('nginx', 'topic')
+      end
+
+      context 'with an ambiguous ref' do
+        let(:tags) { ['topic'] }
+        let(:branches) { ['topic'] }
+
+        it 'raises an error' do
+          expect {git.show_ref(repo_path, 'topic')}.to raise_error(Berkshelf::AmbiguousGitRef)
+        end
+      end
+    end
+
+    describe '::revision_from_ref' do
+      let(:repo_path) { clone_target_for('nginx') }
+      let(:tags) { ['1.0.1'] }
+      let(:branches) { ['topic'] }
+      let!(:repo) {
+        origin_uri = git_origin_for('nginx', tags: tags, branches: branches)
+        git.clone(origin_uri, repo_path)
+      }
+
+      context 'with sha commit id' do
+        let(:revision) { git_sha_for_ref('nginx', '1.0.1') }
+        it 'returns the passed revision' do
+          git.revision_from_ref(repo_path, revision).should == revision
+        end
+      end
+
+      context 'with tag' do
+        let(:revision) { git_sha_for_ref('nginx', '1.0.1') }
+        it 'returns the revision' do
+          git.revision_from_ref(repo_path, '1.0.1').should == revision
+        end
+      end
+
+      context 'with branch' do
+        let(:revision) { git_sha_for_ref('nginx', 'topic') }
+        it 'returns the revision' do
+          git.revision_from_ref(repo_path, 'topic').should == revision
+        end
+      end
+
+      context 'with an invalid ref' do
+        let(:ref) { 'foobar' }
+        it 'raises an error' do
+          expect { git.revision_from_ref(repo_path, ref) }.to raise_error(Berkshelf::InvalidGitRef)
+        end
       end
     end
 


### PR DESCRIPTION
This allows multiple cookbooks to be pulled from different branches of the same git repository.  In the current release, the git repo is cloned and the ref is checked out the first time it's mentioned in the Berksfile.  Any other references to the repo on different branches are ignored due to the way we were using git.  I've changed the checkout process to check out the revision pointed to by the branch or tag name.

The test suite now tests sha revisions, tags, and branches.
