### PR TITLE
Properly implement `berks outdated`

### DIFF
--- a/features/json_formatter.feature
+++ b/features/json_formatter.feature
@@ -92,3 +92,41 @@ Feature: --format json
         ]
       }
       """
+
+  Scenario: JSON output when running the outdated command
+    Given the cookbook store has the cookbooks:
+      | seth | 0.1.0 |
+    Given the Berkshelf API has the cookbooks:
+      | seth | 0.1.0 |
+      | seth | 0.2.9 |
+      | seth | 1.0.0 |
+    And I write to "Berksfile" with:
+      """
+      source "http://localhost:26210"
+
+      cookbook 'seth', '~> 0.1'
+      """
+    And I successfully run `berks outdated --format json`
+    Then the output should contain:
+      """
+      {
+        "cookbooks": [
+          {
+            "version": "0.2.9",
+            "sources": {
+              "http://localhost:26210": {
+                "name": "seth",
+                "version": "0.2.9"
+              }
+            },
+            "name": "seth"
+          }
+        ],
+        "errors": [
+
+        ],
+        "messages": [
+          "The following cookbooks have newer versions:"
+        ]
+      }
+      """

--- a/features/outdated_command.feature
+++ b/features/outdated_command.feature
@@ -4,5 +4,85 @@ Feature: Displaying outdated cookbooks
   So that I can decide whether to update everything at once
 
   Scenario: the dependency is up to date
+    Given the Chef Server has cookbooks:
+      | bacon | 1.0.0 |
+      | bacon | 1.1.0 |
+    And the Berkshelf API server's cache is up to date
+    And I write to "Berksfile" with:
+      """
+      source "http://localhost:26210"
+
+      cookbook 'bacon', '~> 1.1.0'
+      """
+    And I write to "Berksfile.lock" with:
+      """
+      {
+        "dependencies": {
+          "bacon": {
+            "locked_version": "1.1.0"
+          }
+        }
+      }
+      """
+    When I successfully run `berks outdated`
+    Then the output should contain:
+      """
+      All cookbooks up to date!
+      """
+
   Scenario: the dependency has a no version constraint and there are new items
+    Given the Chef Server has cookbooks:
+      | bacon | 1.0.0 |
+      | bacon | 1.1.0 |
+    And the Berkshelf API server's cache is up to date
+    And I write to "Berksfile" with:
+      """
+      source "http://localhost:26210"
+
+      cookbook 'bacon'
+      """
+    And I write to "Berksfile.lock" with:
+      """
+      {
+        "dependencies": {
+          "bacon": {
+            "locked_version": "1.0.0"
+          }
+        }
+      }
+      """
+    When I successfully run `berks outdated`
+    Then the output should contain:
+      """
+      The following cookbooks have newer versions:
+        * bacon (1.1.0) [http://localhost:26210]
+      """
+
   Scenario: the dependency has a version constraint and there are new items that satisfy it
+    Given the Chef Server has cookbooks:
+      | bacon | 1.1.0 |
+      | bacon | 1.2.1 |
+      | bacon | 1.5.8 |
+    And the Berkshelf API server's cache is up to date
+    And I write to "Berksfile" with:
+      """
+      source "http://localhost:26210"
+
+      cookbook 'bacon', '~> 1.0'
+      """
+    And I write to "Berksfile.lock" with:
+      """
+      {
+        "dependencies": {
+          "bacon": {
+            "locked_version": "1.0.0"
+          }
+        }
+      }
+      """
+    When I successfully run `berks outdated`
+    Then the output should contain:
+      """
+      The following cookbooks have newer versions:
+        * bacon (1.5.8) [http://localhost:26210]
+      """

--- a/lib/berkshelf/api_client/remote_cookbook.rb
+++ b/lib/berkshelf/api_client/remote_cookbook.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Berkshelf
   class APIClient
     # A representation of cookbook metadata indexed by a Berkshelf API Server. Returned
@@ -36,6 +38,17 @@ module Berkshelf
       # @return [String]
       def location_path
         @attributes[:location_path]
+      end
+
+      def to_hash
+        {
+          name: name,
+          version: version
+        }
+      end
+
+      def to_json(options = {})
+        ::JSON.pretty_generate(to_hash, options)
       end
     end
   end

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -292,10 +292,16 @@ module Berkshelf
     desc 'outdated [COOKBOOKS]', 'List dependencies that have new versions available that satisfy their constraints'
     def outdated(*cookbook_names)
       berksfile = Berkshelf::Berksfile.from_file(options[:berksfile])
-      Berkshelf.formatter.msg 'Listing outdated cookbooks with newer versions available...'
+      options[:cookbooks] = cookbook_names
+      outdated = berksfile.outdated(options.symbolize_keys)
 
-      outdated_options = { cookbooks: cookbook_names }.merge(options).symbolize_keys
-      berksfile.outdated(outdated_options)
+      if outdated.empty?
+        Berkshelf.formatter.msg "All cookbooks up to date!"
+      else
+        Berkshelf.formatter.msg "The following cookbooks have newer versions:"
+      end
+
+      Berkshelf.formatter.outdated(outdated)
     end
 
     desc 'init [PATH]', 'Initialize Berkshelf in the given directory'

--- a/lib/berkshelf/formatters.rb
+++ b/lib/berkshelf/formatters.rb
@@ -79,7 +79,16 @@ module Berkshelf
           end
       end
 
-      formatter_methods :fetch, :install, :use, :upload, :msg, :error, :package, :show, :vendor
+      formatter_methods :error,
+                        :fetch,
+                        :install,
+                        :msg,
+                        :outdated,
+                        :package,
+                        :show,
+                        :upload,
+                        :use,
+                        :vendor
 
       def cleanup_hook
         # run after the task is finished

--- a/lib/berkshelf/formatters/human_readable.rb
+++ b/lib/berkshelf/formatters/human_readable.rb
@@ -39,6 +39,24 @@ module Berkshelf
         Berkshelf.ui.info "Uploading #{cookbook} (#{version}) to: '#{chef_api_url}'"
       end
 
+      # Output a list of outdated cookbooks and the most recent version
+      # using {Berkshelf.ui}
+      #
+      # @param [Hash] hash
+      #   the list of outdated cookbooks in the format
+      #   { 'cookbook' => { 'api.berkshelf.com' => #<Cookbook> } }
+      def outdated(hash)
+        hash.keys.each do |name|
+          hash[name].each do |source, newest|
+            string = "  * #{newest.name} (#{newest.version})"
+            unless Berksfile.default_sources.map { |s| s.uri.to_s }.include?(source)
+              string << " [#{source}]"
+            end
+            Berkshelf.ui.info string
+          end
+        end
+      end
+
       # Output a Cookbook package message using {Berkshelf.ui}
       #
       # @param [String] cookbook

--- a/lib/berkshelf/formatters/json.rb
+++ b/lib/berkshelf/formatters/json.rb
@@ -73,6 +73,23 @@ module Berkshelf
         cookbooks[cookbook][:uploaded_to] = chef_api_url
       end
 
+      # Output a list of outdated cookbooks and the most recent version
+      # to delayed output
+      #
+      # @param [Hash] hash
+      #   the list of outdated cookbooks in the format
+      #   { 'cookbook' => { 'api.berkshelf.com' => #<Cookbook> } }
+      def outdated(hash)
+        hash.keys.each do |name|
+          hash[name].each do |source, cookbook|
+            cookbooks[name] ||= {}
+            cookbooks[name][:version] = cookbook.version
+            cookbooks[name][:sources] ||= {}
+            cookbooks[name][:sources][source] = cookbook
+          end
+        end
+      end
+
       # Add a Cookbook package entry to delayed output
       #
       # @param [String] cookbook


### PR DESCRIPTION
Follow up of #693 

The original implementation of `berks outdated` was added as a BETA feature because it was almost useless and couldn't be implemented properly without a view of the entire dependency matrix.

In #693 I have stubbed the original implementation out. It should be re-implemented to take into consideration the entire dependency matrix provided by all berkshelf API sources added to the Berksfile.
