### PR TITLE
`berks init` should raise a friendly error if the current directory does not contain a cookbook

### DIFF
--- a/features/init_command.feature
+++ b/features/init_command.feature
@@ -14,25 +14,18 @@ Feature: initialize command
       metadata
       """
     And the output should contain "Successfully initialized"
-    And the exit status should be 0
 
   Scenario: initializing a path that does not contain a cookbook
     Given a directory named "not_a_cookbook"
-    When I successfully run `berks init not_a_cookbook`
-    Then the directory "not_a_cookbook" should have the following files:
-      | Berksfile |
-    And the directory "not_a_cookbook" should not have the following files:
-      | chefignore |
-    And the file "Berksfile" in the directory "not_a_cookbook" should not contain:
-      """
-      metadata
-      """
-    And the output should contain "Successfully initialized"
-    And the exit status should be 0
+    When I run `berks init not_a_cookbook`
+    And the exit status should be "NotACookbook"
 
   Scenario: initializing with no value given for target
+    Given I write to "metadata.rb" with:
+      """
+      name 'sparkle_motion'
+      """
     When I successfully run `berks init`
     Then the output should contain "Successfully initialized"
     And a file named "Berksfile" should exist
-    And a file named "chefignore" should not exist
-    And the exit status should be 0
+    And a file named "chefignore" should exist

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -308,11 +308,6 @@ module Berkshelf
       Berkshelf.formatter.deprecation '--git is now the default' if options[:git]
       Berkshelf.formatter.deprecation '--vagrant is now the default' if options[:vagrant]
 
-      if File.chef_cookbook?(path)
-        options[:chefignore]     = true
-        options[:metadata_entry] = true
-      end
-
       Berkshelf::InitGenerator.new([path], options).invoke_all
 
       Berkshelf.formatter.msg 'Successfully initialized'

--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -475,4 +475,18 @@ module Berkshelf
   class DuplicateDemand < BerkshelfError; status_code(138); end
   class VendorError < BerkshelfError; status_code(139); end
   class LockfileNotFound < BerkshelfError; status_code(140); end
+
+  class NotACookbook < BerkshelfError
+    status_code(141)
+
+    # @param [String] path
+    #   the path to the thing that is not a cookbook
+    def initialize(path)
+      @path = File.expand_path(path) rescue path
+    end
+
+    def to_s
+      "#{@path} does not appear to be a valid cookbook. Does it have a `metadata.rb`?"
+    end
+  end
 end

--- a/lib/berkshelf/init_generator.rb
+++ b/lib/berkshelf/init_generator.rb
@@ -13,11 +13,11 @@ module Berkshelf
 
     class_option :metadata_entry,
       type: :boolean,
-      default: false
+      default: true
 
     class_option :chefignore,
       type: :boolean,
-      default: false
+      default: true
 
     class_option :skip_vagrant,
       type: :boolean,
@@ -59,6 +59,7 @@ module Berkshelf
     end
 
     def generate
+      validate_cookbook
       validate_configuration
       check_option_support
 
@@ -126,6 +127,19 @@ module Berkshelf
           metadata.name.empty? ? File.basename(target) : metadata.name
         rescue CookbookNotFound, IOError
           File.basename(target)
+        end
+      end
+
+      # Assert the current working directory is a cookbook
+      #
+      # @raise [NotACookbook] if the current working directory is
+      #   not a cookbook
+      #
+      # @return [nil]
+      def validate_cookbook
+        path = File.expand_path(File.join(target, 'metadata.rb'))
+        unless File.exists?(path)
+          raise Berkshelf::NotACookbook.new(path)
         end
       end
 


### PR DESCRIPTION
`berks init` should raise a friendly error message if the current working directory does not contain a cookbook

See #816 for details
