### PR TITLE
Default locations are broken

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -109,9 +109,7 @@ module Berkshelf
           begin
             cached_cookbook = location.download(storage_path)
             break
-          rescue Berkshelf::CookbookNotFound,
-                 Ridley::Errors::ResourceNotFound,
-                 Ridley::Errors::HTTPNotFound
+          rescue Berkshelf::CookbookNotFound
             cached_cookbook, location = nil
             next
           end

--- a/lib/berkshelf/locations/chef_api_location.rb
+++ b/lib/berkshelf/locations/chef_api_location.rb
@@ -174,7 +174,8 @@ module Berkshelf
         else
           conn.cookbook.latest_version(name)
         end
-      rescue Ridley::Errors::HTTPNotFound
+      rescue Ridley::Errors::HTTPNotFound,
+             Ridley::Errors::ResourceNotFound
         @target_cookbook = nil
       end
 

--- a/spec/support/chef_api.rb
+++ b/spec/support/chef_api.rb
@@ -24,7 +24,8 @@ module Berkshelf
         else
           ridley.cookbook.delete(name, version)
         end
-      rescue Ridley::Errors::HTTPNotFound
+      rescue Ridley::Errors::HTTPNotFound,
+             Ridley::Errors::ResourceNotFound
         true
       end
 
@@ -36,7 +37,8 @@ module Berkshelf
         else
           !versions.find { |ver| ver == version }.nil?
         end
-      rescue Ridley::Errors::HTTPNotFound
+      rescue Ridley::Errors::HTTPNotFound,
+             Ridley::Errors::ResourceNotFound
         false
       end
 


### PR DESCRIPTION
Given a `Berksfile`:

``` ruby
chef_api :config
site :opscode

cookbook 'berkshelf-cookbook-fixture', '1.0.0'
```

And `berkshelf-cookbook-fixture` does not exist on the Chef Server.

When running `berks install`

Ridley throws an error that we aren't catching and it doesn't try to download from the community site.

---
## Scenario

``` text
Scenario: with a default chef_api(1) and site(2) location with a cookbook source that is not satisfied by the chef_api(1) location
  Given I write to "Berksfile" with:
    """
    chef_api :config
    site :opscode

    cookbook 'berkshelf-cookbook-fixture', '1.0.0'
    """
  And the Chef server does not have the cookbooks:
    | berkshelf-cookbook-fixture | 1.0.0 |
  When I successfully run `berks install`
  Then the output should contain:
    """
    Installing berkshelf-cookbook-fixture (1.0.0) from site: 'http://cookbooks.opscode.com/api/v1/cookbooks'
    """
  And the cookbook store should have the cookbooks:
    | berkshelf-cookbook-fixture | 1.0.0 |
  And the exit status should be 0
```

---
## Stacktrace

``` text
Scenario: with a default chef_api(1) and site(2) location with a cookbook source that is not satisfied by the chef_api(1) location # features/default_locations.feature:28
  Given I write to "Berksfile" with:                                                                                               # aruba-0.5.2/lib/aruba/cucumber.rb:31
    """
    chef_api :config
    site :opscode

    cookbook 'berkshelf-cookbook-fixture', '1.0.0'
    """
  And the Chef server does not have the cookbooks:                                                                                 # features/step_definitions/chef_server_steps.rb:3
    | berkshelf-cookbook-fixture | 1.0.0 |
  When I successfully run `berks install`                                                                                          # aruba-0.5.2/lib/aruba/cucumber.rb:71
    Exit status was 47 but expected it to be 0. Output:

    Ridley::Errors::ResourceNotFound caused by #<Ridley::Errors::HTTPNotFound: {"error":["Cannot find a cookbook named berkshelf-cookbook-fixture"]}>: {"error":["Cannot find a cookbook named berkshelf-cookbook-fixture"]}

     (RSpec::Expectations::ExpectationNotMetError)
    features/default_locations.feature:38:in `When I successfully run `berks install`'
  Then the output should contain:                                                                                                  # aruba-0.5.2/lib/aruba/cucumber.rb:113
    """
    Installing berkshelf-cookbook-fixture (1.0.0) from site: 'http://cookbooks.opscode.com/api/v1/cookbooks'
    """
  And the cookbook store should have the cookbooks:                                                                                # features/step_definitions/filesystem_steps.rb:54
    | berkshelf-cookbook-fixture | 1.0.0 |
  And the exit status should be 0                                                                                                  # aruba-0.5.2/lib/aruba/cucumber.rb:154
```
