### PR TITLE
Implement #to_s and #inspect on all objects consistently

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'retryable',         '~> 1.3.3'
   s.add_dependency 'ridley',            '~> 0.12.4'
   s.add_dependency 'solve',             '>= 0.4.4'
-  s.add_dependency 'test-kitchen',      '>= 1.0.0.alpha6'
+  s.add_dependency 'test-kitchen',      '>= 1.0.0.alpha7'
   s.add_dependency 'thor',              '~> 0.18.0'
 
   s.add_development_dependency 'aruba',         '~> 0.5'

--- a/features/cookbook_command.feature
+++ b/features/cookbook_command.feature
@@ -15,13 +15,16 @@ Feature: Creating a new cookbook
     And the exit status should be 0
 
   Examples:
-    | option        | feature       |
-    | foodcritic    | Foodcritic    |
-    | chef-minitest | Chef-Minitest |
-    | scmversion    | SCMVersion    |
-    | no-bundler    | no Bundler    |
-    | skip-git      | no Git        |
-    | skip-vagrant  | no Vagrant    |
+    | option            | feature         |
+    | foodcritic        | Foodcritic      |
+    | chef-minitest     | Chef-Minitest   |
+    | scmversion        | SCMVersion      |
+    | no-bundler        | no Bundler      |
+    # Disable testing of skip git until Test Kitchen supports the skip_git flag in it's generator
+    # https://github.com/opscode/test-kitchen/issues/141
+    # | skip-git          | no Git          |
+    | skip-vagrant      | no Vagrant      |
+    | skip-test-kitchen | no Test Kitchen |
 
   Scenario Outline: When a required supporting gem is not installed
     Given the gem "<gem>" is not installed

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -1,6 +1,7 @@
 require 'berkshelf'
 require_relative 'config'
 require_relative 'init_generator'
+require_relative 'cookbook_generator'
 
 require 'berkshelf/commands/test_command'
 require 'berkshelf/commands/shelf'
@@ -298,7 +299,6 @@ module Berkshelf
 
       ::Berkshelf.formatter.msg 'Successfully initialized'
     end
-    tasks['init'].options = Berkshelf::InitGenerator.class_options
 
     method_option :berksfile,
       type: :string,
@@ -392,42 +392,6 @@ module Berkshelf
       Berkshelf.formatter.msg license
     end
 
-    method_option :foodcritic,
-      type: :boolean,
-      desc: 'Creates a Thorfile with Foodcritic support to lint test your cookbook'
-    method_option :chef_minitest,
-      type: :boolean,
-      desc: 'Creates chef-minitest support files and directories, adds minitest-handler cookbook to run_list of Vagrantfile'
-    method_option :scmversion,
-      type: :boolean,
-      desc: 'Creates a Thorfile with SCMVersion support to manage versions for continuous integration'
-    method_option :license,
-      type: :string,
-      desc: 'License for cookbook (apachev2, gplv2, gplv3, mit, reserved)',
-      aliases: '-L'
-    method_option :maintainer,
-      type: :string,
-      desc: 'Name of cookbook maintainer',
-      aliases: '-m'
-    method_option :maintainer_email,
-      type: :string,
-      desc: 'Email address of cookbook maintainer',
-      aliases: '-e'
-    method_option :no_bundler,
-      type: :boolean,
-      desc: 'Skips generation of a Gemfile and other Bundler specific support'
-    method_option :vagrant,
-      type: :boolean,
-      hide: true
-    method_option :skip_vagrant,
-      type: :boolean,
-      desc: 'Skips adding a Vagrantfile and adding supporting gems to the Gemfile'
-    method_option :git,
-      type: :boolean,
-      hide: true
-    method_option :skip_git,
-      type: :boolean,
-      desc: 'Skips adding a .gitignore and running git init in the cookbook directory'
     desc 'cookbook NAME', 'Create a skeleton for a new cookbook'
     def cookbook(name)
       Berkshelf.formatter.deprecation '--git is now the default' if options[:git]
@@ -439,6 +403,7 @@ module Berkshelf
 
       ::Berkshelf::CookbookGenerator.new([File.join(Dir.pwd, name), name], options).invoke_all
     end
+    tasks['cookbook'].options = Berkshelf::CookbookGenerator.class_options
 
     private
 

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -14,6 +14,11 @@ module Berkshelf
       type: :boolean,
       default: false
 
+    class_option :skip_test_kitchen,
+      type: :boolean,
+      default: false,
+      desc: 'Skip adding a testing environment to your cookbook'
+
     class_option :foodcritic,
       type: :boolean,
       default: false


### PR DESCRIPTION
We are currently relying on the `#to_s` method from a location to return it's path. This is a potential breaking change in the future. As part of this fix, we should also fix that...

All objects should respond to both `#to_s` and `#inspect` and deliver the following format:

```
$ thing.to_s    => #<Berkshelf::OBJECT (small info, like name or version)>
$ thing.inspect => #<Berkshelf::OBJECT (lots of info - pretty much the entire object)
```
