### PR TITLE
:json is not registered on Faraday::Response (RuntimeError)

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mixlib-config',     '~> 1.1'
   s.add_dependency 'mixlib-shellout',   '~> 1.1'
   s.add_dependency 'retryable',         '~> 1.3.3'
-  s.add_dependency 'ridley',            '~> 0.12.1'
+  s.add_dependency 'ridley',            '~> 0.12.4'
   s.add_dependency 'solve',             '>= 0.4.4'
   s.add_dependency 'test-kitchen',      '>= 1.0.0.alpha6'
   s.add_dependency 'thor',              '~> 0.18.0'

--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -74,7 +74,7 @@ module Berkshelf
       @retry_interval = options[:retry_interval]
 
       builder = Faraday::Builder.new do |b|
-        b.response :json
+        b.response :parse_json
         b.request :retry,
           max: @retries,
           interval: @retry_interval,


### PR DESCRIPTION
This seems to happen when trying to download a cookbook with `site :opscode`.

```
$ berks install --debug
Using sendgrid (0.1.0) at path: '/Users/mike/projects/sendgrid-ops/sendgrid'
/Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/faraday-0.8.7/lib/faraday.rb:64:in `lookup_middleware': :json is not registered on Faraday::Response (RuntimeError)
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/faraday-0.8.7/lib/faraday/builder.rb:146:in `use_symbol'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/faraday-0.8.7/lib/faraday/builder.rb:104:in `response'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/community_rest.rb:77:in `block in initialize'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/faraday-0.8.7/lib/faraday/builder.rb:61:in `build'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/faraday-0.8.7/lib/faraday/builder.rb:50:in `initialize'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/community_rest.rb:76:in `new'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/community_rest.rb:76:in `initialize'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/locations/site_location.rb:33:in `new'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/locations/site_location.rb:33:in `initialize'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/location.rb:97:in `new'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/location.rb:97:in `init'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/downloader.rb:104:in `block in search_locations'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/downloader.rb:103:in `each'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/downloader.rb:103:in `search_locations'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/downloader.rb:79:in `download'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/resolver.rb:134:in `install_source'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/resolver.rb:54:in `add_source'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/resolver.rb:78:in `block in add_source_dependencies'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/resolver.rb:75:in `each'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/resolver.rb:75:in `add_source_dependencies'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/resolver.rb:32:in `block in initialize'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/resolver.rb:31:in `each'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/resolver.rb:31:in `initialize'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/berksfile.rb:669:in `new'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/berksfile.rb:669:in `resolve'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/berksfile.rb:429:in `install'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/cli.rb:164:in `install'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/lib/berkshelf/cli.rb:17:in `dispatch'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/gems/berkshelf-2.0.0.beta/bin/berks:6:in `<top (required)>'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/bin/berks:19:in `load'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/bin/berks:19:in `<main>'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/mike/.rvm/gems/ruby-1.9.3-p429/bin/ruby_noexec_wrapper:14:in `<main>'
```
