### PR TITLE
Make version string output easier to read

### DIFF
--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -1,6 +1,7 @@
 require 'berkshelf'
 require_relative 'config'
 require_relative 'init_generator'
+require_relative 'cookbook_generator'
 
 require 'berkshelf/commands/test_command'
 require 'berkshelf/commands/shelf'


### PR DESCRIPTION
the version command spits out a bunch of licensing which makes it hard to focus on the version number. I was going submit a PR for coloring the version string. @ivey suggested I delete the licensing instead, which I also approve of. He didn't know why the licensing, so suggested an issue for discussion.
