### PR TITLE
Rescue CookbookNotFound in lockfile#load!

### DIFF
--- a/features/lockfile.feature
+++ b/features/lockfile.feature
@@ -106,6 +106,36 @@ Feature: Creating and reading the Berkshelf lockfile
       }
       """
 
+  Scenario: Reading the Berksfile.lock when it contains an invalid path location
+    Given the cookbook store has the cookbooks:
+      | fake | 1.0.0 |
+    And I write to "Berksfile" with:
+      """
+      cookbook 'fake'
+      """
+    And I write to "Berksfile.lock" with:
+      """
+      {
+        "sources":{
+          "non-existent":{
+            "path":"/this/path/does/not/exist"
+          }
+        }
+      }
+      """
+    When I successfully run `berks install`
+    Then the file "Berksfile.lock" should contain JSON:
+      """
+      {
+        "sources":{
+          "fake":{
+            "locked_version":"1.0.0"
+          }
+        }
+      }
+      """
+    And the exit status should be 0
+
   Scenario: Installing a cookbook with dependencies
     Given the cookbook store has the cookbooks:
       | dep | 1.0.0 |

--- a/lib/berkshelf/lockfile.rb
+++ b/lib/berkshelf/lockfile.rb
@@ -33,7 +33,14 @@ module Berkshelf
       hash     = parse(contents)
 
       hash[:dependencies].each do |name, options|
-        add(Berkshelf::Dependency.new(berksfile, name.to_s, options))
+        begin
+          add(Berkshelf::Dependency.new(berksfile, name.to_s, options))
+        rescue Berkshelf::CookbookNotFound
+          # It's possible that a source is locked that contains a path location, and
+          # that path location was renamed or no longer exists. When loading the
+          # lockfile, Berkshelf will throw an error if it can't find a cookbook that
+          # previously existed at a path location.
+        end
       end
     end
 


### PR DESCRIPTION
It's possible that a source is locked that contains a path location, and that path location was renamed or no longer exists. When loading the lockfile, Berkshelf will throw an error if it can't find a cookbook that previously existed at a path location.

This was never an issue before, because the lockfile was not trusted if the SHAs did not match. Now that we always evaluate, it's possible for the lockfile to contain stale entries.
