### PR TITLE
Fix generator files to allow multiple hyphens in cookbook_name

### DIFF
--- a/generator_files/default_test.rb.erb
+++ b/generator_files/default_test.rb.erb
@@ -2,7 +2,7 @@ require File.expand_path('../support/helpers', __FILE__)
 
 describe '<%= cookbook_name %>::default' do
 
-  include Helpers::<%= cookbook_name.capitalize.sub('-','_') %>
+  include Helpers::<%= cookbook_name.capitalize.gsub('-','_') %>
 
   # Example spec tests can be found at http://git.io/Fahwsw
   it 'runs no tests by default' do

--- a/generator_files/helpers.rb.erb
+++ b/generator_files/helpers.rb.erb
@@ -1,5 +1,5 @@
 module Helpers
-  module <%= cookbook_name.capitalize.sub('-','_') %>
+  module <%= cookbook_name.capitalize.gsub('-','_') %>
     include MiniTest::Chef::Assertions
     include MiniTest::Chef::Context
     include MiniTest::Chef::Resources


### PR DESCRIPTION
If a cookbook name contains multiple hyphens, the generated default_test.rb and helpers.rb will have invalid module name.
