### PR TITLE
remove quotes around `ref` as they will break `:git` locations (at least...

### DIFF
--- a/lib/berkshelf/git.rb
+++ b/lib/berkshelf/git.rb
@@ -79,7 +79,7 @@ module Berkshelf
       # @raise [AmbiguousGitRef] if the ref could refer to more than one revision
       def show_ref(repo_path, ref)
         Dir.chdir repo_path do
-          lines = git('show-ref', "'#{ref}'").lines.to_a
+          lines = git('show-ref', ref).lines.to_a
 
           raise AmbiguousGitRef, ref if lines.size > 1
 


### PR DESCRIPTION
... on win7 / msysgit)

The single quotes around `ref` break the `:git` locations (on windows /msysgit) at least, see [this comment](https://github.com/RiotGames/berkshelf/issues/601#issuecomment-18823619) in #601

This PR removes the single quotes which is consistent with other occurrences of `ref` being passed to `git(*cmd)` in the same file
