### PR TITLE
Standardize cucumber tests

### DIFF
--- a/features/apply_command.feature
+++ b/features/apply_command.feature
@@ -9,10 +9,8 @@ Feature: Applying cookbook versions to a Chef Environment
     And the cookbook store has the cookbooks:
       | dependency | 2.0.0 |
     And The Chef Server has an environment named "berkshelf_lock_test"
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', '1.0.0'
       """
     When I successfully run `berks apply berkshelf_lock_test`
@@ -20,16 +18,14 @@ Feature: Applying cookbook versions to a Chef Environment
       | cookbook   | version_lock |
       | fake       | 1.0.0 |
       | dependency | 2.0.0 |
-    And the exit status should be 0
+
 
   Scenario: Locking cookbook versions to a non-existent Chef Environment
     Given The Chef Server does not have an environment named "berkshelf_lock_test"
     And the cookbook store has the cookbooks:
       | fake | 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', '1.0.0'
       """
     When I run `berks apply berkshelf_lock_test`

--- a/features/berksfile.feature
+++ b/features/berksfile.feature
@@ -6,8 +6,6 @@ Feature: Evaluating a Berksfile
   Scenario: Containing pure Ruby
     Given I write to "Berksfile" with:
       """
-      source "http://localhost:26210"
-
       if ENV['BACON']
         puts "If you don't got bacon..."
       else
@@ -24,8 +22,6 @@ Feature: Evaluating a Berksfile
   Scenario: Containing methods I shouldn't be able to call
     Given I write to "Berksfile" with:
       """
-      source "http://localhost:26210"
-
       add_location(:foo)
       """
     When I run `berks install`
@@ -40,8 +36,6 @@ Feature: Evaluating a Berksfile
   Scenario: Containing Ruby syntax errors
     Given I write to "Berksfile" with:
       """
-      source "http://localhost:26210"
-
       ptus "This is a ruby syntax error"
       """
     When I run `berks install`

--- a/features/config.feature
+++ b/features/config.feature
@@ -9,7 +9,6 @@ Feature: Reading a Berkshelf configuration file
       | config.omnibus.chef_version = :latest |
       | config.vm.box = "opscode_ubuntu-12.04_provisionerless" |
       | config.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box" |
-    And the exit status should be 0
 
   Scenario: Using a Berkshelf configuration file that disables the vagrant-omnibus plugin
     Given I have a Berkshelf config file containing:
@@ -108,7 +107,7 @@ Feature: Reading a Berkshelf configuration file
       | config.vm.network :forwarded_port, guest: 12345, host: 54321 |
       | config.vm.network :private_network, ip: "12.34.56.78" |
       | config.vm.network :public_network |
-    And the exit status should be 0
+
 
   Scenario: Using a partial Berkshelf configuration file
     Given I have a Berkshelf config file containing:
@@ -126,7 +125,7 @@ Feature: Reading a Berkshelf configuration file
     When I successfully run `berks cookbook sparkle_motion`
     Then the resulting "sparkle_motion" Vagrantfile should contain:
       | config.vm.network :forwarded_port, guest: 12345, host: 54321 |
-    And the exit status should be 0
+
 
   Scenario: Using an invalid Berkshelf configuration file
     Given I have a Berkshelf config file containing:
@@ -166,4 +165,3 @@ Feature: Reading a Berkshelf configuration file
       | chef.chef_server_url        = "localhost:4000"      |
       | chef.validation_client_name = "my_client-validator" |
       | chef.validation_key_path    = "/a/b/c/my_client-validator.pem" |
-    Then the exit status should be 0

--- a/features/configure_command.feature
+++ b/features/configure_command.feature
@@ -28,7 +28,7 @@ Feature: Configuring Berkshelf via the command line
       | chef.validation_key_path    | /Users/reset/.chef/reset.pem                      |
       | vagrant.vm.box              | Berkshelf-minimal                                 |
       | vagrant.vm.box_url          | https://dl.dropbox.com/Berkshelf.box              |
-    And the exit status should be 0
+
 
   Scenario: Accepting the default values
     Given I do not have a Chef config
@@ -53,7 +53,6 @@ Feature: Configuring Berkshelf via the command line
       | vagrant.vm.box_url          | https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box |
       | vagrant.omnibus.enabled     | BOOLEAN[true] |
       | vagrant.omnibus.version     | latest |
-    And the exit status should be 0
 
   Scenario: Creating a Berkshelf configuration file when one already exists
     Given I already have a Berkshelf config file
@@ -85,7 +84,6 @@ Feature: Configuring Berkshelf via the command line
       | chef.validation_key_path    | /Users/reset/.chef/reset.pem                      |
       | vagrant.vm.box              | Berkshelf-minimal                                 |
       | vagrant.vm.box_url          | https://dl.dropbox.com/Berkshelf.box              |
-    And the exit status should be 0
 
     Examples:
       | path                   |

--- a/features/contingent_command.feature
+++ b/features/contingent_command.feature
@@ -15,10 +15,8 @@ Feature: Running the contingent command
       | dep | ~> 1.0.0 |
     And the cookbook store contains a cookbook "ekaf" "1.0.0" with dependencies:
       | dep | ~> 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', '1.0.0'
       cookbook 'ekaf', '1.0.0'
       """
@@ -29,15 +27,13 @@ Feature: Running the contingent command
         * ekaf (1.0.0)
         * fake (1.0.0)
       """
-    And the exit status should be 0
+
 
   Scenario: When there are no dependent cookbooks
     Given the cookbook store has the cookbooks:
       | fake | 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', '1.0.0'
       """
     And I successfully run `berks contingent dep`
@@ -45,13 +41,10 @@ Feature: Running the contingent command
       """
       There are no cookbooks contingent upon 'dep' defined in this Berksfile
       """
-    And the exit status should be 0
+
 
   Scenario: When the cookbook is not in the Berksfile
-    Given I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
-      """
+    Given I have a Berksfile pointing at the local Berkshelf API
     And I successfully run `berks contingent dep`
     Then the output should contain:
       """

--- a/features/cookbook_command.feature
+++ b/features/cookbook_command.feature
@@ -6,13 +6,11 @@ Feature: Creating a new cookbook
   Scenario: With the default options
     When I successfully run `berks cookbook sparkle_motion`
     Then I should have a new cookbook skeleton "sparkle_motion"
-    And the exit status should be 0
+
 
   Scenario Outline: With various options
     When I successfully run `berks cookbook sparkle_motion --<option>`
     Then I should have a new cookbook skeleton "sparkle_motion" with <feature> support
-    And the exit status should be 0
-
   Examples:
     | option            | feature         |
     | foodcritic        | Foodcritic      |
@@ -25,21 +23,20 @@ Feature: Creating a new cookbook
     | skip-vagrant      | no Vagrant      |
     | skip-test-kitchen | no Test Kitchen |
 
+
   Scenario Outline: When a required supporting gem is not installed
     Given the gem "<gem>" is not installed
     When I successfully run `berks cookbook sparkle_motion --<option>`
     Then I should have a new cookbook skeleton "sparkle_motion" with <feature> support
     And the output should contain a warning to suggest supporting the option "<option>" by installing "<gem>"
-    And the exit status should be 0
-
   Examples:
     | option     | feature    | gem             |
     | foodcritic | Foodcritic | foodcritic      |
     | scmversion | SCMVersion | thor-scmversion |
