### PR TITLE
Is there any config file for author name/email to populate while creating cookbook?

### DIFF
--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -392,7 +392,6 @@ module Berkshelf
       desc: "Creates a Thorfile with SCMVersion support to manage versions for continuous integration"
     method_option :license,
       type: :string,
-      default: "reserved",
       desc: "License for cookbook (apachev2, gplv2, gplv3, mit, reserved)",
       aliases: "-L"
     method_option :maintainer,


### PR DESCRIPTION
When I issue cmd to create new cookbook (berks cookbook mycook), the scaffolded cookbook has:

```
#
# Cookbook Name:: ruby_quick_installer
# Recipe:: default
#
# Copyright (C) 2013 YOUR_NAME
#
# All rights reserved - Do Not Redistribute
#
```

Is there any config-rc kinda setting file that have the infos that berkshelf can use to pre-populate those info in the generated recipes like the `YOUR_NAME` or email of the authoer?
