### PR TITLE
ActiveSupport 4.0 breaks everything

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 1.9.1'
   s.required_rubygems_version = '>= 1.8.0'
 
-  s.add_dependency 'activesupport',     '>= 3.2.0'
+  s.add_dependency 'activesupport',     '~> 3.2.0'
   s.add_dependency 'addressable',       '~> 2.3.4'
   s.add_dependency 'buff-shell_out',    '~> 0.1'
   s.add_dependency 'celluloid',         '>= 0.14.0'


### PR DESCRIPTION
So I know that master has just removed ActiveSupport entirely, but unless it is going to be released ASAP I would issue a quick fix to pin `~>=3.2.0`.
