### PR TITLE
Move back to a single builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-env:
-  - TEST_SUITE=unit CI=true
-  - TEST_SUITE=acceptance CI=true
-  - TEST_SUITE=quality CI=true
 notifications:
   irc:
     channels:
@@ -17,4 +13,4 @@ bundler_args: --without guard
 before_script:
   - git config --global user.email "ci@berkshelf.com"
   - git config --global user.name "Berkshelf"
-script: 'bundle exec thor spec:$TEST_SUITE'
+script: 'bundle exec thor spec:ci


### PR DESCRIPTION
With the cucumber changes, we are fast enough to run everything on a single builder. Plus its confusing to figure out who failed what build when we split things up. We are currently using 3x3 builders, which blocks almost all of Travis's boxes. I would rather block 2-3 boxes for 10 minutes than all of them for 5.
