### PR TITLE
Always raise exception when uploading a metadata frozen cookbook

### DIFF
--- a/features/json_formatter.feature
+++ b/features/json_formatter.feature
@@ -65,6 +65,47 @@ Feature: --format json
       }
       """
 
+  Scenario: JSON output when running the show command
+    Given the cookbook store has the cookbooks:
+      | fake | 1.0.0 |
+    And I write to "Berksfile" with:
+      """
+      source "http://localhost:26210"
+
+      cookbook 'fake', '1.0.0'
+      """
+    And I write to "Berksfile.lock" with:
+      """
+      {
+        "dependencies": {
+          "fake": {
+            "locked_version": "1.0.0"
+          }
+        }
+      }
+      """
+    When I successfully run `berks show fake --format json`
+    Then the output should contain JSON:
+      """
+      {
+        "cookbooks": [
+          {
+            "name": "fake",
+            "version": "1.0.0",
+            "description": "A fabulous new cookbook",
+            "author": "YOUR_COMPANY_NAME",
+            "email": "YOUR_EMAIL",
+            "license": "none"
+          }
+        ],
+        "errors": [
+
+        ],
+        "messages": [
+        ]
+      }
+      """
+
   Scenario: JSON output when running the upload command
     Given I write to "Berksfile" with:
       """

