### PR TITLE
json parsing middleware registerd as :parse_json in Ridley 0.12.4

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mixlib-shellout', '~> 1.1'
   s.add_dependency 'mixlib-config', '~> 1.1'
   s.add_dependency 'faraday', '>= 0.8.5'
-  s.add_dependency 'ridley', '~> 0.12.1'
+  s.add_dependency 'ridley', '~> 0.12.4'
   s.add_dependency 'chozo', '>= 0.6.1'
   s.add_dependency 'hashie', '>= 2.0.2'
   s.add_dependency 'minitar'

--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -72,7 +72,7 @@ module Berkshelf
       @retry_interval = options[:retry_interval]
 
       builder = Faraday::Builder.new do |b|
-        b.response :json
+        b.response :parse_json
         b.request :retry,
           max: @retries,
           interval: @retry_interval,


### PR DESCRIPTION
lock to ~> 0.12.4 and change the name of the middleware in community REST
