### PR TITLE
Merge pull request #642 from RiotGames/use-mixin-shellout

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport',     '>= 3.2.0'
   s.add_dependency 'addressable',       '~> 2.3.4'
+  s.add_dependency 'buff-shell_out',    '~> 0.1'
   s.add_dependency 'celluloid',         '>= 0.14.0'
   s.add_dependency 'chozo',             '>= 0.6.1'
   s.add_dependency 'faraday',           '>= 0.8.5'

--- a/lib/berkshelf/git.rb
+++ b/lib/berkshelf/git.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'buff/shell_out'
 
 module Berkshelf
   class Git
@@ -9,7 +10,7 @@ module Berkshelf
     HAS_SPACE_RE = %r{\s}.freeze
 
     class << self
-      include Ridley::Mixin::ShellOut
+      include Buff::ShellOut
 
       # @overload git(commands)
       #   Shellout to the Git executable on your system with the given commands.


### PR DESCRIPTION
use Mixin::ShellOut instead of Ridley::Mixin::ShellOut
