### PR TITLE
Only show failing specs and cukes on Travis

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -56,11 +56,11 @@ class Spec < Thor
 
   no_tasks do
     def units_command
-      run('rspec --color --format=documentation spec/unit')
+      run('rspec --color --format progress spec/unit')
     end
 
     def acceptance_command
-      run('cucumber --color --format pretty --tags ~@no_run')
+      run('cucumber --color --format progress --tags ~@no_run')
     end
 
     def quality_command


### PR DESCRIPTION
It's becoming very cucumbersome to parse through all the passing specs/cukes to see a failing one on Travis. This PR uses the `progress` formatter for both, thus only showing the failures.

@reset @ivey thoughts?