+
 
   Scenario: When bundler is not installed
     Given the gem "bundler" is not installed
     When I successfully run `berks cookbook sparkle_motion`
     Then I should have a new cookbook skeleton "sparkle_motion"
     And the output should contain a warning to suggest supporting the default for "bundler" by installing "bundler"
-    And the exit status should be 0

--- a/features/groups_install.feature
+++ b/features/groups_install.feature
@@ -3,50 +3,16 @@ Feature: Installing specific groups
   I want to be able specify groups of cookbooks to include or exclude
   So I don't install cookbooks that are part of a group that I do not want to install
 
-  Scenario: Using the --except option
+  Background:
     Given the cookbook store has the cookbooks:
-      | default  | 1.0.0 |
-      | takeme   | 1.0.0 |
-    Given I write to "Berksfile" with:
+      | default | 1.0.0 |
+      | notme   | 1.0.0 |
+      | takeme  | 1.0.0 |
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
-      group :notme do
-        cookbook 'notme', '1.0.0'
-      end
-
       cookbook 'default', '1.0.0'
-
-      group :takeme do
-        cookbook 'takeme', '1.0.0'
-      end
-      """
-    When I successfully run `berks install --except notme`
-    Then the output should contain:
-      """
-      Using default (1.0.0)
-      Using takeme (1.0.0)
-      """
-    And the output should not contain "Using notme (1.0.0)"
-    And the exit status should be 0
-
-  Scenario: Using the --except option with a lockfile
-    Given the cookbook store has the cookbooks:
-      | default  | 1.0.0 |
-      | takeme   | 1.0.0 |
-    Given I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
-
-      group :notme do
-        cookbook 'notme', '1.0.0'
-      end
-
-      cookbook 'default', '1.0.0'
-
-      group :takeme do
-        cookbook 'takeme', '1.0.0'
-      end
+      cookbook 'notme',   '1.0.0', group: :notme
+      cookbook 'takeme',  '1.0.0', group: :takeme
       """
     And I write to "Berksfile.lock" with:
       """
@@ -58,6 +24,9 @@ Feature: Installing specific groups
         }
       }
       """
+
+
+  Scenario: when the --except option
     When I successfully run `berks install --except notme`
     Then the output should contain:
       """
@@ -65,49 +34,16 @@ Feature: Installing specific groups
       Using takeme (1.0.0)
       """
     And the output should not contain "Using notme (1.0.0)"
-    And the exit status should be 0
 
-  Scenario: Using the --only option
-    Given the cookbook store has the cookbooks:
-      | takeme   | 1.0.0 |
-    Given I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
-      group :notme do
-        cookbook 'notme', '1.0.0'
-      end
-
-      cookbook 'default', '1.0.0'
-
-      group :takeme do
-        cookbook 'takeme', '1.0.0'
-      end
-      """
+  Scenario: with the --only option
     When I successfully run `berks install --only takeme`
     Then the output should contain "Using takeme (1.0.0)"
     Then the output should not contain "Using notme (1.0.0)"
     Then the output should not contain "Using default (1.0.0)"
-    And the exit status should be 0
+
 
   Scenario: Attempting to provide an only and except option
-    Given I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
-
-      group :notme do
-        cookbook 'nginx', '= 0.101.2'
-      end
-
-      cookbook 'berkshelf-cookbook-fixture', '1.0.0'
-
-      group :takeme do
-        cookbook 'hostsfile', '1.0.1'
-      end
-      """
     When I run `berks install --only takeme --except notme`
-    Then the output should contain:
-      """
-      Cannot specify both :except and :only
-      """
+    Then the output should contain "Cannot specify both :except and :only"
     And the exit status should be "ArgumentError"

--- a/features/install_command.feature
+++ b/features/install_command.feature
@@ -9,10 +9,8 @@ Feature: install cookbooks from a Berksfile
     And the cookbook store is empty
 
   Scenario: installing the version that best satisfies our demand
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf'
       """
     And the Chef Server has cookbooks:
@@ -28,10 +26,8 @@ Feature: install cookbooks from a Berksfile
       | berkshelf | 2.0.0 |
 
   Scenario: installing an explicit version demand
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf', '1.0.0'
       """
     And the Chef Server has cookbooks:
@@ -47,10 +43,8 @@ Feature: install cookbooks from a Berksfile
       | berkshelf | 1.0.0 |
 
   Scenario: installing demands from all groups
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       group :one do
         cookbook 'ruby'
       end
@@ -74,10 +68,8 @@ Feature: install cookbooks from a Berksfile
       | elixir | 1.0.0 |
 
   Scenario: installing a demand that has already been installed
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf-cookbook-fixture', github: 'RiotGames/berkshelf-cookbook-fixture', branch: 'deps'
       """
     And the cookbook store contains a cookbook "berkshelf" "1.0.0" with dependencies:
@@ -92,10 +84,8 @@ Feature: install cookbooks from a Berksfile
       """
 
   Scenario: installing a demand from a path location
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'example_cookbook', path: '../../fixtures/cookbooks/example_cookbook-0.5.0'
       """
     And the Berkshelf API server's cache is up to date
@@ -106,23 +96,19 @@ Feature: install cookbooks from a Berksfile
       """
 
   Scenario: installing a Berksfile from a remote directory that contains a path location
-    Given I write to "tmp_berks/Berksfile" with:
+    Given I have a Berksfile at "subdirectory" pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'example_cookbook', path: '../../../fixtures/cookbooks/example_cookbook-0.5.0'
       """
-    When I successfully run `berks install -b ./tmp_berks/Berksfile`
+    When I successfully run `berks install -b subdirectory/Berksfile`
     Then the output should contain:
       """
       Using example_cookbook (0.5.0) path: '
       """
 
   Scenario: installing a demand from a Git location
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git"
       """
     When I successfully run `berks install`
@@ -136,10 +122,8 @@ Feature: install cookbooks from a Berksfile
       """
 
   Scenario: installing a demand from a Git location that has already been installed
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git"
       """
     And the cookbook store has the git cookbooks:
@@ -151,10 +135,8 @@ Feature: install cookbooks from a Berksfile
       """
 
   Scenario: installing a Berksfile that contains a Git location with a rel
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", github: 'RiotGames/berkshelf-cookbook-fixture', branch: 'rel', rel: 'cookbooks/berkshelf-cookbook-fixture'
       """
     When I successfully run `berks install`
@@ -168,10 +150,8 @@ Feature: install cookbooks from a Berksfile
       """
 
   Scenario: installing a Berksfile that contains a Git location with a tag
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
       """
     When I successfully run `berks install`
@@ -185,10 +165,8 @@ Feature: install cookbooks from a Berksfile
       """
 
   Scenario: installing a Berksfile that contains a GitHub location
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", github: "RiotGames/berkshelf-cookbook-fixture", tag: "v0.2.0"
       """
     When I successfully run `berks install`
@@ -202,10 +180,8 @@ Feature: install cookbooks from a Berksfile
       """
 
   Scenario Outline: installing a Berksfile that contains a Github location and specific protocol
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", github: "RiotGames/berkshelf-cookbook-fixture", tag: "v1.0.0", protocol: "<protocol>"
       """
     When I successfully run `berks install`
