### PR TITLE
Enable use of vagrant-omnibus plugin in generated vagrant files

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -6,15 +6,20 @@ Feature: Reading a Berkshelf configuration file
   Scenario: Missing a Berkshelf configuration file
     When I successfully run `berks cookbook sparkle_motion`
     Then the resulting "sparkle_motion" Vagrantfile should contain:
-      | config.vm.box = "Berkshelf-CentOS-6.3-x86_64-minimal" |
-      | config.vm.box_url = "https://dl.dropbox.com/u/31081437/Berkshelf-CentOS-6.3-x86_64-minimal.box" |
+      | config.omnibus.chef_version = :latest |
+      | config.vm.box = "opscode_ubuntu-12.04_provisionerless" |
+      | config.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box" |
     And the exit status should be 0
 
-  Scenario: Using a Berkshelf configuration file
+  Scenario: Using a Berkshelf configuration file that disables the vagrant-omnibus plugin
     Given I have a Berkshelf config file containing:
     """
     {
       "vagrant": {
+        "omnibus": {
+          "enabled": false,
+          "version": "11.4.4"
+        },
         "vm": {
           "box": "my_box",
           "box_url": "http://files.vagrantup.com/lucid64.box",
@@ -31,6 +36,73 @@ Feature: Reading a Berkshelf configuration file
     """
     When I successfully run `berks cookbook sparkle_motion`
     Then the resulting "sparkle_motion" Vagrantfile should contain:
+      | #config.omnibus.chef_version = :latest |
+      | config.vm.box = "my_box" |
+      | config.vm.box_url = "http://files.vagrantup.com/lucid64.box" |
+      | config.vm.network :forwarded_port, guest: 12345, host: 54321 |
+      | config.vm.network :private_network, ip: "12.34.56.78" |
+      | config.vm.network :public_network |
+    And the exit status should be 0
+
+  Scenario: Using a Berkshelf configuration file that sets the vagrant-omnibus plugin chef version
+    Given I have a Berkshelf config file containing:
+    """
+    {
+      "vagrant": {
+        "omnibus": {
+          "enabled": true,
+          "version": "11.4.4"
+        },
+        "vm": {
+          "box": "my_box",
+          "box_url": "http://files.vagrantup.com/lucid64.box",
+          "forward_port": {
+            "12345": "54321"
+          },
+          "network": {
+            "bridged": true,
+            "hostonly": "12.34.56.78"
+          }
+        }
+      }
+    }
+    """
+    When I successfully run `berks cookbook sparkle_motion`
+    Then the resulting "sparkle_motion" Vagrantfile should contain:
+      | config.omnibus.chef_version = "11.4.4" |
+      | config.vm.box = "my_box" |
+      | config.vm.box_url = "http://files.vagrantup.com/lucid64.box" |
+      | config.vm.network :forwarded_port, guest: 12345, host: 54321 |
+      | config.vm.network :private_network, ip: "12.34.56.78" |
+      | config.vm.network :public_network |
+    And the exit status should be 0
+
+  Scenario: Using a Berkshelf configuration file that sets the vagrant-omnibus plugin chef version to latest
+    Given I have a Berkshelf config file containing:
+    """
+    {
+      "vagrant": {
+        "omnibus": {
+          "enabled": true,
+          "version": "latest"
+        },
+        "vm": {
+          "box": "my_box",
+          "box_url": "http://files.vagrantup.com/lucid64.box",
+          "forward_port": {
+            "12345": "54321"
+          },
+          "network": {
+            "bridged": true,
+            "hostonly": "12.34.56.78"
+          }
+        }
+      }
+    }
+    """
+    When I successfully run `berks cookbook sparkle_motion`
+    Then the resulting "sparkle_motion" Vagrantfile should contain:
+      | config.omnibus.chef_version = :latest |
       | config.vm.box = "my_box" |
       | config.vm.box_url = "http://files.vagrantup.com/lucid64.box" |
       | config.vm.network :forwarded_port, guest: 12345, host: 54321 |

--- a/features/configure_command.feature
+++ b/features/configure_command.feature
@@ -49,8 +49,10 @@ Feature: Configuring Berkshelf via the command line
       | chef.validation_client_name | chef-validator                      |
       | chef.client_key             | /etc/chef/client.pem                |
       | chef.validation_key_path    | /etc/chef/validation.pem            |
-      | vagrant.vm.box              | Berkshelf-CentOS-6.3-x86_64-minimal |
-      | vagrant.vm.box_url          | https://dl.dropbox.com/u/31081437/Berkshelf-CentOS-6.3-x86_64-minimal.box |
+      | vagrant.vm.box              | opscode_ubuntu-12.04_provisionerless |
+      | vagrant.vm.box_url          | https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box |
+      | vagrant.omnibus.enabled     | BOOLEAN[true] |
+      | vagrant.omnibus.version     | latest |
     And the exit status should be 0
 
   Scenario: Creating a Berkshelf configuration file when one already exists

--- a/features/step_definitions/config_steps.rb
+++ b/features/step_definitions/config_steps.rb
@@ -27,6 +27,9 @@ Then /^a Berkshelf config file should exist and contain:$/ do |table|
   check_file_presence([Berkshelf.config.path], true)
 
   table.raw.each do |key, value|
