### PR TITLE
fix lockfiles, improve cache performance across the board

### DIFF
--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -20,7 +20,7 @@ module Berkshelf
       #   a path on disk to the location of a Cookbook
       #
       # @return [Berkshelf::CachedCookbook]
-      def from_path(path)
+      def from_path(path, provided_name=nil)
         path = Pathname.new(path)
         metadata = Chef::Cookbook::Metadata.new
 
@@ -30,7 +30,11 @@ module Berkshelf
           raise CookbookNotFound, "No 'metadata.rb' file found at: '#{path}'"
         end
 
-        name = metadata.name.empty? ? File.basename(path) : metadata.name
+        name = provided_name || metadata.name
+
+        if !name or name.empty?
+          name = File.basename(path)
+        end
 
         new(name, path, metadata)
       end

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -117,7 +117,6 @@ module Berkshelf
       aliases: "-o"
     method_option :berksfile,
       type: :string,
-      default: File.join(Dir.pwd, Berkshelf::DEFAULT_FILENAME),
       desc: "Path to a Berksfile to operate off of.",
       aliases: "-b",
       banner: "PATH"
@@ -128,7 +127,11 @@ module Berkshelf
       banner: "PATH"
     desc "install", "Install the Cookbooks specified by a Berksfile or a Berksfile.lock"
     def install
-      berksfile = ::Berkshelf::Berksfile.from_file(options[:berksfile])
+      # loljava
+      lockfile_name = Berkshelf::Lockfile::DEFAULT_FILENAME
+      berksfile_name = Berkshelf::DEFAULT_FILENAME
+      default_filename = [lockfile_name, berksfile_name].find { |x| File.exist?(File.join(Dir.pwd, x)) }
+      berksfile = ::Berkshelf::Berksfile.from_file(options[:berksfile] || default_filename)
       berksfile.install(options)
     end
 

--- a/lib/berkshelf/cookbook_source.rb
+++ b/lib/berkshelf/cookbook_source.rb
@@ -93,7 +93,7 @@ module Berkshelf
     #  @option options [String] :locked_version
     def initialize(name, options = {})
       @name = name
-      @version_constraint = Solve::Constraint.new(options[:constraint] || ">= 0.0.0")
+      @version_constraint = Solve::Constraint.new(options[:locked_version] || options[:constraint] || ">= 0.0.0")
       @groups = []
       @cached_cookbook = nil
       @location = nil
@@ -106,6 +106,13 @@ module Berkshelf
 
       if @location.is_a?(PathLocation)
         @cached_cookbook = CachedCookbook.from_path(location.path)
+      end
+
+      cache_path = File.join(Berkshelf.cookbooks_dir, "#{name}-#{options[:locked_version]}")
+
+      if File.directory?(cache_path) and !@location and options[:locked_version]
+        @cached_cookbook = CachedCookbook.from_path(cache_path, name)
+        @location = PathLocation.new(name, version_constraint, :path => cache_path)
       end
 
       @locked_version = Solve::Version.new(options[:locked_version]) if options[:locked_version]

--- a/lib/berkshelf/locations/path_location.rb
+++ b/lib/berkshelf/locations/path_location.rb
@@ -24,7 +24,7 @@ module Berkshelf
     #
     # @return [Berkshelf::CachedCookbook]
     def download(destination)
-      cached = CachedCookbook.from_path(path)
+      cached = CachedCookbook.from_path(path, name)
       validate_cached(cached)
 
       set_downloaded_status(true)

--- a/lib/berkshelf/lockfile.rb
+++ b/lib/berkshelf/lockfile.rb
@@ -25,7 +25,7 @@ module Berkshelf
         if source.location.is_a?(GitLocation)
           definition += ", :git => '#{source.location.uri}', :ref => '#{source.location.branch || 'HEAD'}'"
         elsif source.location.is_a?(PathLocation)
-          definition += ", :path => '#{source.location.path}'"
+          definition += ", :path => '#{File.expand_path(source.location.path, Dir.pwd)}'"
         else
           definition += ", :locked_version => '#{source.locked_version}'"
         end


### PR DESCRIPTION
So, it helps when you have a cache to actually use it, and when you do use it, to not make it so slow that downloading it is faster than reading it off a local SSD.

These patches do that against 1.1.6 by short pathing across the board and fixing lock files. This would have been easier if the resolver critical path wasn't a giant pile of spaghetti, which I'm pretty sure is why update is still dog slow but I don't have time to fix everything.

Results against a corpus of around 100 cookbooks, most of them from git (but some of them from the cookbooks api) that are already in cache:

```
before (1.1.6 gem from rubygems.org):
berks install --path cookbooks  58.73s user 18.32s system 18% cpu 6:51.95 total

after:
berks install --path cookbooks  5.00s user 2.08s system 79% cpu 8.904 total
```

7 minutes down to 9 seconds. You judge for yourself.

Feel free to merge it, no tests, no author changes. Largely just sending the PR here so you don't put your name on this too and pretending like you wrote it between telling people how to code and fighting for the user. I plan to run off my fork.

And to think, we started this thing because librarian was slow. Shame shame.

HAND.
