### PR TITLE
Version Constraint in metadata.rb not honored

### DIFF
--- a/features/install_command.feature
+++ b/features/install_command.feature
@@ -449,8 +449,8 @@ Feature: install cookbooks from a Berksfile
       depends 'mysql', '3.0.2'   # depends on openssl
       depends 'openssl', '1.0.0'
       """
-    When I run `bundle exec berks install`
+    When I run `berks install`
     Then the output should contain:
       """
-      openssl (1.0.0)
+      Installing openssl (1.0.0)
       """


### PR DESCRIPTION
Originally #709, but this includes a failing cucumber scenario for the feature. 

**This will need back-ported into 2-0-stable**
