### PR TITLE
Remove all uses of ActiveSupport methods

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 1.9.1'
   s.required_rubygems_version = '>= 1.8.0'
 
-  s.add_dependency 'activesupport',     '>= 3.2.0'
   s.add_dependency 'addressable',       '~> 2.3.4'
   s.add_dependency 'buff-shell_out',    '~> 0.1'
   s.add_dependency 'celluloid',         '>= 0.14.0'

--- a/generator_files/Vagrantfile.erb
+++ b/generator_files/Vagrantfile.erb
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
   # via the IP. Host-only networks can talk to the host machine as well as
   # any other machines on the same network, but cannot be accessed (through this
   # network interface) by any external networks.
-<% if berkshelf_config.vagrant.vm.network.hostonly.present? -%>
+<% if !berkshelf_config.vagrant.vm.network.hostonly.nil? -%>
   config.vm.network :private_network, ip: "<%= berkshelf_config.vagrant.vm.network.hostonly %>"
 <% else %>
   config.vm.network :private_network, ip: "192.168.33.10"

--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext'
 require 'archive/tar/minitar'
 require 'celluloid'
 require 'chozo/core_ext'

--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Berkshelf
   class CachedCookbook < Ridley::Chef::Cookbook
     class << self
@@ -18,45 +20,75 @@ module Berkshelf
 
     DIRNAME_REGEXP = /^(.+)-(.+)$/
 
+    extend Forwardable
+    def_delegators :metadata, :description, :maintainer, :maintainer_email, :license, :platforms
+
     # @return [Hash]
     def dependencies
       metadata.recommendations.merge(metadata.dependencies)
     end
 
+    # Pretty print this cookbook as a String
+    #
+    # @return [String]
     def pretty_print
-      [].tap do |a|
-        a.push "        Name: #{cookbook_name}" unless name.blank?
-        a.push "     Version: #{version}" unless version.blank?
-        a.push " Description: #{metadata.description}" unless metadata.description.blank?
-        a.push "      Author: #{metadata.maintainer}" unless metadata.maintainer.blank?
-        a.push "       Email: #{metadata.maintainer_email}" unless metadata.maintainer_email.blank?
-        a.push "     License: #{metadata.license}" unless metadata.license.blank?
-        a.push "   Platforms: #{pretty_map(metadata.platforms, 14)}" unless metadata.platforms.blank?
-        a.push "Dependencies: #{pretty_map(dependencies, 14)}" unless dependencies.blank?
+      [
+        "        Name: #{cookbook_name}",
+        "     Version: #{version}",
+        " Description: #{description}",
+        "      Author: #{maintainer}",
+        "       Email: #{maintainer_email}",
+        "     License: #{license}",
+        "   Platforms: #{pretty_map(platforms, 14)}",
+        "Dependencies: #{pretty_map(dependencies, 14)}",
+      ].reject do |item|
+        contents = item.split(':', 2).last.strip
+        contents.nil? || contents.empty?
       end.join("\n")
     end
 
+    # The pretty formatted JSON of this cookbook.
+    #
+    # @return [String]
     def pretty_json
-      pretty_hash.to_json
+      JSON.pretty_generate(pretty_hash)
     end
 
+    # The hash of this cookbook.
+    #
+    # @return [Hash]
     def pretty_hash
-      {}.tap do |h|
-        h[:name]          = cookbook_name unless name.blank?
-        h[:version]       = version unless version.blank?
-        h[:description]   = metadata.description unless metadata.description.blank?
-        h[:author]        = metadata.maintainer unless metadata.maintainer.blank?
-        h[:email]         = metadata.maintainer_email unless metadata.maintainer_email.blank?
-        h[:license]       = metadata.license unless metadata.license.blank?
-        h[:platforms]     = metadata.platforms.to_hash unless metadata.platforms.blank?
-        h[:dependencies]  = dependencies.to_hash unless dependencies.blank?
+      {
+        name:         cookbook_name,
+        version:      version,
+        description:  description,
+        author:       maintainer,
+        email:        maintainer_email,
+        license:      license,
+        platforms:    hash_or_nil(platforms),
+        dependencies: hash_or_nil(dependencies),
+      }.reject do |key, value|
+        value.nil? ||
+        value.empty? || (value.respond_to?(:strip) && value.strip.empty?)
       end
     end
 
     private
-
+      # Map dependencies with appropriate spacing.
+      #
+      # @return [String]
       def pretty_map(hash, padding)
+        return hash unless hash.is_a?(Hash)
         hash.map { |k,v| "#{k} (#{v})" }.join("\n" + ' '*padding)
