### PR TITLE
Only set the path option if it existed when parsing a legacy lockfile

### DIFF
--- a/lib/berkshelf/lockfile.rb
+++ b/lib/berkshelf/lockfile.rb
@@ -261,7 +261,9 @@ module Berkshelf
           #
           # @param [Hash] options
           def manipulate(options = {})
-            options[:path] = berksfile.find(name).instance_variable_get(:@options)[:path] || options[:path]
+            if options[:path]
+              options[:path] = berksfile.find(name).instance_variable_get(:@options)[:path] || options[:path]
+            end
             options
           end
       end


### PR DESCRIPTION
- See #529

The solution in #529 actually introduces a small bug. This avoids said bug.
