### PR TITLE
removed config.ssh.max_tries settings from Vargrantfile Template cause backwards incompatibility

### DIFF
--- a/generator_files/Vagrantfile.erb
+++ b/generator_files/Vagrantfile.erb
@@ -75,12 +75,7 @@ Vagrant.configure("2") do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
-<% if berkshelf_config.vagrant.version == "1.3.x" -%>
     config.vm.boot_timeout = 120
-<% else -%>
-    config.ssh.max_tries = 40
-    config.ssh.timeout   = 120
-<% end -%>
 
   # The path to the Berksfile to use with Vagrant Berkshelf
   # config.berkshelf.berksfile_path = "./Berksfile"

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -93,10 +93,6 @@ module Berkshelf
     attribute 'raise_license_exception',
       type: Boolean,
       default: false
-    attribute 'vagrant.version',
-      type: String,
-      default: '1.3.x',
-      required: true
     attribute 'vagrant.vm.box',
       type: String,
       default: 'opscode_ubuntu-12.04_provisionerless',


### PR DESCRIPTION
Vagrant 1.3.4 throws an error if they exists:

There are errors in the configuration of this machine. Please fix
the following errors and try again:

SSH:
- The following settings shouldn't exist: max_tries, timeout
