### PR TITLE
Init Error

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -15,17 +15,18 @@ Gem::Specification.new do |s|
     "justin.campbell@riotgames.com"
   ]
 
-  s.description           = %q{Manages a Cookbook's, or an Application's, Cookbook dependencies}
-  s.summary               = s.description
-  s.homepage              = "http://berkshelf.com"
-  s.license               = "Apache 2.0"
-  s.files                 = `git ls-files`.split($\)
-  s.executables           = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  s.test_files            = s.files.grep(%r{^(test|spec|features)/})
-  s.name                  = "berkshelf"
-  s.require_paths         = ["lib"]
-  s.version               = Berkshelf::VERSION
-  s.required_ruby_version = ">= 1.9.1"
+  s.description               = %q{Manages a Cookbook's, or an Application's, Cookbook dependencies}
+  s.summary                   = s.description
+  s.homepage                  = "http://berkshelf.com"
+  s.license                   = "Apache 2.0"
+  s.files                     = `git ls-files`.split($\)
+  s.executables               = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  s.test_files                = s.files.grep(%r{^(test|spec|features)/})
+  s.name                      = "berkshelf"
+  s.require_paths             = ["lib"]
+  s.version                   = Berkshelf::VERSION
+  s.required_ruby_version     = ">= 1.9.1"
+  s.required_rubygems_version = ">= 1.8.0"
 
   s.add_dependency 'celluloid', '>= 0.13.0'
   s.add_dependency 'yajl-ruby'


### PR DESCRIPTION
Got this error, any ideas?

```
~/.rvm/gems/ruby-1.9.2-p320/gems/berkshelf-1.4.0/lib/berkshelf/init_generator.rb:155:in `assert_default_supported': undefined method `find_by_name' for Gem::Specification:Class (NoMethodError)
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/berkshelf-1.4.0/lib/berkshelf/init_generator.rb:129:in `check_option_support'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/berkshelf-1.4.0/lib/berkshelf/init_generator.rb:54:in `generate'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `block in invoke_all'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `each'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `map'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `invoke_all'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/berkshelf-1.4.0/lib/berkshelf/cli.rb:307:in `init'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/berkshelf-1.4.0/lib/berkshelf/cli.rb:17:in `dispatch'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/gems/berkshelf-1.4.0/bin/berks:6:in `<top (required)>'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/bin/berks:19:in `load'
    from /home/kbacha/.rvm/gems/ruby-1.9.2-p320/bin/berks:19:in `<main>'
```