+    if value == "BOOLEAN[true]"
+      value = true
+    end
     expect(Berkshelf.config[key]).to eq(value)
   end
 end

--- a/generator_files/Vagrantfile.erb
+++ b/generator_files/Vagrantfile.erb
@@ -8,6 +8,17 @@ Vagrant.configure("2") do |config|
 
   config.vm.hostname = "<%= "#{cookbook_name.gsub('_','-')}-berkshelf" %>"
 
+  # Set the version of chef to install using the vagrant-omnibus plugin
+<% if berkshelf_config.vagrant.omnibus.enabled -%>
+<% if berkshelf_config.vagrant.omnibus.version == "latest" -%>
+  config.omnibus.chef_version = :latest
+<% else %>
+  config.omnibus.chef_version = "<%= berkshelf_config.vagrant.omnibus.version %>"
+<% end -%>
+<% else %>
+  #config.omnibus.chef_version = :latest
+<% end -%>
+
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "<%= berkshelf_config.vagrant.vm.box %>"
 

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -95,11 +95,11 @@ module Berkshelf
       default: false
     attribute 'vagrant.vm.box',
       type: String,
-      default: 'Berkshelf-CentOS-6.3-x86_64-minimal',
+      default: 'opscode_ubuntu-12.04_provisionerless',
       required: true
     attribute 'vagrant.vm.box_url',
       type: String,
-      default: 'https://dl.dropbox.com/u/31081437/Berkshelf-CentOS-6.3-x86_64-minimal.box',
+      default: 'https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box',
       required: true
     attribute 'vagrant.vm.forward_port',
       type: Hash,
@@ -113,6 +113,12 @@ module Berkshelf
     attribute 'vagrant.vm.provision',
       type: String,
       default: 'chef_solo'
+    attribute 'vagrant.omnibus.enabled',
+      type: Boolean,
+      default: true
+    attribute 'vagrant.omnibus.version',
+      type: String,
+      default: 'latest'
     attribute 'ssl.verify',
       type: Boolean,
       default: true,

--- a/spec/unit/berkshelf/init_generator_spec.rb
+++ b/spec/unit/berkshelf/init_generator_spec.rb
@@ -25,6 +25,9 @@ describe Berkshelf::InitGenerator do
         end
         file 'Vagrantfile' do
           contains 'recipe[some_cookbook::default]'
+          contains ' config.omnibus.chef_version = :latest'
+          contains 'config.vm.box = "opscode_ubuntu-12.04_provisionerless"'
+          contains 'config.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box"'
         end
         no_file 'chefignore'
       }
@@ -160,6 +163,59 @@ describe Berkshelf::InitGenerator do
     it 'does not have a Vagrantfile' do
       expect(target).to have_structure {
         no_file 'Vagrantfile'
+      }
+    end
+  end
+
+  context "given the 'vagrant.omnibus.enabled' option set to false" do
+    before do
+      Berkshelf::Config.instance.vagrant.omnibus.enabled = false
+      capture(:stdout) {
+        Berkshelf::InitGenerator.new([target]).invoke_all
+      }
+    end
+
+    it "generates a Vagrantfile without the 'config.omnibus.chef_version' value set" do
+      expect(target).to have_structure {
+        file 'Vagrantfile' do
+          contains "#config.omnibus.chef_version"
+        end
+      }
+    end
+  end
+
+  context "given the 'vagrant.omnibus.version' option set" do
+    before do
+      Berkshelf::Config.instance.vagrant.omnibus.enabled = true
+      Berkshelf::Config.instance.vagrant.omnibus.version = "11.4.4"
+      capture(:stdout) {
+        Berkshelf::InitGenerator.new([target]).invoke_all
+      }
+    end
+
+    it "generates a Vagrantfile with the 'config.omnibus.chef_version' value set" do
+      expect(target).to have_structure {
+        file 'Vagrantfile' do
+          contains " config.omnibus.chef_version = \"11.4.4\""
+        end
+      }
+    end
+  end
+
+  context "given the 'vagrant.omnibus.version' option set to 'latest'" do
+    before do
+      Berkshelf::Config.instance.vagrant.omnibus.enabled = true
+      Berkshelf::Config.instance.vagrant.omnibus.version = "latest"
+      capture(:stdout) {
+        Berkshelf::InitGenerator.new([target]).invoke_all
+      }
+    end
+
+    it "generates a Vagrantfile with the 'config.omnibus.chef_version' value set to :latest" do
+      expect(target).to have_structure {
+        file 'Vagrantfile' do
+          contains " config.omnibus.chef_version = :latest"
+        end
       }
     end
   end


### PR DESCRIPTION
Opscode no longer provide base boxes with chef preinstalled and instead recommend the use of the `vagrant-omnibus` plugin to specify the chef version to install.

These changes allow a chef version to be specified in the berkshelf config so that it can be set by default in generated cookbooks.

As a bonus I have added a cookbook and vagrant file to the project in a separate commit so that vagrant can be used for development of berkshelf.