@@ -224,10 +200,8 @@ Feature: install cookbooks from a Berksfile
       | https |
 
   Scenario: installing a Berksfile that contains a Github location and an unsupported protocol
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", github: "RiotGames/berkshelf-cookbook-fixture", tag: "v0.2.0", protocol: "somethingabsurd"
       """
     When I run `berks install`
@@ -239,14 +213,12 @@ Feature: install cookbooks from a Berksfile
 
   Scenario: running install when current project is a cookbook and the 'metadata' is specified
     Given a cookbook named "sparkle_motion"
-    And the cookbook "sparkle_motion" has the file "Berksfile" with:
+    And I cd to "sparkle_motion"
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       metadata
       """
-    When I cd to "sparkle_motion"
-    And I successfully run `berks install`
+    When I successfully run `berks install`
     Then the output should contain:
       """
       Using sparkle_motion (0.0.0)
@@ -254,10 +226,8 @@ Feature: install cookbooks from a Berksfile
 
   Scenario: running install when current project is a cookbook and the 'metadata' is specified with a path
     Given a cookbook named "fake"
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       metadata path: './fake'
       """
     When I successfully run `berks install`
@@ -272,10 +242,8 @@ Feature: install cookbooks from a Berksfile
       | bacon | 0.2.0 |
       | bacon | 1.0.0 |
     And the Berkshelf API server's cache is up to date
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'bacon', '~> 0.1'
       """
     And I write to "Berksfile.lock" with:
@@ -303,10 +271,8 @@ Feature: install cookbooks from a Berksfile
     And the exit status should be "BerksfileNotFound"
 
   Scenario: running install when the Cookbook is not found on the remote site
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'doesntexist'
       cookbook 'other-failure'
       """
@@ -318,10 +284,8 @@ Feature: install cookbooks from a Berksfile
     And the exit status should be "NoSolutionError"
 
   Scenario: installing a Berksfile that has a Git location source with an invalid Git URI
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'nginx', git: '/something/on/disk'
       """
     When I run `berks install`
@@ -332,10 +296,8 @@ Feature: install cookbooks from a Berksfile
     And the exit status should be "InvalidGitURI"
 
   Scenario: installing when there are sources with duplicate names defined in the same group
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf-cookbook-fixture'
       cookbook 'berkshelf-cookbook-fixture'
       """
@@ -347,10 +309,8 @@ Feature: install cookbooks from a Berksfile
     And the exit status should be "DuplicateDependencyDefined"
 
   Scenario: when a Git demand points to a branch that does not satisfy the version constraint
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", "1.0.0", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
       """
     When I run `berks install`
@@ -362,10 +322,8 @@ Feature: install cookbooks from a Berksfile
     And the exit status should be "CookbookValidationFailure"
 
   Scenario: when a Git demand is defined and a cookbook of the same name and version is already in the cookbook store
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v1.0.0"
       """
     And the cookbook store has the cookbooks:
@@ -379,10 +337,8 @@ Feature: install cookbooks from a Berksfile
       """
 
   Scenario: with a cookbook definition containing an invalid option
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook "berkshelf-cookbook-fixture", whatisthis: "I don't even know", anotherwat: "isthat"
       """
     When I run `berks install`
@@ -393,10 +349,8 @@ Feature: install cookbooks from a Berksfile
     And the exit status should be "InternalError"
 
   Scenario: with a git error during download
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf-cookbook-fixture', '1.0.0'
       cookbook "doesntexist", git: "git://github.com/asdjhfkljashflkjashfakljsf"
       """

--- a/features/json_formatter.feature
+++ b/features/json_formatter.feature
@@ -9,10 +9,8 @@ Feature: --format json
     And the cookbook store is empty
 
   Scenario: JSON output installing a cookbook from the default location
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf', '1.0.0'
       """
     And the Chef Server has cookbooks:
@@ -40,10 +38,8 @@ Feature: --format json
   Scenario: JSON output installing a cookbook we already have
     Given the cookbook store has the cookbooks:
       | berkshelf-cookbook-fixture   | 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf-cookbook-fixture', '1.0.0'
       """
     When I successfully run `berks install --format json`
@@ -68,22 +64,12 @@ Feature: --format json
   Scenario: JSON output when running the show command
     Given the cookbook store has the cookbooks:
       | fake | 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', '1.0.0'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | fake | 1.0.0 |
     When I successfully run `berks show fake --format json`
     Then the output should contain JSON:
       """
@@ -107,10 +93,8 @@ Feature: --format json
       """
 
   Scenario: JSON output when running the upload command
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'example_cookbook', path: '../../fixtures/cookbooks/example_cookbook-0.5.0'
       """
     When I successfully run `berks upload --format json`
