### PR TITLE
remove facter language override prevention hack

### DIFF
--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -1,14 +1,5 @@
 require 'multi_json'
-
-# Fix for Facter < 1.7.0 changing LANG to C
-# https://github.com/puppetlabs/facter/commit/f77584f4
-begin
-  old_lang = ENV['LANG']
-  require 'ridley'
-ensure
-  ENV['LANG'] = old_lang
-end
-
+require 'ridley'
 require 'chozo/core_ext'
 require 'active_support/core_ext'
 require 'archive/tar/minitar'


### PR DESCRIPTION
no longer needed since Celluloid 0.13.0 no longer uses Facter to determine CPU counts
we now require Celluloid >= 0.13.0

@justincampbell 
https://github.com/celluloid/celluloid/commit/568708d627d7bd1ece33c0b00a3f9ac6bf1e0c22
https://github.com/celluloid/celluloid/pull/164#issuecomment-13321498
