### PR TITLE
Don't generate real keys

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -44,7 +44,7 @@ Spork.prefork do
 
   # Chef Zero
   require 'chef_zero/server'
-  @server = ChefZero::Server.new(port: 4000)
+  @server = ChefZero::Server.new(port: 4000, generate_real_keys: false)
   @server.start_background
 
   at_exit do

--- a/spec/support/chef_server.rb
+++ b/spec/support/chef_server.rb
@@ -14,7 +14,7 @@ module Berkshelf::RSpec
       end
 
       def server
-        @server ||= ChefZero::Server.new(port: PORT)
+        @server ||= ChefZero::Server.new(port: PORT, generate_real_keys: false)
       end
 
       def server_url


### PR DESCRIPTION
Inside sources on the Interwebs tell me that setting the `generate_real_keys` flag to `false` makes things ultra-faster. However, I think we have a few tests that rely on "real" keys (maybe not). For discussion.

/cc @jkeiser
