### PR TITLE
Avoid cookbooks vendor directory removal

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -52,8 +52,9 @@ module Berkshelf
           FileUtils.cp_r(files, dest)
         end
 
-        FileUtils.remove_dir(path, force: true)
-        FileUtils.mv(scratch, path)
+        FileUtils.rm_r Dir.glob("#{path}/*"), force: true, secure: true
+        FileUtils.mv Dir.glob("#{scratch}/*"), path
+        FileUtils.remove_dir(scratch, force: true)
 
         path
       end


### PR DESCRIPTION
This is a potential fix for https://github.com/RiotGames/vagrant-berkshelf/issues/17 

The current approach of recreating the original cookbooks folder breaks the guest vagrant lxc machine shared folder (and possibly other providers) and this patch makes sure that it is updated without the need to remove it. I've tested this changes on @mikelococo's https://github.com/mikelococo/demo-berkshelf-17 and things seems to be working fine.

I'm not sure how to write tests for this and right now I'm not able to run Berkshelf specs since I'm away from my computer but I believe that since the external behavior stays the same, it should not break anything :-)
