### PR TITLE
`Berks package` should packaging properly for chef-solo 

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -555,9 +555,12 @@ module Berkshelf
       cached_cookbooks.each { |cookbook| validate_files!(cookbook) }
 
       Dir.mktmpdir do |tmp|
+        cookbooks_dir = File.join(tmp, 'cookbooks')
+        FileUtils.mkdir_p(cookbooks_dir)
+
         cached_cookbooks.each do |cookbook|
           path        = cookbook.path.to_s
-          destination = File.join(tmp, cookbook.cookbook_name)
+          destination = File.join(cookbooks_dir, cookbook.cookbook_name)
 
           FileUtils.cp_r(path, destination)
 


### PR DESCRIPTION
Chef-Solo expects cookbooks to be packaged under ./cookbooks in the archive.  Currently `berks package` puts them in the root of the archive which makes Chef-Solo a very sad panda.  This was first discussed in #509 .
