### PR TITLE
Re-think #463?

### DIFF
--- a/lib/berkshelf/cookbook_source.rb
+++ b/lib/berkshelf/cookbook_source.rb
@@ -68,32 +68,37 @@ module Berkshelf
 
     extend Forwardable
 
+    # @return [Berkshelf::Berksfile]
     attr_reader :berksfile
+    # @return [String]
     attr_reader :name
-    attr_reader :options
+    # @return [Solve::Constraint]
     attr_reader :version_constraint
+    # @return [Berkshelf::CachedCookbook]
     attr_accessor :cached_cookbook
 
-    #  @param [String] name
-    #  @param [Hash] options
+    # @param [Berkshelf::Berksfile] berksfile
+    #   the berksfile this source belongs to
+    # @param [String] name
+    #   the name of source
     #
-    #  @option options [String, Solve::Constraint] constraint
-    #    version constraint to resolve for this source
-    #  @option options [String] :git
-    #    the Git URL to clone
-    #  @option options [String] :site
-    #    a URL pointing to a community API endpoint
-    #  @option options [String] :path
-    #    a filepath to the cookbook on your local disk
-    #  @option options [Symbol, Array] :group
-    #    the group or groups that the cookbook belongs to
-    #  @option options [String] :ref
-    #    the commit hash or an alias to a commit hash to clone
-    #  @option options [String] :branch
-    #    same as ref
-    #  @option options [String] :tag
-    #    same as tag
-    #  @option options [String] :locked_version
+    # @option options [String, Solve::Constraint] :constraint
+    #   version constraint to resolve for this source
+    # @option options [String] :git
+    #   the Git URL to clone
+    # @option options [String] :site
+    #   a URL pointing to a community API endpoint
+    # @option options [String] :path
+    #   a filepath to the cookbook on your local disk
+    # @option options [Symbol, Array] :group
+    #   the group or groups that the cookbook belongs to
+    # @option options [String] :ref
+    #   the commit hash or an alias to a commit hash to clone
+    # @option options [String] :branch
+    #   same as ref
+    # @option options [String] :tag
+    #   same as tag
+    # @option options [String] :locked_version
     def initialize(berksfile, name, options = {})
       self.class.validate_options(options)
 


### PR DESCRIPTION
In #463, we changed the API for initializing a `CookbookSource`. In refactoring #363, a LOT of stuff was broken as a result. Can we revert https://github.com/RiotGames/berkshelf/commit/a4a40057f788ae8bf788d6c5dee7d2b99dae3dae and instead use the already-provided `options` hash for `:berskfile`?
1. It feels very messy to require another object in the initializer
2. It **requires** that a cookbook source is attached to a berksfile, which isn't always the case
3. It doesn't make sense - if I'm creating a "thing" the first "thing" I pass in should be that thing's name, not it's originating source. I wouldn't say `Seth.new(@hospital, "Seth")`

/cc @fnichol @schisamo @jtimberman and @reset because I know this was for TK stuff, but can we please think of a non-API breaking way :smile: 
