### PR TITLE
Speed up Contingent feature

### DIFF
--- a/features/contingent_command.feature
+++ b/features/contingent_command.feature
@@ -1,18 +1,47 @@
-Feature: contingent command
+Feature: Running the contingent command
   As a user with a Berksfile
   I want a way to the cookbooks that depend on another
   So that I can better understand my infrastructure
 
-  @slow_process
-  Scenario: Running the contingent command against a cookbook
-    Given I write to "Berksfile" with:
+  Scenario: When there are dependent cookbooks
+    Given the cookbook store has the cookbooks:
+      | dep | 1.0.0 |
+    And the cookbook store contains a cookbook "fake" "1.0.0" with dependencies:
+      | dep | ~> 1.0.0 |
+    And the cookbook store contains a cookbook "ekaf" "1.0.0" with dependencies:
+      | dep | ~> 1.0.0 |
+    And I write to "Berksfile" with:
       """
-      cookbook 'berkshelf-cookbook-fixture', '1.0.0', github: 'RiotGames/berkshelf-cookbook-fixture', branch: 'deps'
+      cookbook 'fake', '1.0.0'
+      cookbook 'ekaf', '1.0.0'
       """
-    And I successfully run `berks contingent hostsfile`
+    And I successfully run `berks contingent dep`
     Then the output should contain:
       """
-      Cookbooks contingent upon hostsfile:
-        * berkshelf-cookbook-fixture (1.0.0)
+      Cookbooks in this Berksfile contingent upon dep:
+        * ekaf (1.0.0)
+        * fake (1.0.0)
       """
     And the exit status should be 0
+
+  Scenario: When there are no dependent cookbooks
+    Given the cookbook store has the cookbooks:
+      | fake | 1.0.0 |
+    And I write to "Berksfile" with:
+      """
+      cookbook 'fake', '1.0.0'
+      """
+    And I successfully run `berks contingent dep`
+    Then the output should contain:
+      """
+      There are no cookbooks contingent upon 'dep' defined in this Berksfile
+      """
+    And the exit status should be 0
+
+  Scenario: When the cookbook is not in the Berksfile
+    Given an empty file named "Berksfile"
+    And I successfully run `berks contingent dep`
+    Then the output should contain:
+      """
+      There are no cookbooks contingent upon 'dep' defined in this Berksfile
+      """

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -364,19 +364,22 @@ module Berkshelf
 
     method_option :berksfile,
       type: :string,
-      default: File.join(Dir.pwd, Berkshelf::DEFAULT_FILENAME),
+      default: Berkshelf::DEFAULT_FILENAME,
       desc: "Path to a Berksfile to operate off of.",
       aliases: "-b",
       banner: "PATH"
     desc "contingent COOKBOOK", "Display a list of cookbooks that depend on the given cookbook"
     def contingent(name)
-      berksfile = ::Berkshelf::Berksfile.from_file(options[:berksfile])
+      berksfile = Berksfile.from_file(options[:berksfile])
 
-      Berkshelf.formatter.msg "Cookbooks contingent upon #{name}:"
-      sources = Berkshelf.ui.mute { berksfile.resolve(berksfile.sources)[:solution] }.sort.each do |cookbook|
-        if cookbook.dependencies.include?(name)
-          Berkshelf.formatter.msg "  * #{cookbook.cookbook_name} (#{cookbook.version})"
-        end
+      sources = Berkshelf.ui.mute { berksfile.resolve(berksfile.sources)[:solution] }.sort
+      dependencies = sources.select { |cookbook| cookbook.dependencies.include?(name) }
+
+      if dependencies.empty?
+        Berkshelf.formatter.msg "There are no cookbooks contingent upon '#{name}' defined in this Berksfile"
+      else
+        Berkshelf.formatter.msg "Cookbooks in this Berksfile contingent upon #{name}:"
+        print_list(dependencies)
       end
     end
 
@@ -469,6 +472,17 @@ module Berkshelf
 
       def license
         File.read(Berkshelf.root.join('LICENSE'))
+      end
+
+      # Print a list of the given cookbooks. This is used by various
+      # methods like {list} and {contingent}.
+      #
+      # @param [Array<CachedCookbook>] cookbooks
+      #
+      def print_list(cookbooks)
+        Array(cookbooks).each do |cookbook|
+          Berkshelf.formatter.msg "  * #{cookbook.cookbook_name} (#{cookbook.version})"
+        end
       end
   end
 end


### PR DESCRIPTION
This also:
- changes the output of the `contingent` command slightly
- introduces a new private CLI method `#print_list` which will later be utilized by any function that prints a list of cookbooks and versions
