### PR TITLE
`berks shelf show` should take an optional VERSION argument

### DIFF
--- a/features/shelf/show.feature
+++ b/features/shelf/show.feature
@@ -40,7 +40,7 @@ Feature: Displaying information about a cookbook in the Berkshelf shelf
     When I successfully run `berks shelf show fake --version 1.0.0`
     Then the output should contain:
       """
-      Displaying all versions of 'fake' in the Berkshelf shelf:
+      Displaying 'fake' (1.0.0) in the Berkshelf shelf:
               Name: fake
            Version: 1.0.0
        Description: A fabulous new cookbook
@@ -61,7 +61,7 @@ Feature: Displaying information about a cookbook in the Berkshelf shelf
     When I run `berks shelf show fake --version 1.2.3`
     Then the output should contain:
       """
-      Cookbook 'fake' is not in the Berkshelf shelf
+      Cookbook 'fake' (1.2.3) is not in the Berkshelf shelf
       """
     And the CLI should exit with the status code for error "CookbookNotFound"
 
@@ -114,7 +114,7 @@ Feature: Displaying information about a cookbook in the Berkshelf shelf
     When I successfully run `berks shelf show fake --version 1.0.0`
     Then the output should contain:
       """
-      Displaying all versions of 'fake' in the Berkshelf shelf:
+      Displaying 'fake' (1.0.0) in the Berkshelf shelf:
               Name: fake
            Version: 1.0.0
        Description: A fabulous new cookbook

--- a/lib/berkshelf/commands/shelf.rb
+++ b/lib/berkshelf/commands/shelf.rb
@@ -25,7 +25,12 @@ module Berkshelf
     def show(name)
       cookbooks = find(name, options[:version])
 
-      Berkshelf.formatter.msg "Displaying all versions of '#{name}' in the Berkshelf shelf:"
+      if options[:version]
+        Berkshelf.formatter.msg "Displaying '#{name}' (#{options[:version]}) in the Berkshelf shelf:"
+      else
+        Berkshelf.formatter.msg "Displaying all versions of '#{name}' in the Berkshelf shelf:"
+      end
+
       cookbooks.each do |cookbook|
         Berkshelf.formatter.msg(cookbook.pretty_print + "\n\n")
       end
@@ -70,7 +75,11 @@ module Berkshelf
         end
 
         if cookbooks.empty?
-          raise Berkshelf::CookbookNotFound, "Cookbook '#{name}' is not in the Berkshelf shelf"
+          if version
+            raise Berkshelf::CookbookNotFound, "Cookbook '#{name}' (#{version}) is not in the Berkshelf shelf"
+          else
+            raise Berkshelf::CookbookNotFound, "Cookbook '#{name}' is not in the Berkshelf shelf"
+          end
         end
 
         cookbooks


### PR DESCRIPTION
The `berks shelf show` command should take an optional VERSION argument
- If not provided, information about the latest version of the cookbook will be shown
- If it is provided, information about that version of the cookbook will be shown
