### PR TITLE
Always uploads to chef_api defined org, rather than knife defined org

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -503,9 +503,9 @@ module Berkshelf
         raise UploadFailure, "Missing required attribute in your Berkshelf configuration: chef.client_key"
       end
 
-      conn        = Ridley.new(ridley_options)
       solution    = resolve(options)
       upload_opts = options.slice(:force, :freeze)
+      conn        = Ridley.new(ridley_options)
 
       solution.each do |cb|
         Berkshelf.formatter.upload(cb.cookbook_name, cb.version, conn.server_url)


### PR DESCRIPTION
We use a "cookbook" org to upload all our blessed core cookbooks to.  We add a line like this to our Berksfiles: 
`chef_api "https://chef.mydomain.com/organizations/cookbooks", node_name: ENV['USER'], client_key: #{ENV['HOME']}/.chef/#{ENV['USER']}.pem`

Then we use knife.rb in our other org repos to set the chef url for that org. So the workflow is to download these core cookbooks from our cookbook org and upload them to our other orgs (per client/business unit).  This worked fine in 1.2.x, but now I see it always uploading to our cookbook org. I caught this because I happen to have write access to that org and have been testing 1.3.  Even in the berks output it claims to be uploading to the correct org.
