### PR TITLE
Add bzip2 tarball support

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solve',             '>= 0.4.4'
   s.add_dependency 'test-kitchen',      '>= 1.0.0.alpha7'
   s.add_dependency 'thor',              '~> 0.18.0'
+  s.add_dependency 'rbzip2',            '~> 0.2.0'
 
   s.add_development_dependency 'aruba',         '~> 0.5'
   s.add_development_dependency 'cane',          '~> 2.5'

--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -13,6 +13,7 @@ require 'thor'
 require 'tmpdir'
 require 'uri'
 require 'zlib'
+require 'rbzip2'
 
 require_relative 'berkshelf/core_ext'
 require_relative 'berkshelf/errors'

--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -16,6 +16,8 @@ module Berkshelf
           Archive::Tar::Minitar.unpack(Zlib::GzipReader.new(File.open(target, 'rb')), destination)
         elsif is_tar_file(target)
           Archive::Tar::Minitar.unpack(target, destination)
+        elsif is_bzip2_file(target)
+          Archive::Tar::Minitar.unpack(RBzip2::Decompressor.new(File.open(target, 'rb')), destination)
         else
           raise Berkshelf::UnknownCompressionType.new(target)
         end
@@ -45,6 +47,10 @@ module Berkshelf
 
         def is_tar_file(path)
           IO.binread(path, 8, 257).to_s == "ustar\x0000"
+        end
+
+        def is_bzip2_file(path)
+          IO.binread(path, 3) == 'BZh'
         end
     end
 

--- a/lib/berkshelf/core_ext/rbzip2.rb
+++ b/lib/berkshelf/core_ext/rbzip2.rb
@@ -1,0 +1,8 @@
+class RBzip2::Decompressor
+  def pos ; end
+  def pos=(*args) ; end
+  
+  def eof?
+    @io.eof?
+  end
+end


### PR DESCRIPTION
Had to monkey-patch rbzip2 to fake some methods that minitar calls
(unnecessarily in our case) at init, and post-unpack.
