### PR TITLE
Rubygems via https

### DIFF
--- a/generator_files/Gemfile.erb
+++ b/generator_files/Gemfile.erb
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'berkshelf'
 <% if options[:foodcritic] -%>


### PR DESCRIPTION
Stops rubygems whining that you should not use "source :rubygems" in your Gemfile anymore as it is less safe than "source 'https://rubygems.org'". Pretty sure it is backwards compatible but not 100% sure. 
