### PR TITLE
Berksfile will now be installed instead of resolved before upload

### DIFF
--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -54,6 +54,7 @@ module Berkshelf
     end
 
     private
+
       def pretty_map(hash, padding)
         hash.map { |k,v| "#{k} (#{v})" }.join("\n" + ' '*padding)
       end


### PR DESCRIPTION
This is a necessary change to ensure the lockfile is respected and the cookbooks are installed and present in the Berkshelf before they are uploaded to a Chef server
