### PR TITLE
Fix specs - look in right place for testing knife.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ Spork.prefork do
 
   APP_ROOT = File.expand_path('../../', __FILE__)
   ENV["BERKSHELF_PATH"] = File.join(APP_ROOT, "spec", "tmp", "berkshelf")
-  ENV["BERKSHELF_CHEF_CONFIG"] = File.join(APP_ROOT, "spec", "tmp", "knife.rb")
+  ENV["BERKSHELF_CHEF_CONFIG"] = File.join(APP_ROOT, "spec", "knife.rb")
 
   Dir[File.join(APP_ROOT, "spec/support/**/*.rb")].each {|f| require f}
 


### PR DESCRIPTION
My knife.rb had none for cookbook_license which was infiltrating my specs,
because we were looking in the wrong place for the testing version.
