### PR TITLE
If there is a locked_version, check the CookbookStore directly

### DIFF
--- a/features/resolver.feature
+++ b/features/resolver.feature
@@ -20,17 +20,8 @@ Feature: resolve cookbooks
     When I successfully run `berks install`
     Then the output should contain:
       """
-      Attempting to use berkshelf-2.0.0
-      Found Solution
-      {"berkshelf"=>"2.0.0"}
       Attempting to find a solution
-      Adding constraint berkshelf = 2.0.0 from root
-      Resetting possible values for berkshelf
-      Possible values are Searching for a value for berkshelf
-      Constraints are = 2.0.0
-      Possible values are ["berkshelf", []]
-      Could not find an acceptable value for berkshelf
-      Cannot backtrack any further
+      Adding constraint berkshelf >= 0.0.0 from root
       """
 
   Scenario: without DEBUG_RESOLVER

--- a/lib/berkshelf/dependency.rb
+++ b/lib/berkshelf/dependency.rb
@@ -141,7 +141,11 @@ module Berkshelf
       @cached_cookbook ||= if location
         location.download
       else
-        Berkshelf::CookbookStore.instance.satisfy(name, Solve::Constraint.new(locked_version.to_s))
+        if locked_version
+          CookbookStore.instance.cookbook(name, locked_version)
+        else
+          Berkshelf::CookbookStore.instance.satisfy(name, version_constraint)
+        end
       end
     end
 


### PR DESCRIPTION
This causes a dramatic speed improvement for already-downloaded dependencies and ensure the proper cookbook version is actually used.
