### PR TITLE
berks install output has no newlines

### DIFF
--- a/lib/berkshelf/ui.rb
+++ b/lib/berkshelf/ui.rb
@@ -10,14 +10,14 @@ module Berkshelf
       @mute = false
     end
 
-    def say(message = '', color = nil, force_new_line = nil)
+    def say(message = '', color = nil, force_new_line = (message.to_s !~ /( |\t)\Z/))
       return if quiet?
 
       super(message, color, force_new_line)
     end
 
     # @see {say}
-    def info(message = '', color = nil, force_new_line = nil)
+    def info(message = '', color = nil, force_new_line = (message.to_s !~ /( |\t)\Z/))
       say(message, color, force_new_line)
     end
 


### PR DESCRIPTION
Some recent change caused `berks install` output to have no newlines, not even at the end. It looks something like this:

```
% bundle exec berks install
Using app-work (1.1.2) at path: '/Users/joseph/Developer/chef-config/cookbooks/app-work'Using bsdcpio (1.0.0)Using deployless_app (0.6.12)Using apt (1.6.1)Using ark (0.1.0)Using java (1.7.0)Using nginx (1.3.0)Using bluepill (2.2.2)Using rsyslog (1.6.6)Using logrotate (1.0.2)Using yum (2.0.6)Using runit (0.16.0)Using build-essential (1.3.2)Using ohai (1.1.8)Using php (1.1.0)Using xml (1.1.2)Using mysql (2.0.2)Using openssl (1.0.0)Using users (1.2.0)Using rbenv (1.4.1)Using git (2.0.0)Using dmg (1.1.0)% 
```

maybe something about #503's formatters?
