### PR TITLE
Remove alias_method on UI module

### DIFF
--- a/lib/berkshelf/ui.rb
+++ b/lib/berkshelf/ui.rb
@@ -10,12 +10,16 @@ module Berkshelf
       @mute = false
     end
 
-    def say(message = "", color = nil, force_new_line = nil)
+    def say(message = '', color = nil, force_new_line = nil)
       return if quiet?
 
-      super(message, color)
+      super(message, color, force_new_line)
     end
-    alias_method :info, :say
+
+    # @see {say}
+    def info(message = '', color = nil, force_new_line = nil)
+      say(message, color, force_new_line)
+    end
 
     def say_status(status, message, log_status = true)
       return if quiet?
@@ -25,7 +29,7 @@ module Berkshelf
 
     def warn(message, color = :yellow)
       return if quiet?
-      
+
       say(message, color)
     end
 


### PR DESCRIPTION
For whatever reason, `alias_method` inside a module on Windows doesn't do "the thing". It can't find super, which sucks.

There are no "tests" for this because it's only on Windows and we are already testing for it.
