### PR TITLE
relax dependency constraint on Thor

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '>= 1.5.0'
   s.add_dependency 'multi_json', '~> 1.5'
   s.add_dependency 'solve', '>= 0.4.2'
-  s.add_dependency 'thor', '~> 0.16.0'
+  s.add_dependency 'thor', '>= 0.16.0'
   s.add_dependency 'retryable'
 
   s.add_development_dependency 'aruba'


### PR DESCRIPTION
Allows other gem authors who depend on Thor to more easily depend on Berkshelf

https://github.com/opscode/kitchen-vagrant/issues/10
