### PR TITLE
Add ability to give berkshelf an additional path for cookbook templates via config or cli 

### DIFF
--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -273,6 +273,9 @@ module Berkshelf
       end
     end
 
+    method_option :cookbook_templates,
+      type: :string,
+      desc: "Path to user customized cookbook templates"
     method_option :foodcritic,
       type: :boolean,
       desc: "Creates a Thorfile with Foodcritic support to lint test your cookbook"
@@ -349,6 +352,9 @@ module Berkshelf
       Berkshelf.formatter.msg license
     end
 
+    method_option :cookbook_templates,
+      type: :string,
+      desc: "Path to user customized cookbook templates"
     method_option :foodcritic,
       type: :boolean,
       desc: "Creates a Thorfile with Foodcritic support to lint test your cookbook"

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -99,5 +99,7 @@ module Berkshelf
       type: Boolean,
       default: true,
       required: true
+    attribute 'cookbook_templates',
+      type: String
   end
 end

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -37,6 +37,10 @@ module Berkshelf
       type: :string,
       default: Berkshelf::Config.instance.cookbook.email
 
+    class_option :cookbook_templates,
+      type: :string,
+      default: Berkshelf::Config.instance.cookbook_templates
+
     def generate
       empty_directory target.join("files/default")
       empty_directory target.join("templates/default")
@@ -46,6 +50,12 @@ module Berkshelf
       empty_directory target.join("providers")
       empty_directory target.join("recipes")
       empty_directory target.join("resources")
+
+      if options[:cookbook_templates]
+        unless source_paths.include?(options[:cookbook_templates])
+          source_paths.unshift(File.expand_path(options[:cookbook_templates]))
+        end
+      end
 
       template "default_recipe.erb", target.join("recipes/default.rb")
       template "metadata.rb.erb", target.join("metadata.rb")

--- a/lib/berkshelf/init_generator.rb
+++ b/lib/berkshelf/init_generator.rb
@@ -44,10 +44,20 @@ module Berkshelf
       type: :hash,
       default: Config.instance
 
+    class_option :cookbook_templates,
+      type: :string,
+      default: Berkshelf::Config.instance.cookbook_templates
+
     # Generate the cookbook
     def generate
       validate_configuration
       check_option_support
+
+      if options[:cookbook_templates]
+        unless source_paths.include?(options[:cookbook_templates])
+          source_paths.unshift(File.expand_path(options[:cookbook_templates]))
+        end
+      end
 
       template "Berksfile.erb", target.join("Berksfile")
 


### PR DESCRIPTION
I'm not sure if this is the best way to do this, but it is A way.  If this is sensible I can look at adding tests.  If not, feedback pointing me in the right direction would be ace.

---

Add a --cookbook_templates cli and config file option to provide an extra path to search for cookbook templates.

With a few short keystrokes, use your own Vagrantfile.erb, save time,
keystrokes, and possibly even the world itself!

Addresses RiotGames/berkshelf#437
