### PR TITLE
Make the BerksfileNotFound exception less confusing

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -15,7 +15,7 @@ module Berkshelf
       def from_file(file)
         new(file).dsl_eval_file(file)
       rescue Errno::ENOENT => ex
-        raise BerksfileNotFound, "No Berksfile or Berksfile.lock found at: #{file}"
+        raise BerksfileNotFound, ex.message
       rescue => ex
         raise BerksfileReadError.new(ex)
       end


### PR DESCRIPTION
As of now, if reading `metadata.rb` throws an ENOENT (like if you're reading a nonexistent README.md to generate a description D:), berkshelf will give you a possibly incorrect error message.
