### PR TITLE
Enable berkshelf-vagrant by default

### DIFF
--- a/generator_files/Vagrantfile.erb
+++ b/generator_files/Vagrantfile.erb
@@ -68,7 +68,7 @@ Vagrant.configure("2") do |config|
   # The path to the Berksfile to use with Vagrant Berkshelf
   # config.berkshelf.berksfile_path = "./Berksfile"
 
-  # Enabling the Berkshelf plugin. To globally enabled, add this configuration
+  # Enabling the Berkshelf plugin. To enable this globally, add this configuration
   # option to your ~/.vagrant.d/Vagrantfile file
   config.berkshelf.enabled = true
 


### PR DESCRIPTION
This commit needs to accompany RiotGames/berkshelf-vagrant#11 which allows the plugin to be enabled/disabled and defaults to disabled.