+      end
+
+      # Convert the given object to a hash, or return nil.
+      #
+      # @return [Hash, nil]
+      def hash_or_nil(obj)
+        return nil if obj.nil?
+        return obj if obj.is_a?(Hash)
+        obj.respond_to?(:to_hash) ? obj.to_hash : nil
       end
   end
 end

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -114,7 +114,7 @@ module Berkshelf
 
         input = Berkshelf.ui.ask(message)
 
-        if input.present?
+        unless input.to_s.strip.empty?
           @config.set_attribute(attribute, input)
         end
       end
@@ -170,12 +170,8 @@ module Berkshelf
     desc 'update [COOKBOOKS]', 'Update the cookbooks (and dependencies) specified in the Berksfile'
     def update(*cookbook_names)
       berksfile = Berksfile.from_file(options[:berksfile])
-
-      update_options = {
-        cookbooks: cookbook_names
-      }.merge(options).symbolize_keys
-
-      berksfile.update(update_options)
+      options[:cookbooks] = cookbook_names
+      berksfile.update(options)
     end
 
     method_option :berksfile,
@@ -222,11 +218,10 @@ module Berkshelf
     def upload(*cookbook_names)
       berksfile = ::Berkshelf::Berksfile.from_file(options[:berksfile])
 
-      upload_options             = Hash[options.except(:no_freeze, :berksfile)].symbolize_keys
-      upload_options[:cookbooks] = cookbook_names
-      upload_options[:freeze]    = false if options[:no_freeze]
+      options[:cookbooks] = cookbook_names
+      options[:freeze] = !!options[:no_freeze]
 
-      berksfile.upload(upload_options)
+      berksfile.upload(options)
     end
 
     method_option :berksfile,
@@ -242,9 +237,7 @@ module Berkshelf
     desc 'apply ENVIRONMENT', 'Apply the cookbook version locks from Berksfile.lock to a Chef environment'
     def apply(environment_name)
       berksfile    = ::Berkshelf::Berksfile.from_file(options[:berksfile])
-      lock_options = Hash[options].symbolize_keys
-
-      berksfile.apply(environment_name, lock_options)
+      berksfile.apply(environment_name, options)
     end
 
     method_option :berksfile,
@@ -269,11 +262,8 @@ module Berkshelf
       Berkshelf.formatter.msg 'BETA: ignore all other dependencies you may have defined'
       Berkshelf.formatter.msg ''
 
-      outdated_options = {
-        cookbooks: cookbook_names
-      }.merge(options).symbolize_keys
-
-      outdated = berksfile.outdated(outdated_options)
+      options[:cookbooks] = cookbook_names
+      outdated = berksfile.outdated(options)
 
       if outdated.empty?
         Berkshelf.formatter.msg 'All cookbooks up to date'

--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -67,7 +67,11 @@ module Berkshelf
     # @option options [Float] :retry_interval (0.5)
     #   how often we should pause between retries
     def initialize(uri = V1_API, options = {})
-      options         = options.reverse_merge(retries: 5, retry_interval: 0.5)
+      options = {
+        retries: 5,
+        retry_interval: 0.5,
+      }.merge(options)
+
       @api_uri        = Addressable::URI.parse(uri)
       @retries        = options[:retries]
       @retry_interval = options[:retry_interval]

--- a/lib/berkshelf/dependency.rb
+++ b/lib/berkshelf/dependency.rb
@@ -58,7 +58,7 @@ module Berkshelf
 
         if (options.keys & [:site, :path, :git]).size > 1
           invalid = (options.keys & [:site, :path, :git]).map { |opt| "'#{opt}" }
-          raise InternalError, "Cannot specify #{invalid.to_sentence} for a Cookbook Source!"
+          raise InternalError, "Cannot specify #{invalid.join(' and ')} for a Cookbook Source!"
         end
 
         true
@@ -160,7 +160,10 @@ module Berkshelf
     # @return [Solve::Version, nil]
     #   the locked version of this cookbook
     def locked_version
-      @locked_version ||= cached_cookbook.try(:version)
+      @locked_version ||= begin
+        return nil if cached_cookbook.nil?
+        cached_cookbook.version
+      end
     end
 
     # The location for this dependency, such as a remote Chef Server, the
@@ -215,7 +218,7 @@ module Berkshelf
           h[:ref] = location.ref
           h[:rel] = location.rel if location.rel
         end
-      end.reject { |k,v| v.blank? }
+      end.reject { |k,v| v.nil? || v.empty? || (v.respond_to?(:strip) && v.strip.empty?) }
     end
 
     def to_json(options = {})

