### PR TITLE
Failing

### DIFF
--- a/lib/berkshelf/locations/site_location.rb
+++ b/lib/berkshelf/locations/site_location.rb
@@ -15,6 +15,9 @@ module Berkshelf
     # @param [Solve::Constraint] version_constraint
     # @param [Hash] options
     #
+    # @raise [InvalidSiteShortnameError]
+    #   if the given shortname is not defined
+    #
     # @option options [String, Symbol] :site
     #   a URL pointing to a community API endpoint. Alternatively the symbol :opscode can
     #   be provided to initialize a SiteLocation pointing to the Opscode Community Site.
@@ -22,10 +25,8 @@ module Berkshelf
       @name               = name
       @version_constraint = version_constraint
 
-      api_uri = if options[:site].nil? || SHORTNAMES.has_key?(options[:site])
-        SHORTNAMES[options[:site]]
-      elsif options[:site].kind_of?(Symbol)
-        raise InvalidSiteShortnameError.new(options[:site])
+      api_uri = if options[:site].nil?
+        SHORTNAMES[options[:site]] || raise(InvalidSiteShortnameError.new(options[:site]))
       else
         options[:site]
       end


### PR DESCRIPTION
With latest berkshelf 1.4.4 I'm now unable to check for outdated cookbooks with Opscode community website.

When running "berks outdated", I'm getting an error with ridley / faraday library :

```
$> berks outdated
Listing outdated cookbooks with newer versions available...
BETA: this feature will only pull differences from the community site and will
BETA: ignore all other sources you may have defined

/usr/lib/ruby/1.9.1/net/http.rb:1404:in `addr_port': undefined method `+' for nil:NilClass (NoMethodError)
        from /usr/lib/ruby/1.9.1/net/http.rb:1339:in `begin_transport'
        from /usr/lib/ruby/1.9.1/net/http.rb:1315:in `transport_request'
        from /usr/lib/ruby/1.9.1/net/http.rb:1293:in `request'
        from /usr/lib/ruby/1.9.1/net/http.rb:1286:in `block in request'
        from /usr/lib/ruby/1.9.1/net/http.rb:745:in `start'
        from /usr/lib/ruby/1.9.1/net/http.rb:1284:in `request'
        from /usr/lib/ruby/1.9.1/net/http.rb:1026:in `get'
        from /var/lib/gems/1.9.1/gems/faraday-0.8.7/lib/faraday/adapter/net_http.rb:73:in `perform_request'
        from /var/lib/gems/1.9.1/gems/faraday-0.8.7/lib/faraday/adapter/net_http.rb:38:in `call'
        from /var/lib/gems/1.9.1/gems/ridley-0.12.3/lib/ridley/middleware/retry.rb:31:in `call'
        from /var/lib/gems/1.9.1/gems/faraday-0.8.7/lib/faraday/response.rb:8:in `call'
        from /var/lib/gems/1.9.1/gems/faraday-0.8.7/lib/faraday/connection.rb:247:in `run_request'
        from /var/lib/gems/1.9.1/gems/faraday-0.8.7/lib/faraday/connection.rb:100:in `get'
        from /var/lib/gems/1.9.1/gems/berkshelf-1.4.4/lib/berkshelf/community_rest.rb:115:in `latest_version'
        from /var/lib/gems/1.9.1/gems/berkshelf-1.4.4/lib/berkshelf/locations/site_location.rb:57:in `latest_version'
        from /var/lib/gems/1.9.1/gems/berkshelf-1.4.4/lib/berkshelf/berksfile.rb:437:in `block in outdated'
        from /var/lib/gems/1.9.1/gems/berkshelf-1.4.4/lib/berkshelf/berksfile.rb:433:in `each'
        from /var/lib/gems/1.9.1/gems/berkshelf-1.4.4/lib/berkshelf/berksfile.rb:433:in `outdated'
        from /var/lib/gems/1.9.1/gems/berkshelf-1.4.4/lib/berkshelf/cli.rb:265:in `outdated'
        from /var/lib/gems/1.9.1/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from /var/lib/gems/1.9.1/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from /var/lib/gems/1.9.1/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from /var/lib/gems/1.9.1/gems/berkshelf-1.4.4/lib/berkshelf/cli.rb:17:in `dispatch'
        from /var/lib/gems/1.9.1/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
        from /var/lib/gems/1.9.1/gems/berkshelf-1.4.4/bin/berks:6:in `<top (required)>'
        from /usr/local/bin/berks:23:in `load'
        from /usr/local/bin/berks:23:in `<main>'
```

```
ruby --version
ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-linux]
```

```
gem --version
1.8.23
```
