### PR TITLE
test command registered to the CLI properly

### DIFF
--- a/lib/berkshelf/commands/test_command.rb
+++ b/lib/berkshelf/commands/test_command.rb
@@ -6,6 +6,6 @@ module Berkshelf
   end
 
   class Cli < Thor
-    register(Berkshelf::TestCommand, 'test', 'test [COMMAND]', 'Testing tasks for your cookbook')
+    register(Berkshelf::TestCommand, 'test', 'test [COMMAND]', 'Testing tasks for your cookbook', hide: true)
   end
 end


### PR DESCRIPTION
constant name was defined wrong for re-opening the CLI class

This can also be hidden depending on the weigh in on #547