--- a/lib/berkshelf/formatters.rb
+++ b/lib/berkshelf/formatters.rb
@@ -50,7 +50,9 @@ module Berkshelf
     #
     #   Implement {#cleanup_hook} to run any steps required to run after the task is finished
     module AbstractFormatter
-      extend ActiveSupport::Concern
+      def self.included(base)
+        base.send(:extend, ClassMethods)
+      end
 
       module ClassMethods
         # @param [Symbol] id

--- a/lib/berkshelf/locations/chef_api_location.rb
+++ b/lib/berkshelf/locations/chef_api_location.rb
@@ -92,11 +92,11 @@ module Berkshelf
     #   have a value for chef.client_key which points to a readable file containing a Chef
     #   client key.
     def initialize(name, version_constraint, options = {})
-      options = options.reverse_merge(
+      options = {
         client_key: Berkshelf::Config.instance.chef.client_key,
         node_name: Berkshelf::Config.instance.chef.node_name,
-        verify_ssl: Berkshelf::Config.instance.ssl.verify
-      )
+        verify_ssl: Berkshelf::Config.instance.ssl.verify,
+      }.merge(options)
 
       @name               = name
       @version_constraint = version_constraint
@@ -110,10 +110,8 @@ module Berkshelf
       validate_options!(options)
 
       if options[:chef_api] == :config
-        unless Berkshelf::Config.instance.chef.node_name.present? &&
-          Berkshelf::Config.instance.chef.client_key.present? &&
-          Berkshelf::Config.instance.chef.chef_server_url.present?
-
+        chef = Berkshelf::Config.instance.chef
+        if chef.node_name.nil? || chef.client_key.nil? || chef.chef_server_url.nil?
           msg = "A Berkshelf configuration is required with a 'chef.client_key', 'chef.chef_server_Url',"
           msg << " and 'chef.node_name' setting to install or upload cookbooks using 'chef_api :config'."
 

--- a/spec/support/matchers/file_system_matchers.rb
+++ b/spec/support/matchers/file_system_matchers.rb
@@ -58,9 +58,10 @@ module Berkshelf
         end
 
         def file(name, &block)
-          silence_warnings do
-            @tree[name] = FileMatcher.new(location(name), &block)
-          end
+          old_verbose, $VERBOSE = $VERBOSE, nil
+          @tree[name] = FileMatcher.new(location(name), &block)
+        ensure
+          $VERBOSE = old_verbose
         end
 
         def no_file(name)

--- a/spec/unit/berkshelf/cached_cookbook_spec.rb
+++ b/spec/unit/berkshelf/cached_cookbook_spec.rb
@@ -47,16 +47,15 @@ describe Berkshelf::CachedCookbook do
   end
 
 
+  subject { Berkshelf::CachedCookbook.from_store_path(path) }
+
+  let(:dependencies) { { 'mysql' => '= 1.2.0', 'ntp' => '>= 0.0.0' } }
+  let(:recommendations) { { 'database' => '>= 0.0.0' } }
+  let(:path) do
+    generate_cookbook(Berkshelf.cookbook_store.storage_path, 'sparkle', '0.1.0', dependencies: dependencies, recommendations: recommendations)
+  end
+
   describe '#dependencies' do
-    let(:dependencies) { { 'mysql' => '= 1.2.0', 'ntp' => '>= 0.0.0' } }
-    let(:recommendations) { { 'database' => '>= 0.0.0' } }
-
-    let(:path) do
-      generate_cookbook(Berkshelf.cookbook_store.storage_path, 'sparkle', '0.1.0', dependencies: dependencies, recommendations: recommendations)
-    end
-
-    subject { Berkshelf::CachedCookbook.from_store_path(path) }
-
     it 'contains depends from the cookbook metadata' do
       expect(subject.dependencies).to include(dependencies)
     end
@@ -64,5 +63,116 @@ describe Berkshelf::CachedCookbook do
     it 'contains recommendations from the cookbook metadata' do
       expect(subject.dependencies).to include(recommendations)
     end
