### PR TITLE
'berks list' does an implicit 'install'

### DIFF
--- a/features/commands/list.feature
+++ b/features/commands/list.feature
@@ -3,11 +3,14 @@ Feature: berks list
     Given the cookbook store has the cookbooks:
       | fake1 | 1.0.0 |
       | fake2 | 1.0.1 |
-    Given I have a Berksfile pointing at the local Berkshelf API with:
+    And I have a Berksfile pointing at the local Berkshelf API with:
       """
       cookbook 'fake1', '1.0.0'
       cookbook 'fake2', '1.0.1'
       """
+    And the Lockfile has:
+      | fake1 | 1.0.0 |
+      | fake2 | 1.0.1 |
     When I successfully run `berks list`
     Then the output should contain:
       """
@@ -17,7 +20,37 @@ Feature: berks list
       """
 
 
-  Scenario: Running the list command with no sources defined
+  Scenario: Running the list command when the dependencies aren't downloaded
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'fake', '1.0.0'
+      """
+    And the Lockfile has:
+      | fake | 1.0.0 |
+    When I run `berks list`
+    Then the output should contain:
+      """
+      Could not find cookbook 'fake (1.0.0)'.
+      """
+    And the exit status should be "CookbookNotFound"
+
+
+  Scenario: Running the list command when the lockfile isn't present
+    Given the cookbook store has the cookbooks:
+      | fake | 1.0.0 |
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'fake', '1.0.0'
+      """
+    When I run `berks list`
+    Then the output should contain:
+      """
+      Could not find cookbook 'fake (= 1.0.0)'.
+      """
+    And the exit status should be "CookbookNotFound"
+
+
+  Scenario: Running the list command with no dependencies defined
     Given I have a Berksfile pointing at the local Berkshelf API
     When I successfully run `berks list`
     Then the output should contain:

--- a/features/commands/outdated.feature
+++ b/features/commands/outdated.feature
@@ -70,9 +70,9 @@ Feature: berks outdated
     When I run `berks outdated`
     Then the output should contain:
       """
-      Could not find cookbook 'bacon (>= 0.0.0)'. Try running `berks install` to download and install the missing dependencies.
+      Could not find cookbook 'bacon (= 1.0.0)'. Try running `berks install` to download and install the missing dependencies.
       """
-    And the exit status should be "LockfileNotFound"
+    And the exit status should be "CookbookNotFound"
 
 
   Scenario: When the cookbook is not installed
@@ -85,6 +85,6 @@ Feature: berks outdated
     When I run `berks outdated`
     Then the output should contain:
       """
-      Could not find cookbook 'bacon (= 1.0.0)'. Try running `berks install` to download and install the missing dependencies.
+      Could not find cookbook 'bacon (1.0.0)'. Try running `berks install` to download and install the missing dependencies.
       """
     And the exit status should be "CookbookNotFound"

--- a/features/commands/show.feature
+++ b/features/commands/show.feature
@@ -38,9 +38,9 @@ Feature: berks show
     When I run `berks show fake`
     Then the output should contain:
       """
-      Could not find cookbook 'fake (>= 0.0.0)'. Try running `berks install` to download and install the missing dependencies.
+      Could not find cookbook 'fake (= 1.0.0)'. Try running `berks install` to download and install the missing dependencies.
       """
-    And the exit status should be "LockfileNotFound"
+    And the exit status should be "CookbookNotFound"
 
 
   Scenario: When the cookbook is not installed
@@ -54,6 +54,6 @@ Feature: berks show
     When I run `berks show fake`
     Then the output should contain:
       """
-      Could not find cookbook 'fake (= 1.0.0)'. Try running `berks install` to download and install the missing dependencies.
+      Could not find cookbook 'fake (1.0.0)'. Try running `berks install` to download and install the missing dependencies.
       """
     And the exit status should be "CookbookNotFound"

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -321,15 +321,8 @@ module Berkshelf
       banner: 'PATH'
     desc 'list', 'List all cookbooks and their dependencies specified by your Berksfile'
     def list
-      berksfile    = Berksfile.from_file(options[:berksfile])
-      dependencies = Berkshelf.ui.mute { berksfile.install }.sort
-
-      if dependencies.empty?
-        Berkshelf.formatter.msg 'There are no cookbooks installed by your Berksfile'
-      else
-        Berkshelf.formatter.msg 'Cookbooks installed by your Berksfile:'
-        print_list(dependencies)
-      end
+      berksfile = Berksfile.from_file(options[:berksfile])
+      Berkshelf.formatter.list(berksfile.list)
     end
 
     method_option :berksfile,
@@ -341,7 +334,7 @@ module Berkshelf
     desc "show [COOKBOOK]", "Display name, author, copyright, and dependency information about a cookbook"
     def show(name)
       berksfile = Berksfile.from_file(options[:berksfile])
-      cookbook = berksfile.retrieve_locked(name)
+      cookbook = berksfile.retrieve_locked(berksfile.find!(name))
       Berkshelf.formatter.show(cookbook)
     end
 

--- a/lib/berkshelf/dependency.rb
+++ b/lib/berkshelf/dependency.rb
@@ -203,8 +203,12 @@ module Berkshelf
       SCM_LOCATIONS.include?(location.class.location_key)
     end
 
+    def <=>(other)
+      [self.name, self.version_constraint] <=> [other.name, other.version_constraint]
+    end
+
     def to_s
-      "#{name} (#{version_constraint})"
+      "#{name} (#{locked_version || version_constraint})"
     end
 
     def inspect

