### PR TITLE
Fixed 'greater than equal to' symbol in index.md

### DIFF
--- a/_includes/index.md
+++ b/_includes/index.md
@@ -271,9 +271,9 @@ Constraints can be specified as
 
 * Equal to (=)
 * Greater than (>)
-* Greater than equal to (<)
+* Greater than or equal to (>=)
 * Less than (<)
-* Less than equal to (<=)
+* Less than or equal to (<=)
 * Pessimistic (~>)
 
 The final parameter is an options hash


### PR DESCRIPTION
- Changed the 'greater than equal to' symbol from '<' to '>='
- Inserted an 'or' to the 'greater than equal to' and 'less than equal to' constraint definitions