@@ -142,31 +126,21 @@ Feature: --format json
       | seth | 0.2.9 |
       | seth | 1.0.0 |
     And the Berkshelf API server's cache is up to date
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'seth', '~> 0.1'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "seth": {
-            "locked_version": "0.1.0"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | seth | 0.1.0 |
     And I successfully run `berks outdated --format json`
-    Then the output should contain:
+    Then the output should contain JSON:
       """
       {
         "cookbooks": [
           {
             "version": "0.2.9",
             "sources": {
-              "http://localhost:26210": {
+              "http://0.0.0.0:26210": {
                 "name": "seth",
                 "version": "0.2.9"
               }

--- a/features/licenses.feature
+++ b/features/licenses.feature
@@ -7,21 +7,18 @@ Feature: Installing cookbooks with specific licenses
     Given the Berkshelf API server's cache is empty
     And the Chef Server is empty
     And the cookbook store is empty
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'fake', '1.0.0'
+      """
 
-  Scenario: With licenses defined
+
+  Scenario: when licenses is defined
     Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 0.1.0 | mit |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
-
-      cookbook 'berkshelf-cookbook-fixture', '~> 0.1'
-      """
+      | fake | 1.0.0 | mit |
     And I have a Berkshelf config file containing:
       """
-      {
-        "allowed_licenses": ["mit"]
-      }
+      { "allowed_licenses": ["mit"] }
       """
     When I successfully run `berks install`
     Then the output should not contain:
@@ -29,20 +26,13 @@ Feature: Installing cookbooks with specific licenses
       is not in your list of allowed licenses
       """
 
-  Scenario: With a license that is not listed
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 0.1.0 | mit |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
-      cookbook 'berkshelf-cookbook-fixture', '~> 0.1'
-      """
+  Scenario: when a license is not listed
+    Given the cookbook store has the cookbooks:
+      | fake | 1.0.0 | mit |
     And I have a Berkshelf config file containing:
       """
-      {
-        "allowed_licenses": ["apache2"]
-      }
+      { "allowed_licenses": ["apache2"] }
       """
     When I successfully run `berks install`
     Then the output should contain:
@@ -50,21 +40,13 @@ Feature: Installing cookbooks with specific licenses
       'mit' is not in your list of allowed licenses
       """
 
-  Scenario: With raise_license_exception defined
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 0.1.0 | mit |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
-      cookbook 'berkshelf-cookbook-fixture', '~> 0.1'
-      """
+  Scenario: when raise_license_exception is defined
+    Given the cookbook store has the cookbooks:
+      | fake | 1.0.0 | mit |
     And I have a Berkshelf config file containing:
       """
-      {
-        "allowed_licenses": ["mit"],
-        "raise_license_exception": true
-      }
+      { "allowed_licenses": ["mit"], "raise_license_exception": true }
       """
     When I successfully run `berks install`
     Then the output should not contain:
@@ -72,21 +54,13 @@ Feature: Installing cookbooks with specific licenses
       is not in your list of allowed licenses
       """
 
-  Scenario: With a license that is not listed
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 0.1.0 | mit |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
-      cookbook 'berkshelf-cookbook-fixture', '~> 0.1'
-      """
+  Scenario: when raise_license_exception is defined and a license is not listed
+    Given the cookbook store has the cookbooks:
+      | fake | 1.0.0 | mit |
     And I have a Berkshelf config file containing:
       """
-      {
-        "allowed_licenses": ["apache2"],
-        "raise_license_exception": true
-      }
+      { "allowed_licenses": ["apache2"], "raise_license_exception": true }
       """
     When I run `berks install`
     Then the output should contain:
@@ -95,21 +69,17 @@ Feature: Installing cookbooks with specific licenses
       """
     And the exit status should be "LicenseNotAllowed"
 
-  Scenario: With a :path location
+
+  Scenario: when the cookbook is a path location
     Given the cookbook store has the cookbooks:
       | fake | 0.1.0 | mit |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', path: '../../tmp/berkshelf/cookbooks/fake-0.1.0'
       """
     And I have a Berkshelf config file containing:
       """
-      {
-        "allowed_licenses": ["apache2"],
-        "raise_license_exception": true
-      }
+      { "allowed_licenses": ["apache2"], "raise_license_exception": true }
       """
     When I successfully run `berks install`
     Then the output should not contain:

--- a/features/list_command.feature
+++ b/features/list_command.feature
@@ -7,10 +7,8 @@ Feature: Listing cookbooks defined by a Berksfile
     Given the cookbook store has the cookbooks:
       | fake1 | 1.0.0 |
       | fake2 | 1.0.1 |
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake1', '1.0.0'
       cookbook 'fake2', '1.0.1'
       """
@@ -21,16 +19,12 @@ Feature: Listing cookbooks defined by a Berksfile
         * fake1 (1.0.0)
         * fake2 (1.0.1)
       """
-    And the exit status should be 0
+
 
   Scenario: Running the list command with no sources defined
-    Given I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
-      """
+    Given I have a Berksfile pointing at the local Berkshelf API
     When I successfully run `berks list`
     Then the output should contain:
       """
       There are no cookbooks installed by your Berksfile
       """
-    And the exit status should be 0

--- a/features/lockfile.feature
+++ b/features/lockfile.feature
@@ -3,34 +3,30 @@ Feature: Creating and reading the Berkshelf lockfile
   I want my versions to be locked even when I don't specify versions in my Berksfile
   So when I share my repository, all other developers get the same versions that I did when I installed.
 
-  Scenario: Writing the Berksfile.lock
+  Background:
     Given the cookbook store has the cookbooks:
+      | fake | 0.1.0 |
+      | fake | 0.2.0 |
       | fake | 1.0.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
+    And the cookbook store has the git cookbooks:
+      | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
+      | berkshelf-cookbook-fixture | 1.0.0 | 919afa0c402089df23ebdf36637f12271b8a96b4 |
+      | berkshelf-cookbook-fixture | 1.0.0 | a97b9447cbd41a5fe58eee2026e48ccb503bd3bc |
+      | berkshelf-cookbook-fixture | 1.0.0 | 93f5768b7d14df45e10d16c8bf6fe98ba3ff809a |
 
+  Scenario: Writing the Berksfile.lock
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'fake', '1.0.0'
       """
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "fake":{
-            "locked_version":"1.0.0"
-          }
-        }
-      }
-      """
-
-  Scenario: Wiring the Berksfile.lock when a 1.0 lockfile is present
-    Given the cookbook store has the cookbooks:
+    Then the Lockfile should have:
       | fake | 1.0.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+
+  Scenario: Writing the Berksfile.lock when a 1.0 lockfile is present
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'fake', '1.0.0'
       """
     And I write to "Berksfile.lock" with:
@@ -39,54 +35,14 @@ Feature: Creating and reading the Berkshelf lockfile
       """
     When I successfully run `berks install`
     Then the output should warn about the old lockfile format
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
-
-  Scenario: Wiring the Berksfile.lock when a 2.0 lockfile is present
-    Given the cookbook store has the cookbooks:
+    And the Lockfile should have:
       | fake | 1.0.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
-      cookbook 'fake', '1.0.0'
-      """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
-    When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
 
-  Scenario: Writing the Berksfile.lock when an old lockfile is present and contains a full path
+  Scenario: Writing the Berksfile.lock when a 1.0 lockfile is present and contains a full path
     Given a cookbook named "fake"
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', '0.0.0', path: './fake'
       """
     And I write to "Berksfile.lock" with:
@@ -95,391 +51,205 @@ Feature: Creating and reading the Berkshelf lockfile
       """
     When I successfully run `berks install`
     Then the output should warn about the old lockfile format
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "fake":{
-            "path":"./fake"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | fake | ./fake |
 
-  Scenario: Reading the Berksfile.lock when it contains an invalid path location
-    Given the cookbook store has the cookbooks:
-      | fake | 1.0.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
-      cookbook 'fake'
+  Scenario: Writing the Berksfile.lock when a 2.0 lockfile is present
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'fake', '1.0.0'
       """
     And I write to "Berksfile.lock" with:
       """
       {
-        "dependencies":{
-          "non-existent":{
-            "path":"/this/path/does/not/exist"
+        "sources": {
+          "fake": {
+            "locked_version": "1.0.0"
           }
         }
       }
       """
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
+    Then the Lockfile should have:
+      | fake | 1.0.0 |
+
+
+  Scenario: Reading the Berksfile.lock when it contains an invalid path location
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      {
-        "dependencies":{
-          "fake":{
-            "locked_version":"1.0.0"
-          }
-        }
-      }
+      cookbook 'fake'
       """
+    And the Lockfile has:
+      | non-existent | /this/path/does/not/exist |
+    When I successfully run `berks install`
+    Then the Lockfile should have:
+      | fake | 1.0.0 |
+
 
   Scenario: Installing a cookbook with dependencies
     Given the cookbook store has the cookbooks:
       | dep | 1.0.0 |
     And the cookbook store contains a cookbook "fake" "1.0.0" with dependencies:
       | dep | ~> 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', '1.0.0'
       """
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies": {
-          "fake":{
-            "locked_version": "1.0.0"
-          },
-          "dep":{
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | fake | 1.0.0 |
+      | dep  | 1.0.0 |
+
 
   Scenario: Writing the Berksfile.lock with a pessimistic lock
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
-      cookbook 'berkshelf-cookbook-fixture', '~> 1.0.0'
+      cookbook 'fake', '~> 1.0.0'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"1.0.0"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | fake | 1.0.0 |
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"1.0.0"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | fake | 1.0.0 |
+
 
   Scenario: Updating with a Berksfile.lock with pessimistic lock
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 0.2.0 |
-      | berkshelf-cookbook-fixture | 1.0.0 |
-    And I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
+      cookbook 'fake', '~> 0.1'
+      """
+    And the Lockfile has:
+      | fake | 0.1.0 |
+    When I successfully run `berks update fake`
+    Then the Lockfile should have:
+      | fake | 0.2.0 |
 
-      cookbook 'berkshelf-cookbook-fixture', '~> 0.1'
-      """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"0.1.0"
-          }
-        }
-      }
-      """
-    When I successfully run `berks update berkshelf-cookbook-fixture`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"0.2.0"
-          }
-        }
-      }
-      """
 
   Scenario: Updating with a Berksfile.lock with hard lock
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
+      cookbook 'fake', '0.1.0'
+      """
+    And the Lockfile has:
+      | fake | 0.1.0 |
+    When I successfully run `berks update fake`
+    Then the Lockfile should have:
+      | fake | 0.1.0 |
 
-      cookbook 'berkshelf-cookbook-fixture', '1.0.0'
-      """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"1.0.0"
-          }
-        }
-      }
-      """
-    When I successfully run `berks update berkshelf-cookbook-fixture`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"1.0.0"
-          }
-        }
-      }
-      """
 
   Scenario: Updating a Berksfile.lock with a git location
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 1.0.0 |
-    And I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf-cookbook-fixture', git: 'git://github.com/RiotGames/berkshelf-cookbook-fixture.git', ref: '919afa0c4'
       """
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "git":"git://github.com/RiotGames/berkshelf-cookbook-fixture.git",
-            "ref":"919afa0c402089df23ebdf36637f12271b8a96b4",
-            "locked_version":"1.0.0"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | berkshelf-cookbook-fixture | 1.0.0 | 919afa0c402089df23ebdf36637f12271b8a96b4 |
+
 
   Scenario: Updating a Berksfile.lock with a git location and a branch
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 1.0.0 |
-    And I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf-cookbook-fixture', git: 'git://github.com/RiotGames/berkshelf-cookbook-fixture.git', branch: 'master'
       """
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "git":"git://github.com/RiotGames/berkshelf-cookbook-fixture.git",
-            "ref":"a97b9447cbd41a5fe58eee2026e48ccb503bd3bc",
-            "locked_version":"1.0.0"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | berkshelf-cookbook-fixture | 1.0.0 | a97b9447cbd41a5fe58eee2026e48ccb503bd3bc |
+
 
   Scenario: Updating a Berksfile.lock with a git location and a branch
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 70a527e17d91f01f031204562460ad1c17f972ee |
-    And I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf-cookbook-fixture', git: 'git://github.com/RiotGames/berkshelf-cookbook-fixture.git', tag: 'v0.2.0'
       """
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "git":"git://github.com/RiotGames/berkshelf-cookbook-fixture.git",
-            "ref":"70a527e17d91f01f031204562460ad1c17f972ee",
-            "locked_version":"0.2.0"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
+
 
   Scenario: Updating a Berksfile.lock with a GitHub location
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 919afa0c402089df23ebdf36637f12271b8a96b4 |
-    And I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf-cookbook-fixture', github: 'RiotGames/berkshelf-cookbook-fixture', ref: '919afa0c4'
       """
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "git":"git://github.com/RiotGames/berkshelf-cookbook-fixture.git",
-            "ref":"919afa0c402089df23ebdf36637f12271b8a96b4",
-            "locked_version":"1.0.0"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | berkshelf-cookbook-fixture | 1.0.0 | 919afa0c402089df23ebdf36637f12271b8a96b4 |
+
 
   Scenario: Updating a Berksfile.lock when a git location with :rel
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'berkshelf-cookbook-fixture', github: 'RiotGames/berkshelf-cookbook-fixture', branch: 'rel', rel: 'cookbooks/berkshelf-cookbook-fixture'
       """
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "git":"git://github.com/RiotGames/berkshelf-cookbook-fixture.git",
-            "ref":"93f5768b7d14df45e10d16c8bf6fe98ba3ff809a",
-            "rel":"cookbooks/berkshelf-cookbook-fixture",
-            "locked_version":"1.0.0"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | berkshelf-cookbook-fixture | 1.0.0 | 93f5768b7d14df45e10d16c8bf6fe98ba3ff809a | cookbooks/berkshelf-cookbook-fixture |
+
 
   Scenario: Updating a Berksfile.lock with a path location
     Given a cookbook named "fake"
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', path: './fake'
       """
     When I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "fake":{
-            "path":"./fake"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | fake | ./fake |
+
 
   Scenario: Installing a Berksfile with a metadata location
     Given a cookbook named "fake"
-    And the cookbook "fake" has the file "Berksfile" with:
+    And I cd to "fake"
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       metadata
       """
-    When I cd to "fake"
-    And I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "path": "."
-          }
-        }
-      }
-      """
+    When I successfully run `berks install`
+    Then the Lockfile should have:
+      | fake | . |
+
 
   Scenario: Installing a Berksfile with a metadata location
     Given a cookbook named "fake"
-    And the cookbook "fake" has the file "Berksfile" with:
+    And I cd to "fake"
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       metadata
       """
-    And the cookbook "fake" has the file "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "path": "."
-          }
-        }
-      }
-      """
-    When I cd to "fake"
-    And I successfully run `berks install`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "path": "."
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | fake | . |
+    When I successfully run `berks install`
+    Then the Lockfile should have:
+      | fake | . |
+
 
   Scenario: Installing when the locked version is no longer satisfied
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 1.0.0 |
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
-      cookbook 'berkshelf-cookbook-fixture', '1.0.0'
+      cookbook 'fake', '~> 1.3.0'
       """
-    And I successfully run `berks install`
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
-
-      cookbook 'berkshelf-cookbook-fixture', '~> 1.3.0'
-      """
+    And the Lockfile has:
+      | fake | 1.0.0 |
     When I run `berks install`
     Then the output should contain:
       """
-      Berkshelf could not find compatible versions for cookbook 'berkshelf-cookbook-fixture':
+      Berkshelf could not find compatible versions for cookbook 'fake':
         In Berksfile:
-          berkshelf-cookbook-fixture (~> 1.3.0)
+          fake (~> 1.3.0)
 
         In Berksfile.lock:
-          berkshelf-cookbook-fixture (1.0.0)
+          fake (1.0.0)
 
-      Try running `berks update berkshelf-cookbook-fixture`, which will try to find 'berkshelf-cookbook-fixture' matching '~> 1.3.0'
+      Try running `berks update fake`, which will try to find 'fake' matching '~> 1.3.0'
       """
     And the exit status should be "OutdatedDependency"
 
-  Scenario: Installing when the Lockfile is empty
-    Given the cookbook store has the cookbooks:
-      | fake | 1.0.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+  Scenario: Installing when the Lockfile is empty
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'fake', '1.0.0'
       """
     And an empty file named "Berksfile.lock"
@@ -489,11 +259,10 @@ Feature: Creating and reading the Berkshelf lockfile
       Using fake (1.0.0)
       """
 
-  Scenario: Installing when the Lockfile is in a bad state
-    Given I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+  Scenario: Installing when the Lockfile is in a bad state
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'fake', '1.0.0'
       """
     Given I write to "Berksfile.lock" with:

--- a/features/outdated_command.feature
+++ b/features/outdated_command.feature
@@ -10,57 +10,39 @@ Feature: Displaying outdated cookbooks
     And the Berkshelf API server's cache is up to date
     And the cookbook store has the cookbooks:
       | bacon | 1.1.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'bacon', '~> 1.1.0'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "bacon": {
-            "locked_version": "1.1.0"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | bacon | 1.1.0 |
     When I successfully run `berks outdated`
     Then the output should contain:
       """
       All cookbooks up to date!
       """
 
-  Scenario: the dependency has a no version constraint and there are new items
+
+  Scenario: the dependency has no version constraint and there are new items
     Given the Chef Server has cookbooks:
       | bacon | 1.0.0 |
       | bacon | 1.1.0 |
     And the Berkshelf API server's cache is up to date
     And the cookbook store has the cookbooks:
       | bacon | 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'bacon'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "bacon": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | bacon | 1.0.0 |
     When I successfully run `berks outdated`
     Then the output should contain:
       """
       The following cookbooks have newer versions:
-        * bacon (1.1.0) [http://localhost:26210]
+        * bacon (1.1.0)
       """
+
 
   Scenario: the dependency has a version constraint and there are new items that satisfy it
     Given the Chef Server has cookbooks:
@@ -70,34 +52,23 @@ Feature: Displaying outdated cookbooks
     And the Berkshelf API server's cache is up to date
     And the cookbook store has the cookbooks:
       | bacon | 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'bacon', '~> 1.0'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "bacon": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | bacon | 1.0.0 |
     When I successfully run `berks outdated`
     Then the output should contain:
       """
       The following cookbooks have newer versions:
-        * bacon (1.5.8) [http://localhost:26210]
+        * bacon (1.5.8)
       """
+
 
   Scenario: When there is no lockfile present
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'bacon', '1.0.0'
       """
     When I run `berks outdated`
@@ -107,23 +78,14 @@ Feature: Displaying outdated cookbooks
       """
     And the exit status should be "LockfileNotFound"
 
-  Scenario: When the cookbook is not installed
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+  Scenario: When the cookbook is not installed
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'bacon', '1.0.0'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "bacon": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | bacon | 1.0.0 |
     When I run `berks outdated`
     Then the output should contain:
       """

--- a/features/package_command.feature
+++ b/features/package_command.feature
@@ -3,13 +3,13 @@ Feature: Packaging a cookbook as a tarball for distribution
   I want to be able to package a cookbook
   So that I can use it outside of Berkshelf
 
-  Scenario: When no options are passed
+  Background:
     Given the cookbook store has the cookbooks:
       | fake | 1.0.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+  Scenario: When no options are passed
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'fake', '~> 1.0.0'
       """
     When I successfully run `berks package fake`
@@ -19,25 +19,19 @@ Feature: Packaging a cookbook as a tarball for distribution
       Cookbook(s) packaged to
       """
 
-  Scenario: With the --output option
-    Given the cookbook store has the cookbooks:
-      | fake | 1.0.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+  Scenario: With the --output option
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'fake', '~> 1.0.0'
       """
     When I successfully run `berks package fake --output foo/bar`
     Then a file named "foo/bar/fake.tar.gz" should exist
 
-  Scenario: With an installed cookbook name
-    Given the cookbook store has the cookbooks:
-      | fake | 1.0.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+  Scenario: With an installed cookbook name
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'fake', '~> 1.0.0'
       """
     When I run `berks package non-existent`
@@ -48,12 +42,11 @@ Feature: Packaging a cookbook as a tarball for distribution
       """
     And the exit status should be "CookbookNotFound"
 
+
   Scenario: With an invalid cookbook
     Given a cookbook named "cookbook with spaces"
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'cookbook with spaces', path: './cookbook with spaces'
       """
     When I run `berks package`

--- a/features/shelf/list.feature
+++ b/features/shelf/list.feature
@@ -9,7 +9,7 @@ Feature: Listing all cookbooks in the Berkshelf shelf
       """
       There are no cookbooks in the Berkshelf shelf
       """
-    And the exit status should be 0
+
 
   Scenario: With two cookbooks in the store
     Given the cookbook store has the cookbooks:
@@ -22,7 +22,7 @@ Feature: Listing all cookbooks in the Berkshelf shelf
         * ekaf (2.3.4)
         * fake (1.0.0)
       """
-    And the exit status should be 0
+
 
   Scenario: With multiple cookbook versions installed
     Given the cookbook store has the cookbooks:
@@ -36,4 +36,3 @@ Feature: Listing all cookbooks in the Berkshelf shelf
       Cookbooks in the Berkshelf shelf:
         * fake (1.0.0, 1.1.0, 1.2.0, 2.0.0)
       """
-    And the exit status should be 0

--- a/features/shelf/show.feature
+++ b/features/shelf/show.feature
@@ -11,6 +11,7 @@ Feature: Displaying information about a cookbook in the Berkshelf shelf
       """
     And the exit status should be "CookbookNotFound"
 
+
   Scenario: With cookbooks in the store
     Given the cookbook store has the cookbooks:
       | fake | 1.0.0 |
@@ -30,7 +31,6 @@ Feature: Displaying information about a cookbook in the Berkshelf shelf
       """
       Name: ekaf
       """
-    And the exit status should be 0
 
 
   Scenario: With cookbooks in the store and the --version option
@@ -52,7 +52,7 @@ Feature: Displaying information about a cookbook in the Berkshelf shelf
       """
       Name: ekaf
       """
-    And the exit status should be 0
+
 
   Scenario: With cookbooks in the store and the --version option doesn't exist
     Given the cookbook store has the cookbooks:
@@ -103,7 +103,7 @@ Feature: Displaying information about a cookbook in the Berkshelf shelf
              Email: YOUR_EMAIL
            License: none
       """
-    And the exit status should be 0
+
 
   Scenario: With multiple cookbook versions installed and the --version flag
     Given the cookbook store has the cookbooks:
@@ -149,4 +149,3 @@ Feature: Displaying information about a cookbook in the Berkshelf shelf
              Email: YOUR_EMAIL
            License: none
       """
-    And the exit status should be 0

--- a/features/shelf/uninstall.feature
+++ b/features/shelf/uninstall.feature
@@ -11,6 +11,7 @@ Feature: Removing a cookbook from the Berkshelf shelf
       """
     And the exit status should be "CookbookNotFound"
 
+
   Scenario: With two cookbooks in the store
     Given the cookbook store has the cookbooks:
       | fake | 1.0.0 |
@@ -24,7 +25,7 @@ Feature: Removing a cookbook from the Berkshelf shelf
       | fake | 1.0.0 |
     And the cookbook store should have the cookbooks:
       | ekaf | 2.3.4 |
-    And the exit status should be 0
+
 
   Scenario: With multiple cookbook versions installed
     Given the cookbook store has the cookbooks:
@@ -45,7 +46,7 @@ Feature: Removing a cookbook from the Berkshelf shelf
       | fake | 1.1.0 |
       | fake | 1.2.0 |
       | fake | 2.0.0 |
-    And the exit status should be 0
+
 
   Scenario: When specifying a version
     Given the cookbook store has the cookbooks:
@@ -64,7 +65,7 @@ Feature: Removing a cookbook from the Berkshelf shelf
       | fake | 1.1.0 |
       | fake | 1.2.0 |
       | fake | 2.0.0 |
-    And the exit status should be 0
+
 
   @spawn
   Scenario: With contingencies
@@ -86,7 +87,7 @@ Feature: Removing a cookbook from the Berkshelf shelf
       """
     And the cookbook store should not have the cookbooks:
       | ekaf | 2.3.4 |
-    And the exit status should be 0
+
 
   Scenario: With contingencies and the --force flag
     Given the cookbook store contains a cookbook "fake" "1.0.0" with dependencies:
@@ -100,4 +101,3 @@ Feature: Removing a cookbook from the Berkshelf shelf
       """
     And the cookbook store should not have the cookbooks:
       | ekaf | 2.3.4 |
-    And the exit status should be 0

--- a/features/show_command.feature
+++ b/features/show_command.feature
@@ -6,22 +6,12 @@ Feature: Displaying information about a cookbook defined by a Berksfile
   Scenario: With no options
     Given the cookbook store has the cookbooks:
       | fake | 1.0.0 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
       cookbook 'fake', '1.0.0'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | fake | 1.0.0 |
     When I successfully run `berks show fake`
     Then the output should contain:
       """
@@ -33,11 +23,9 @@ Feature: Displaying information about a cookbook defined by a Berksfile
            License: none
       """
 
+
   Scenario: When the cookbook is not in the Berksfile
-    Given I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
-      """
+    Given I have a Berksfile pointing at the local Berkshelf API
     When I run `berks show fake`
     Then the output should contain:
       """
@@ -45,11 +33,10 @@ Feature: Displaying information about a cookbook defined by a Berksfile
       """
     And the exit status should be "DependencyNotFound"
 
-  Scenario: When there is no lockfile present
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+  Scenario: When there is no lockfile present
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'fake', '1.0.0'
       """
     When I run `berks show fake`
@@ -59,23 +46,15 @@ Feature: Displaying information about a cookbook defined by a Berksfile
       """
     And the exit status should be "LockfileNotFound"
 
-  Scenario: When the cookbook is not installed
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+  Scenario: When the cookbook is not installed
+    Given the cookbook store is empty
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
       cookbook 'fake', '1.0.0'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies": {
-          "fake": {
-            "locked_version": "1.0.0"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | fake | 1.0.0 |
     When I run `berks show fake`
     Then the output should contain:
       """

--- a/features/step_definitions/berksfile_steps.rb
+++ b/features/step_definitions/berksfile_steps.rb
@@ -1,4 +1,39 @@
-Given /I have a Berksfile pointing at the community API endpoint with:/ do |contents|
-  contents = "source '#{Berkshelf::Berksfile::DEFAULT_API_URL}'\n\n" + contents
-  write_file('Berksfile', contents)
+Given /I have a Berksfile pointing at the community API endpoint with:/ do |content|
+  steps %Q{
+    Given a file named "Berksfile" with:
+      """
+      source '#{Berkshelf::Berksfile::DEFAULT_API_URL}'
+
+      #{content}
+      """
+  }
+end
+
+Given /^I have a Berksfile pointing at the local Berkshelf API$/ do
+  steps %Q{
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      """
+  }
+end
+
+Given /^I have a Berksfile pointing at the local Berkshelf API with:$/ do |content|
+  steps %Q{
+    Given I have a Berksfile at "." pointing at the local Berkshelf API with:
+      """
+      #{content}
+      """
+  }
+end
+
+Given /^I have a Berksfile at "(.+)" pointing at the local Berkshelf API with:$/ do |path, content|
+  steps %Q{
+    Given a directory named "#{path}"
+    And a file named "#{path}/Berksfile" with:
+      """
+      source 'http://0.0.0.0:#{BERKS_API_PORT}'
+
+      #{content}
+      """
+  }
 end

--- a/features/step_definitions/json_steps.rb
+++ b/features/step_definitions/json_steps.rb
@@ -14,13 +14,6 @@ class Hash
   end
 end
 
-Then /^the file "(.*?)" should contain JSON:$/ do |file, data|
-  target = JSON.pretty_generate(JSON.parse(data).sort_by_key)
-  actual = JSON.pretty_generate(JSON.parse(File.read(File.join(current_dir, file))).sort_by_key)
-
-  expect(actual).to eq(target)
-end
-
 Then /^the output should contain JSON:$/ do |data|
   target = JSON.pretty_generate(JSON.parse(data).sort_by_key)
   actual = JSON.pretty_generate(JSON.parse(all_output).sort_by_key)

--- a/features/step_definitions/lockfile_steps.rb
+++ b/features/step_definitions/lockfile_steps.rb
@@ -2,3 +2,56 @@ Then(/^the output should warn about the old lockfile format$/) do
   message = Berkshelf::Lockfile.class_eval('LockfileLegacy.send(:warning_message)')
   expect(all_output).to include(message)
 end
+
+Given /^the Lockfile has:$/ do |table|
+  result = { 'dependencies' => {} }
+
+  table.raw.each do |name, locked_or_path, ref, rel|
+    result['dependencies'][name] = {}
+
+    if locked_or_path =~ /(\d+\.){2}\d/
+      result['dependencies'][name]['locked_version'] = locked_or_path
+    else
+      result['dependencies'][name]['path'] = locked_or_path
+    end
+
+    unless ref.nil?
+      result['dependencies'][name]['rel'] = ref
+    end
+
+    unless rel.nil?
+      result['dependencies'][name]['rel'] = rel
+    end
+  end
+
+  File.open(File.join(current_dir, 'Berksfile.lock'), 'w') do |file|
+    file.write(JSON.pretty_generate(result) + "\n")
+  end
+end
+
+Then /^the Lockfile should have:$/ do |table|
+  hash = JSON.parse(File.read(File.join(current_dir, 'Berksfile.lock')))
+  dependencies = hash['dependencies']
+
+  table.raw.each do |name, locked_or_path, ref, rel|
+    expect(dependencies).to have_key(name)
+
+    if locked_or_path =~ /(\d+\.){2}\d/
+      expect(dependencies[name]).to have_key('locked_version')
+      expect(dependencies[name]['locked_version']).to eq(locked_or_path)
+    else
+      expect(dependencies[name]).to have_key('path')
+      expect(dependencies[name]['path']).to eq(locked_or_path)
+    end
+
+    unless ref.nil?
+      expect(dependencies[name]).to have_key('ref')
+      expect(dependencies[name]['ref']).to eq(ref)
+    end
+
+    unless rel.nil?
+      expect(dependencies[name]).to have_key('rel')
+      expect(dependencies[name]['rel']).to eq(rel)
+    end
+  end
+end

--- a/features/update_command.feature
+++ b/features/update_command.feature
@@ -3,134 +3,50 @@ Feature: Updating a cookbook defined by a Berksfile
   I want a way to update the versions without clearing out the files I've downloaded
   So that I can update faster than a clean install
 
-  Scenario: With the old lockfile format
+  Background:
     Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 0.1.0 |
-    And I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
+      | fake | 0.1.0 |
+      | fake | 0.2.0 |
+      | fake | 1.0.0 |
+      | ekaf | 1.0.0 |
+      | ekaf | 1.0.1 |
 
-      cookbook 'berkshelf-cookbook-fixture', '~> 0.1'
-      """
-    And I write to "Berksfile.lock" with:
-      """
-      cookbook 'berkshelf-cookbook-fixture', :locked_version => '0.1.0'
-      """
-    When I successfully run `berks update`
-    Then the output should warn about the old lockfile format
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"0.1.0"
-          }
-        }
-      }
-      """
 
   Scenario: Without a cookbook specified
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 0.1.0 |
-      | berkshelf-cookbook-fixture | 0.2.0 |
-      | hostsfile                  | 1.0.1 |
-    And I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
-      cookbook 'berkshelf-cookbook-fixture', '~> 0.1'
-      cookbook 'hostsfile', '~> 1.0.0'
+      cookbook 'fake', '~> 0.1'
+      cookbook 'ekaf', '~> 1.0.0'
       """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"0.1.0"
-          },
-          "hostsfile":{
-            "locked_version":"1.0.1"
-          }
-        }
-      }
-      """
+    And the Lockfile has:
+      | fake | 0.1.0 |
+      | ekaf | 1.0.0 |
     When I successfully run `berks update`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"0.2.0"
-          },
-          "hostsfile":{
-            "locked_version":"1.0.1"
-          }
-        }
-      }
-      """
+    Then the Lockfile should have:
+      | fake | 0.2.0 |
+      | ekaf | 1.0.1 |
+
 
   Scenario: With a single cookbook specified
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 0.1.0 |
-      | berkshelf-cookbook-fixture | 0.2.0 |
-      | hostsfile                  | 1.0.1 |
-    Given I write to "Berksfile" with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
+      cookbook 'fake', '~> 0.1'
+      cookbook 'ekaf', '~> 1.0.0'
+      """
+    And the Lockfile has:
+      | fake | 0.1.0 |
+      | ekaf | 1.0.0 |
+    When I successfully run `berks update fake`
+    Then the Lockfile should have:
+      | fake | 0.2.0 |
+      | ekaf | 1.0.0 |
 
-      cookbook 'berkshelf-cookbook-fixture', '~> 0.1'
-      cookbook 'hostsfile', '~> 1.0.0'
-      """
-    And I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"0.1.0"
-          },
-          "hostsfile":{
-            "locked_version":"1.0.1"
-          }
-        }
-      }
-      """
-    And I successfully run `berks update berkshelf-cookbook-fixture`
-    Then the file "Berksfile.lock" should contain JSON:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"0.2.0"
-          },
-          "hostsfile":{
-            "locked_version":"1.0.1"
-          }
-        }
-      }
-      """
 
   Scenario: With a cookbook that does not exist
