### PR TITLE
File validation check is way too greedy

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -800,10 +800,11 @@ module Berkshelf
       # @param [Berkshelf::CachedCookbook] cookbook
       #  the Cookbook to validate
       def validate_files!(cookbook)
-        path = cookbook.path.to_s
+        path = cookbook.path
 
         files = Dir.glob(File.join(path, '**', '*.rb')).select do |f|
-          f =~ /[[:space:]]/
+          f = Pathname.new(f).relative_path_from(path.dirname)
+          f.to_s =~ /[[:space:]]/
         end
 
         raise Berkshelf::InvalidCookbookFiles.new(cookbook, files) unless files.empty?


### PR DESCRIPTION
Presently the file validation check checks for spaces in any part of the
file path to the cookbook. This change ensures that we just check the
cookbook name and paths underneath the cookbook.

Otherwise we get:

```
Uploading zookeeper (0.1.5) to: 'https://api.opscode.com:443/organizations/ean'
The cookbook 'zookeeper' has invalid filenames:

  /var/app/jenkins/jobs/ean-zookeeper cookbook/workspace/attributes/default.rb
  /var/app/jenkins/jobs/ean-zookeeper cookbook/workspace/recipes/default.rb
  /var/app/jenkins/jobs/ean-zookeeper cookbook/workspace/metadata.rb

Please note, spaces are not a valid character in filenames
```
