### PR TITLE
Add support for multiple chef servers

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -63,21 +63,17 @@ module Berkshelf
       super(path, options)
     end
 
-    attribute 'chef.chef_server_url',
-      type: String,
-      default: Berkshelf.chef_config.chef_server_url
-    attribute 'chef.validation_client_name',
-      type: String,
-      default: Berkshelf.chef_config.validation_client_name
-    attribute 'chef.validation_key_path',
-      type: String,
-      default: Berkshelf.chef_config.validation_key
-    attribute 'chef.client_key',
-      type: String,
-      default: Berkshelf.chef_config.client_key
-    attribute 'chef.node_name',
-      type: String,
-      default: Berkshelf.chef_config.node_name
+    attribute 'chef_servers',
+      type: Hash,
+      default: {
+        default: {
+          chef_server_url: Berkshelf.chef_config.chef_server_url,
+          validation_client_name: Berkshelf.chef_config.validation_client_name,
+          validation_key_path: Berkshelf.chef_config.validation_key,
+          client_key: Berkshelf.chef_config.client_key,
+          node_name: Berkshelf.chef_config.node_name
+        }
+      }
     attribute 'cookbook.copyright',
       type: String,
       default: Berkshelf.chef_config.cookbook_copyright
@@ -123,5 +119,32 @@ module Berkshelf
       type: Boolean,
       default: true,
       required: true
+
+    # @return [Hash]
+    def chef
+      chef_server(:default)
+    end
+
+    # @param [#to_sym] name
+    #
+    # @return [Hash]
+    def chef_server(name)
+      chef_servers[name.to_sym]
+    end
+
+    def whitelist_assign(new_attributes = {})
+      # @todo remove for Berkshelf 4.0
+      if chef_attributes = new_attributes.delete("chef")
+        Berkshelf.ui.deprecated "The Berkshelf configuration file now allows you to configure more than one Chef Server."
+        Berkshelf.ui.deprecated "See https://github.com/RiotGames/berkshelf/wiki/3.0-Config-file-changes for more details."
+        Berkshelf.ui.deprecated "Configuring a single Chef server will be deprecated in a future version of Berkshelf."
+        Berkshelf.ui.deprecated "Update your configuration file at '#{path}' to squelch this message."
+
+        new_attributes["chef_servers"] ||= Hash.new
+        new_attributes["chef_servers"]["default"] = chef_attributes
+      end
+
+      super(new_attributes)
+    end
   end
 end

--- a/spec/unit/berkshelf/config_spec.rb
+++ b/spec/unit/berkshelf/config_spec.rb
@@ -1,53 +1,101 @@
 require 'spec_helper'
 
 describe Berkshelf::Config do
-  describe '.file' do
-    context 'when the file does not exist' do
-      before { File.stub(:exists?).and_return(false) }
+  describe "ClassMethods" do
+    describe '::file' do
+      context 'when the file does not exist' do
+        before { File.stub(:exists?).and_return(false) }
 
-      it 'is nil' do
-        expect(Berkshelf::Config.file).to be_nil
+        it 'is nil' do
+          expect(Berkshelf::Config.file).to be_nil
+        end
       end
     end
-  end
 
-  describe '.instance' do
-    it 'should be a Berkshelf::Config' do
-      expect(Berkshelf::Config.instance).to be_an_instance_of(Berkshelf::Config)
-    end
-  end
-
-  describe '.path' do
-    it 'is a string' do
-      expect(Berkshelf::Config.path).to be_a(String)
+    describe '::instance' do
+      it 'should be a Berkshelf::Config' do
+        expect(Berkshelf::Config.instance).to be_an_instance_of(Berkshelf::Config)
+      end
     end
 
-    before do
-      File.stub(:exists?).and_return(false)
-    end
+    describe '::path' do
+      it 'is a string' do
+        expect(Berkshelf::Config.path).to be_a(String)
+      end
 
-    after do
-      Berkshelf::Config.instance_variable_set(:@path, nil)
-    end
-
-    context "when ENV['BERKSHELF_CONFIG'] is used" do
       before do
-        ENV.stub(:[]).with('BERKSHELF_CONFIG').and_return('/tmp/config.json')
-        File.stub(:exists?).with('/tmp/config.json').and_return(true)
+        File.stub(:exists?).and_return(false)
       end
 
-      it "points to a location within it" do
-        expect(Berkshelf::Config.path).to eq('/tmp/config.json')
+      after do
+        Berkshelf::Config.instance_variable_set(:@path, nil)
+      end
+
+      context "when ENV['BERKSHELF_CONFIG'] is used" do
+        before do
+          ENV.stub(:[]).with('BERKSHELF_CONFIG').and_return('/tmp/config.json')
+          File.stub(:exists?).with('/tmp/config.json').and_return(true)
+        end
+
+        it "points to a location within it" do
+          expect(Berkshelf::Config.path).to eq('/tmp/config.json')
+        end
+      end
+    end
+
+    describe "::set_path" do
+      subject(:set_path) { described_class.set_path("/tmp/other_path.json") }
+
+      it "sets the #instance to nil" do
+        set_path
+        expect(described_class.instance_variable_get(:@instance)).to be_nil
       end
     end
   end
 
-  describe "::set_path" do
-    subject(:set_path) { described_class.set_path("/tmp/other_path.json") }
+  describe "#chef_servers" do
+    it "returns a hash containing a default entry" do
+      expect(subject.chef_servers).to be_a(Hash)
+      expect(subject.chef_servers).to have(1).item
+      expect(subject.chef_servers).to have_key(:default)
+    end
+  end
 
-    it "sets the #instance to nil" do
-      set_path
-      expect(described_class.instance_variable_get(:@instance)).to be_nil
+  describe "#chef_server" do
+    it "returns the entry for the given name" do
+      expect(subject.chef_server(:default)).to be_a(Hash)
+    end
+
+    context "when the entry does not exist" do
+      it "returns nil" do
+        expect(subject.chef_server(:something_not_there)).to be_nil
+      end
+    end
+  end
+
+  describe "#chef" do
+    it "returns the default chef server entry" do
+      expect(subject.chef).to eq(subject.chef_server(:default))
+    end
+  end
+
+  context "loading an old style config" do
+    it "coerces the chef keys into the default chef server" do
+      json   = JSON.generate(chef: {
+        chef_server_url: "val1",
+        validation_client_name: "val2",
+        validation_key_path: "val3",
+        client_key: "val4",
+        node_name: "val5"
+      })
+      config         = described_class.from_json(json)
+      default_server = config.chef_servers[:default]
+
+      expect(default_server[:chef_server_url]).to eq("val1")
+      expect(default_server[:validation_client_name]).to eq("val2")
+      expect(default_server[:validation_key_path]).to eq("val3")
+      expect(default_server[:client_key]).to eq("val4")
+      expect(default_server[:node_name]).to eq("val5")
     end
   end
 end


### PR DESCRIPTION
Berkshelf users should be able to install and pull cookbooks from multiple Chef servers.

This could possibly be implemented with "from" and "to" semantics.

Use case:

berks install from corp-master
berks upload to laptop-local-chefserver
_multi-vm-vagrant-up_ _test_ _hack_ _hack_ _test_
berks upload to staging-organization