-    Given the cookbook store has the cookbooks:
-      | berkshelf-cookbook-fixture | 0.1.0 |
-    Given I write to "Berksfile" with:
-      """
-      source "http://localhost:26210"
-
-      cookbook 'berkshelf-cookbook-fixture', '~> 0.1'
-      """
-    Given I write to "Berksfile.lock" with:
-      """
-      {
-        "dependencies":{
-          "berkshelf-cookbook-fixture":{
-            "locked_version":"0.1.0"
-          }
-        }
-      }
-      """
-    When I run `berks update non-existent-cookbook`
+    Given I have a Berksfile pointing at the local Berkshelf API
+    When I run `berks update not_real`
     Then the output should contain:
       """
-      Could not find cookbook(s) 'non-existent-cookbook' in any of the configured dependencies. Is it in your Berksfile?
+      Could not find cookbook(s) 'not_real' in any of the configured dependencies. Is it in your Berksfile?
       """
     And the exit status should be "DependencyNotFound"

--- a/features/vendor_command.feature
+++ b/features/vendor_command.feature
@@ -5,79 +5,52 @@ Feature: Vendoring cookbooks to a directory
 
   Background:
     Given the Berkshelf API server's cache is empty
-    And the Chef Server is empty
+    And the Chef Server has cookbooks:
+      | fake | 1.0.0 |
+      | ekaf | 2.0.0 |
+    And the Berkshelf API server's cache is up to date
 
   Scenario: successfully vendoring a Berksfile with multiple cookbook demands
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
-      cookbook 'berkshelf'
-      cookbook 'elixir'
+      cookbook 'fake'
+      cookbook 'ekaf'
       """
-    And the Chef Server has cookbooks:
-      | berkshelf | 1.0.0 |
-      | elixir    | 1.0.0 |
-    And the Berkshelf API server's cache is up to date
     When I successfully run `berks vendor cukebooks`
-    Then the output should contain:
-      """
-      Vendoring berkshelf (1.0.0) to
-      """
-    And the output should contain:
-      """
-      Vendoring elixir (1.0.0) to
-      """
-    And a directory named "cukebooks/berkshelf" should exist
-    And a directory named "cukebooks/elixir" should exist
-    And the directory "cukebooks/berkshelf" should contain version "1.0.0" of the "berkshelf" cookbook
-    And the directory "cukebooks/elixir" should contain version "1.0.0" of the "elixir" cookbook
+    Then the directory "cukebooks/fake" should contain version "1.0.0" of the "fake" cookbook
+    And the directory "cukebooks/ekaf" should contain version "2.0.0" of the "ekaf" cookbook
+
 
   Scenario: attempting to vendor when no Berksfile is present
     When I run `berks vendor cukebooks`
     Then the exit status should be "BerksfileNotFound"
 
-  Scenario: vendoring a Berksfile with a metadata demand
-    Given a cookbook named "sparkle-motion"
-    And the cookbook "sparkle-motion" has the file "Berksfile" with:
-      """
-      source "http://localhost:26210"
 
