### PR TITLE
Add cucumber test for helpful constraint error message

### DIFF
--- a/features/commands/install.feature
+++ b/features/commands/install.feature
@@ -41,6 +41,28 @@ Feature: berks install
       | berkshelf | 1.0.0 |
 
 
+  Scenario: installing an explicit version demand that cannot be solved
+    Given the cookbook store contains a cookbook "fake" "1.0.0" with dependencies:
+      | unsatisfiable | < 1.0.0 |
+    And the cookbook store contains a cookbook "ekaf" "1.0.0" with dependencies:
+      | unsatisfiable | > 1.0.0 |
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'fake', '1.0.0'
+      """
+    And the Berkshelf API server's cache is up to date
+    When I run `berks install`
+    Then the output should contain:
+      """
+      Berkshelf could not find compatible versions for cookbook "unsatisfiable":
+        fake depends on
+          unsatisfiable (< 1.0.0)
+
+        ekaf depends on
+          ekaf (> 1.0.0)
+      """
+
+
   Scenario: installing demands from all groups
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """


### PR DESCRIPTION
Right now, the error message that comes back when a solution cannot be found is not very helpful. It includes the entire demands graph instead of the "unresolvable" things. 

``` text
Unable to find a solution for demands: [#<Berkshelf::Dependency: apt (= 2.1.1), locked_version: #<Solve::Version 2.1.1>, groups: [:default], location: default>, #<Berkshelf::Dependency: build-essential (= 1.4.2), locked_version: #<Solve::Version 1.4.2>, groups: [:default], location: default>, #<Berkshelf::Dependency: chef-client (= 3.0.4), locked_version: #<Solve::Version 3.0.4>, groups: [:default], location: default>, #<Berkshelf::Dependency: dynect (= 1.0.4), locked_version: #<Solve::Version 1.0.4>, groups: [:default], location: default>, #...]
```

Here's a cucumber test for what I think the response should look like. This may actually be further down the stack in Solve, but I'm not super familiar with that codebase.

/cc @andrewGarson 
