### PR TITLE
Workaround issue where Cygwin Git will create a directory called C: in

### DIFF
--- a/lib/berkshelf/git.rb
+++ b/lib/berkshelf/git.rb
@@ -41,6 +41,10 @@ module Berkshelf
       # @return [String]
       #   the destination the URI was cloned to
       def clone(uri, destination = Dir.mktmpdir)
+        if File::ALT_SEPARATOR
+          destination = destination.to_s.gsub(File::SEPARATOR, File::ALT_SEPARATOR)
+        end
+
         git('clone', uri, destination.to_s)
 
         destination


### PR DESCRIPTION
the current directory when using berkshelf through vagrant.

This is for #784.