--- a/lib/berkshelf/formatters.rb
+++ b/lib/berkshelf/formatters.rb
@@ -82,6 +82,7 @@ module Berkshelf
       formatter_methods :error,
                         :fetch,
                         :install,
+                        :list,
                         :msg,
                         :outdated,
                         :package,

--- a/lib/berkshelf/formatters/human_readable.rb
+++ b/lib/berkshelf/formatters/human_readable.rb
@@ -77,6 +77,20 @@ module Berkshelf
         Berkshelf.ui.info "Cookbook(s) packaged to #{destination}!"
       end
 
+      # Output a list of cookbooks using {Berkshelf.ui}
+      #
+      # @param [Hash<Dependency, CachedCookbook>] list
+      def list(list)
+        if list.empty?
+          Berkshelf.ui.info "There are no cookbooks installed by your Berksfile"
+        else
+          Berkshelf.ui.info "Cookbooks installed by your Berksfile:"
+          list.each do |dependency, cookbook|
+            Berkshelf.ui.info("  * #{cookbook.cookbook_name} (#{cookbook.version})")
+          end
+        end
+      end
+
       # Output Cookbook info message using {Berkshelf.ui}
       #
       # @param [CachedCookbook] cookbook

--- a/lib/berkshelf/formatters/json.rb
+++ b/lib/berkshelf/formatters/json.rb
@@ -115,6 +115,19 @@ module Berkshelf
         cookbooks[cookbook][:destination] = destination
       end
 
+      # Output a list of cookbooks to delayed output
+      #
+      # @param [Hash<Dependency, CachedCookbook>] list
+      def list(list)
+        list.each do |dependency, cookbook|
+          cookbooks[cookbook.cookbook_name] ||= {}
+          cookbooks[cookbook.cookbook_name][:version] = cookbook.version
+          if dependency.location
+            cookbooks[cookbook.cookbook_name][:location] = dependency.location
+          end
+        end
+      end
+
       # Output Cookbook info entry to delayed output
       #
       # @param [CachedCookbook] cookbook

--- a/lib/berkshelf/locations/path_location.rb
+++ b/lib/berkshelf/locations/path_location.rb
@@ -1,24 +1,5 @@
 module Berkshelf
   class PathLocation < Location::Base
-    class << self
-      # Expand and return a string representation of the given path if it is
-      # absolute or a path in the users home directory.
-      #
-      # Returns the given relative path otherwise.
-      #
-      # @param [#to_s] path
-      #
-      # @return [String]
-      def normalize_path(path)
-        path = path.to_s
-        if (path[0] == '~') || Pathname.new(path).absolute?
-          File.expand_path(path)
-        else
-          path
-        end
-      end
-    end
-
     set_location_key :path
     set_valid_options :path, :metadata
 

--- a/spec/unit/berkshelf/berksfile_spec.rb
+++ b/spec/unit/berkshelf/berksfile_spec.rb
@@ -333,30 +333,25 @@ describe Berkshelf::Berksfile do
 
   describe '#retrieve_locked' do
     let(:lockfile) { double('lockfile', find: locked) }
+    let(:dependency) { double('dependency', name: 'bacon') }
     let(:locked) { double('locked', cached_cookbook: cached, locked_version: '1.0.0') }
     let(:cached) { double('cached') }
 
     before do
-      subject.stub(:validate_cookbook_names!)
       subject.stub(:lockfile).and_return(lockfile)
     end
 
-    it 'validates cookbook names' do
-      expect(subject).to receive(:validate_cookbook_names!).once
-      subject.retrieve_locked('bacon')
-    end
-
-    it 'raises an error when the lockfile does not exist' do
+    it 'raises an error when the lockfile does not have the source' do
       lockfile.stub(:find)
       expect {
-        subject.retrieve_locked('bacon')
-      }.to raise_error(Berkshelf::LockfileNotFound)
+        subject.retrieve_locked(dependency)
+      }.to raise_error(Berkshelf::CookbookNotFound)
     end
 
     it 'raises an error when the cookbook is not downloaded' do
-      locked.stub(:cached_cookbook)
+      locked.stub(:downloaded?).and_return(false)
       expect {
-        subject.retrieve_locked('bacon')
+        subject.retrieve_locked(dependency)
       }.to raise_error(Berkshelf::CookbookNotFound)
     end
   end


### PR DESCRIPTION
New to Berkshelf and playing the game of "where's my cookbook" I discovered that running 'berks list' inside a cookbook directory runs an implicit 'berks install'  Is that the  expected behavior?    I would expect the 'list' call to return empty until 'berks install' is explicitly run on the cookbook.

```
mymac:cookbooks$ berks shelf list
There are no cookbooks in the Berkshelf shelf


# go into wrapper cookbook directory and see what's in the berkshelf
mymac:cookbooks$ cd wrapper_cookbook
mymac:wrapper_cookbook$ berks list
Cookbooks installed by your Berksfile:
  * wrapper_cookbook (0.1.0)
  * logrotate (1.3.0)

# look at what is 'installed' on my berkshelf 
mymac:wrapper_cookbook$ ls ~/.berkshelf/cookbooks/
logrotate-1.3.0


#check the shelf
mymac:wrapper_cookbook$ berks shelf list
Cookbooks in the Berkshelf shelf:
  * logrotate (1.3.0)


#leave wrapper_cookbook and look at shelf.
mymac:wrapper_cookbook$ cd ..
mymac:cookbooks$ berks shelf list
Cookbooks in the Berkshelf shelf:
  * logrotate (1.3.0)

```
