### PR TITLE
Address issue #845: Raise a helpful error if github location ends in .git

### DIFF
--- a/features/commands/install.feature
+++ b/features/commands/install.feature
@@ -243,6 +243,19 @@ Feature: berks install
       """
 
 
+  Scenario: installing a Berksfile that contains a GitHub location ending in .git
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook "berkshelf-cookbook-fixture", github: "RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
+      """
+    When I run `berks install`
+    Then the output should contain:
+      """
+      'RiotGames/berkshelf-cookbook-fixture.git' is not a valid GitHub identifier - should not end in '.git'
+      """
+    And the exit status should be "InvalidGitHubIdentifier"
+
+
   Scenario Outline: installing a Berksfile that contains a Github location and specific protocol
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """

--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -144,6 +144,19 @@ module Berkshelf
     end
   end
 
+  class InvalidGitHubIdentifier < BerkshelfError
+    status_code(110)
+
+    # @param [String] repo_identifier
+    def initialize(repo_identifier)
+      @repo_identifier = repo_identifier
+    end
+
+    def to_s
+      "'#{@repo_identifier}' is not a valid GitHub identifier - should not end in '.git'"
+    end
+  end
+
   class UnknownGitHubProtocol < BerkshelfError
     status_code(110)
 

--- a/lib/berkshelf/locations/github_location.rb
+++ b/lib/berkshelf/locations/github_location.rb
@@ -19,6 +19,9 @@ module Berkshelf
     #   the protocol with which to communicate with GitHub
     def initialize(dependency, options = {})
       @repo_identifier = options.delete(:github)
+      if repo_identifier.end_with?(".git")
+        raise InvalidGitHubIdentifier.new(repo_identifier)
+      end
       @protocol        = (options.delete(:protocol) || DEFAULT_PROTOCOL).to_sym
       options[:git]    = github_url
       super


### PR DESCRIPTION
To address issue #845, this change raises a helpful exception message if the identifier provided to a `github` location ends in ".git".  A test is included.
