### PR TITLE
change default vendor location to 'berks-cookbooks'

### DIFF
--- a/features/vendor_command.feature
+++ b/features/vendor_command.feature
@@ -65,8 +65,8 @@ Feature: Vendoring cookbooks to a directory
       | berkshelf | 1.0.0 |
     And the Berkshelf API server's cache is up to date
     When I successfully run `berks vendor`
-    And a directory named "cookbooks/berkshelf" should exist
-    And the directory "cookbooks/berkshelf" should contain version "1.0.0" of the "berkshelf" cookbook
+    And a directory named "berks-cookbooks/berkshelf" should exist
+    And the directory "berks-cookbooks/berkshelf" should contain version "1.0.0" of the "berkshelf" cookbook
 
   Scenario: vendoring to a directory that already exists
     Given I write to "Berksfile" with:

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -408,7 +408,7 @@ module Berkshelf
       aliases: '-b',
       banner: 'PATH'
     desc "vendor [PATH]", "Vendor the cookbooks specified by the Berksfile into a directory"
-    def vendor(path = File.join(Dir.pwd, "cookbooks"))
+    def vendor(path = File.join(Dir.pwd, "berks-cookbooks"))
       berksfile = Berkshelf::Berksfile.from_file(options[:berksfile])
       berksfile.vendor(path, options)
     end


### PR DESCRIPTION
Per @ivey's comment: https://github.com/RiotGames/berkshelf/pull/729/files#r5222502

@ivey @sethvargo 
