### PR TITLE
version numbers must be strings to prevent environment.save crash

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -580,7 +580,7 @@ module Berkshelf
         install
 
         environment.cookbook_versions = {}.tap do |cookbook_versions|
-          lockfile.sources.each { |source| cookbook_versions[source.name] = source.locked_version }
+          lockfile.sources.each { |source| cookbook_versions[source.name] = source.locked_version.to_s }
         end
 
         environment.save


### PR DESCRIPTION
fix for issue #520
