### PR TITLE
Fail gracefully if README.md does not exist

### DIFF
--- a/generator_files/metadata.rb.erb
+++ b/generator_files/metadata.rb.erb
@@ -3,7 +3,7 @@ maintainer       '<%= maintainer %>'
 maintainer_email '<%= maintainer_email %>'
 license          '<%= license_name %>'
 description      'Installs/Configures <%= name %>'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md')) rescue description
 <% if options[:scmversion] -%>
 version          IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0.1.0'
 <% else -%>


### PR DESCRIPTION
In 2.0.7 and prior if README.md did not exist `berks install` would
fail with an error about being unable to find the Berksfile.
Since 956cf37 the error message is more clear, but we should still avoid
failing entirely.
