### PR TITLE
Identify C-based gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - jruby-19mode
 env:
   - TEST_SUITE=unit CI=true
   - TEST_SUITE=acceptance CI=true


### PR DESCRIPTION
In order to support JRuby and reduce cross-platform friction, we should identify and possibly replace any C-based gems.