+  Scenario: vendoring a Berksfile with a metadata demand
+    Given a cookbook named "fake"
+    And I cd to "fake"
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
       metadata
       """
-    When I cd to "sparkle-motion"
-    And I successfully run `berks vendor cukebooks`
-    Then the output should contain:
-      """
-      Vendoring sparkle-motion (0.0.0) to
-      """
-    And a directory named "cukebooks/sparkle-motion" should exist
-    And the directory "cukebooks/sparkle-motion" should contain version "0.0.0" of the "sparkle-motion" cookbook
+    When I successfully run `berks vendor cukebooks`
+    And the directory "cukebooks/fake" should contain version "0.0.0" of the "fake" cookbook
+
 
   Scenario: vendoring without an explicit path to vendor into
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
-      cookbook 'berkshelf'
+      cookbook 'fake'
       """
-    And the Chef Server has cookbooks:
-      | berkshelf | 1.0.0 |
-    And the Berkshelf API server's cache is up to date
     When I successfully run `berks vendor`
-    And a directory named "berks-cookbooks/berkshelf" should exist
-    And the directory "berks-cookbooks/berkshelf" should contain version "1.0.0" of the "berkshelf" cookbook
+    And the directory "berks-cookbooks/fake" should contain version "1.0.0" of the "fake" cookbook
+
 
   Scenario: vendoring to a directory that already exists
-    Given I write to "Berksfile" with:
+    Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      source "http://localhost:26210"
-
-      cookbook 'berkshelf'
+      cookbook 'fake'
       """
-    And the Chef Server has cookbooks:
-      | berkshelf | 1.0.0 |
-    And the Berkshelf API server's cache is up to date
     And a directory named "cukebooks"
     When I run `berks vendor cukebooks`
     And the exit status should be "VendorError"


### PR DESCRIPTION
This PR attempts to standardize and reduce repetition in our cucumber tests by adding more step definitions for common tasks. It also removes the superfluous checks for exit status 0 when using `successfully` in aruba.

This also adds two new lockfile definitions, which make working with the JSON less impossible.