+
+    it 'returns a hash' do
+      expect(subject.dependencies).to be_a(Hash)
+    end
+  end
+
+  describe '#pretty_print' do
+    shared_examples 'a pretty_print cookbook attribute' do |attribute, label|
+      it "is not present when the `#{attribute}` attribute is nil" do
+        subject.stub(attribute.to_sym)
+        expect(subject.pretty_print).to_not include(label || attribute)
+      end
+
+      it "is not present when the `#{attribute}` attribute is an empty string" do
+        subject.stub(attribute.to_sym).and_return('')
+        expect(subject.pretty_print).to_not include(label || attribute)
+      end
+
+      it "is not present when the `#{attribute}` attribute is an empty array" do
+        subject.stub(attribute.to_sym).and_return([])
+        expect(subject.pretty_print).to_not include(label || attribute)
+      end
+
+      it "is not present when the `#{attribute}` attribute is an empty hash" do
+        subject.stub(attribute.to_sym).and_return({})
+        expect(subject.pretty_print).to_not include(label || attribute)
+      end
+
+      it "is present when the `#{attribute}` attribute has a String value" do
+        subject.stub(attribute.to_sym).and_return('foo')
+        expect(subject.pretty_print).to include(label || attribute)
+      end
+
+      it "is present when the `#{attribute}` attribute has an Array value" do
+        subject.stub(attribute.to_sym).and_return(['foo'])
+        expect(subject.pretty_print).to include(label || attribute)
+      end
+
+      it "is present when the `#{attribute}` attribute has a Hash value" do
+        subject.stub(attribute.to_sym).and_return({foo: 'bar'})
+        expect(subject.pretty_print).to include(label || attribute)
+      end
+    end
+
+    it_behaves_like 'a pretty_print cookbook attribute', 'cookbook_name', 'Name'
+    it_behaves_like 'a pretty_print cookbook attribute', 'version', 'Version'
+    it_behaves_like 'a pretty_print cookbook attribute', 'description', 'Description'
+    it_behaves_like 'a pretty_print cookbook attribute', 'maintainer', 'Author'
+    it_behaves_like 'a pretty_print cookbook attribute', 'maintainer_email', 'Email'
+    it_behaves_like 'a pretty_print cookbook attribute', 'license', 'License'
+    it_behaves_like 'a pretty_print cookbook attribute', 'platforms', 'Platforms'
+    it_behaves_like 'a pretty_print cookbook attribute', 'dependencies', 'Dependencies'
+  end
+
+  describe '#pretty_json' do
+    let(:hash) { { 'cookbook_name' => 'foo', 'version' => '1.0.0' } }
+
+    before do
+      subject.stub(:to_hash).and_return(hash)
+    end
+
+    it 'generates the JSON from the #to_hash method' do
+      subject.should_receive(:to_hash).once
+      subject.to_json
+    end
+
+    it 'returns a String' do
+      expect(subject.to_json).to be_a(String)
+    end
+
+    it 'pretty formats the string' do
+      expect(JSON.parse(subject.to_json)).to eq(hash)
+    end
+  end
+
+  describe '#pretty_hash', focus: true do
+    shared_examples 'a pretty_hash cookbook attribute' do |attribute, key|
+      it "is not present when the `#{attribute}` attribute is nil" do
+        subject.stub(attribute.to_sym)
+        expect(subject.pretty_hash).to_not have_key((key || attribute).to_sym)
+      end
+
+      it "is not present when the `#{attribute}` attribute is an empty string" do
+        subject.stub(attribute.to_sym).and_return('')
+        expect(subject.pretty_hash).to_not have_key((key || attribute).to_sym)
+      end
+
+      it "is not present when the `#{attribute}` attribute is an empty array" do
+        subject.stub(attribute.to_sym).and_return([])
+        expect(subject.pretty_hash).to_not have_key((key || attribute).to_sym)
+      end
+
+      it "is not present when the `#{attribute}` attribute is an empty hash" do
+        subject.stub(attribute.to_sym).and_return([])
+        expect(subject.pretty_hash).to_not have_key((key || attribute).to_sym)
+      end
+
+      it "is present when the `#{attribute}` attribute has a Hash value" do
+        subject.stub(attribute.to_sym).and_return({foo: 'bar'})
+        expect(subject.pretty_hash).to have_key((key || attribute).to_sym)
+      end
+    end
+
+    it_behaves_like 'a pretty_hash cookbook attribute', 'cookbook_name', 'name'
+    it_behaves_like 'a pretty_hash cookbook attribute', 'version'
+    it_behaves_like 'a pretty_hash cookbook attribute', 'description'
+    it_behaves_like 'a pretty_hash cookbook attribute', 'maintainer', 'author'
+    it_behaves_like 'a pretty_hash cookbook attribute', 'maintainer_email', 'email'
+    it_behaves_like 'a pretty_hash cookbook attribute', 'license'
+    it_behaves_like 'a pretty_hash cookbook attribute', 'platforms'
+    it_behaves_like 'a pretty_hash cookbook attribute', 'dependencies'
   end
 end


### PR DESCRIPTION
Initial attempt at removing active support

Even though this removes active support as a direct dependency, it doesn't remove active support entirely, since Ridley and Chozo both depend on it.