--- a/features/show_command.feature
+++ b/features/show_command.feature
@@ -33,47 +33,6 @@ Feature: Displaying information about a cookbook defined by a Berksfile
            License: none
       """
 
-  Scenario: When JSON is requested
-    Given the cookbook store has the cookbooks:
-      | fake | 1.0.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
-
-      cookbook 'fake', '1.0.0'
-      """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
-    When I successfully run `berks show fake --format json`
-    Then the output should contain JSON:
-      """
-      {
-        "cookbooks": [
-          {
-            "name": "fake",
-            "version": "1.0.0",
-            "description": "A fabulous new cookbook",
-            "author": "YOUR_COMPANY_NAME",
-            "email": "YOUR_EMAIL",
-            "license": "none"
-          }
-        ],
-        "errors": [
-
-        ],
-        "messages": [
-        ]
-      }
-      """
-
   Scenario: When the cookbook is not in the Berksfile
     Given I write to "Berksfile" with:
       """
@@ -84,7 +43,7 @@ Feature: Displaying information about a cookbook defined by a Berksfile
       """
       Could not find cookbook(s) 'fake' in any of the configured dependencies. Is it in your Berksfile?
       """
-    And the exit status should be "CookbookNotFound"
+    And the exit status should be "DependencyNotFound"
 
   Scenario: When there is no lockfile present
     And I write to "Berksfile" with:

--- a/features/step_definitions/chef_server_steps.rb
+++ b/features/step_definitions/chef_server_steps.rb
@@ -8,9 +8,17 @@ Given /^the Chef Server has cookbooks:$/ do |cookbooks|
   cookbooks.raw.each do |name, version|
     purge_cookbook(name, version)
     cb_path = generate_cookbook(tmp_path, name, version)
-    upload_cookbook(cb_path)
+    upload_cookbook(cb_path, freeze: false, force: true)
   end
 end
+
+Given /^the Chef Server has frozen cookbooks:$/ do |cookbooks|
+  cookbooks.raw.each do |name, version|
+    purge_cookbook(name, version)
+    cb_path = generate_cookbook(tmp_path, name, version)
+    upload_cookbook(cb_path, freeze: true, force: true)
+  end
+ end
 
 Then /^the Chef Server should have the cookbooks:$/ do |cookbooks|
   cookbooks.raw.each do |name, version|

--- a/features/update_command.feature
+++ b/features/update_command.feature
@@ -133,4 +133,4 @@ Feature: Updating a cookbook defined by a Berksfile
       """
       Could not find cookbook(s) 'non-existent-cookbook' in any of the configured dependencies. Is it in your Berksfile?
       """
-    And the exit status should be "CookbookNotFound"
+    And the exit status should be "DependencyNotFound"

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -250,11 +250,10 @@ module Berkshelf
     def upload(*cookbook_names)
       berksfile = Berkshelf::Berksfile.from_file(options[:berksfile])
 
-      upload_options             = Hash[options.except(:no_freeze, :berksfile)].symbolize_keys
-      upload_options[:cookbooks] = cookbook_names
-      upload_options[:freeze]    = false if options[:no_freeze]
+      options[:cookbooks] = cookbook_names
+      options[:freeze] = !options[:no_freeze]
 
-      berksfile.upload(upload_options)
+      berksfile.upload(options.symbolize_keys)
     end
 
     method_option :berksfile,

--- a/lib/berkshelf/dependency.rb
+++ b/lib/berkshelf/dependency.rb
@@ -109,12 +109,20 @@ module Berkshelf
       @options            = options
       @berksfile          = berksfile
       @name               = name
+      @metadata           = options[:metadata]
       @location           = Location.init(self, options)
       @locked_version     = Solve::Version.new(options[:locked_version]) if options[:locked_version]
       @version_constraint = Solve::Constraint.new(options[:constraint] || DEFAULT_CONSTRAINT)
 
       add_group(options[:group]) if options[:group]
       add_group(:default) if groups.empty?
+    end
+
+    # Return true if this is a metadata location.
+    #
+    # @return [Boolean]
+    def metadata?
+      !!@metadata
     end
 
     def add_group(*local_groups)

--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -222,7 +222,23 @@ module Berkshelf
   class ConfigExists < BerkshelfError; status_code(116); end
   class ConfigurationError < BerkshelfError; status_code(117); end
   class InsufficientPrivledges < BerkshelfError; status_code(119); end
-  class DependencyNotFound < BerkshelfError; status_code(120); end
+
+  class DependencyNotFound < BerkshelfError
+    status_code(120)
+
+    # @param [String, Array<String>] cookbooks
+    #   the list of cookbooks that were not defined
+    def initialize(cookbooks)
+      @cookbooks = Array(cookbooks)
+    end
+
+    def to_s
+      list = @cookbooks.collect {|c| "'#{c}'" }
+      "Could not find cookbook(s) #{list.join(', ')} in any of the configured" <<
+      " dependencies. #{list.size == 1 ? 'Is it' : 'Are they' } in your Berksfile?"
+    end
+  end
+
   class ValidationFailed < BerkshelfError; status_code(121); end
   class InvalidVersionConstraint < BerkshelfError; status_code(122); end
   class CommunitySiteError < BerkshelfError; status_code(123); end
@@ -247,7 +263,21 @@ module Berkshelf
   class ClientKeyFileNotFound < BerkshelfError; status_code(125); end
 
   class UploadFailure < BerkshelfError; end
-  class FrozenCookbook < UploadFailure; status_code(126); end
+
+  class FrozenCookbook < UploadFailure
+    status_code(126)
+
+    # @param [CachedCookbook] cookbook
+    def initialize(cookbook)
+      @cookbook = cookbook
+    end
+
+    def to_s
+      "The cookbook #{@cookbook.cookbook_name} (#{@cookbook.version})" <<
+        " already exists and is frozen on the Chef Server. Use the --force" <<
+        " option to override."
+    end
+  end
 
   class OutdatedDependency < BerkshelfError
     status_code(128)

--- a/lib/berkshelf/formatters.rb
+++ b/lib/berkshelf/formatters.rb
@@ -85,6 +85,7 @@ module Berkshelf
                         :msg,
                         :outdated,
                         :package,
+                        :skip,
                         :show,
                         :upload,
                         :use,

--- a/lib/berkshelf/formatters/human_readable.rb
+++ b/lib/berkshelf/formatters/human_readable.rb
@@ -37,11 +37,18 @@ module Berkshelf
 
       # Output a Cookbook upload message using {Berkshelf.ui}
       #
-      # @param [String] cookbook
-      # @param [String] version
-      # @param [String] chef_api_url
-      def upload(cookbook, version, chef_api_url)
-        Berkshelf.ui.info "Uploading #{cookbook} (#{version}) to: '#{chef_api_url}'"
+      # @param [Berkshelf::CachedCookbook] cookbook
+      # @param [Ridley::Connection] conn
+      def upload(cookbook, conn)
+        Berkshelf.ui.info "Uploading #{cookbook.cookbook_name} (#{cookbook.version}) to: '#{conn.server_url}'"
+      end
+
+      # Output a Cookbook skip message using {Berkshelf.ui}
+      #
+      # @param [Berkshelf::CachedCookbook] cookbook
+      # @param [Ridley::Connection] conn
+      def skip(cookbook, conn)
+        Berkshelf.ui.info "Skipping #{cookbook.cookbook_name} (#{cookbook.version}) (already uploaded)"
       end
 
       # Output a list of outdated cookbooks and the most recent version

--- a/lib/berkshelf/formatters/json.rb
+++ b/lib/berkshelf/formatters/json.rb
@@ -69,13 +69,24 @@ module Berkshelf
 
       # Add a Cookbook upload entry to delayed output
       #
-      # @param [String] cookbook
-      # @param [String] version
-      # @param [String] chef_api_url
-      def upload(cookbook, version, chef_api_url)
-        cookbooks[cookbook] ||= {}
-        cookbooks[cookbook][:version] = version
-        cookbooks[cookbook][:uploaded_to] = chef_api_url
+      # @param [Berkshelf::CachedCookbook] cookbook
+      # @param [Ridley::Connection] conn
+      def upload(cookbook, conn)
+        name = cookbook.cookbook_name
+        cookbooks[name] ||= {}
+        cookbooks[name][:version] = cookbook.version
+        cookbooks[name][:uploaded_to] = conn.server_url
+      end
+
+      # Add a Cookbook skip entry to delayed output
+      #
+      # @param [Berkshelf::CachedCookbook] cookbook
+      # @param [Ridley::Connection] conn
+      def skip(cookbook, conn)
+        name = cookbook.cookbook_name
+        cookbooks[name] ||= {}
+        cookbooks[name][:version] = cookbook.version
+        cookbooks[name][:skipped] = true
       end
 
       # Output a list of outdated cookbooks and the most recent version

--- a/spec/support/chef_api.rb
+++ b/spec/support/chef_api.rb
@@ -8,9 +8,16 @@ module Berkshelf
         ridley.cookbook.all
       end
 
-      def upload_cookbook(path)
+      def upload_cookbook(path, options = {})
         cached = CachedCookbook.from_store_path(path)
-        ridley.cookbook.upload(cached.path, name: cached.cookbook_name)
+
+        options = {
+          force: false,
+          freeze: false,
+          name: cached.cookbook_name,
+        }.merge(options)
+
+        ridley.cookbook.upload(cached.path, options)
       end
 
       # Remove the version of the given cookbook from the Chef Server defined


### PR DESCRIPTION
Most community tools (including the Chef-shipped `knife`) raise an exception when attempting to upload a frozen cookbook when the same version already exists on the remote Chef Server. Berkshelf, however, quietly catches the exception and continues. The user must specify the `--halt-on-frozen` flag to overwrite. There are proposals to change the output message to something more descriptive, but I don't think that's in the best interest of the project.

This differential in mental model is the source of many issues on Berkshelf regarding the behavior of the uploader. For example, when a user is working in development and uploading to the Chef Server, Berkshelf will happily freeze and ignore future changes. This makes for quite the head-scratching situation.

Here, I'm proposing a simple fix that will align Berkshelf more with other community tools, without changing the underlying behavior. I think it's a best practice to freeze any uploaded cookbooks. However, I don't think requiring the user specify a flag to see the failures is a good idea.

This commit removes the `--halt-on-frozen` flag entirely and Berkshelf will always raise an exception if the cookbook is frozen (in line with other community tools). Should a user wish to overwrite this behavior, he may specify the `--force` flag (which already exists). This tells Ridley to overwrite the frozen version.

So there are now two pathways for a user to work in development with a remote Chef Server:
1. Getting the exception and then `--force`ing:
   
   ``` text
   $ berks upload
   # ...
   
   # (makes changes)
   
   $ berks upload
   Error: the cookbook 'foo' is frozen at 1.0.0 on the remote server. Re-run with the --force flag to overwrite
   
   $ berks upload --force
   # :)
   ```
2. Using `--no-freeze`:
   
   ``` text
   $ berks upload --no-freeze
   # ...
   
   # (makes changes)
   
   $ berks upload --no-freeze
   # :)
   ```
