### PR TITLE
Issue #882: change skip messages to say "frozen"

### DIFF
--- a/features/commands/upload.feature
+++ b/features/commands/upload.feature
@@ -168,11 +168,11 @@ Feature: berks upload
     When I successfully run `berks upload`
     Then the output should contain:
       """
-      Skipping fake (1.0.0) (already uploaded)
+      Skipping fake (1.0.0) (frozen)
       """
     And the output should contain:
       """
-      Skipped uploading some cookbooks because they already existed on the remote server. Re-run with the `--force` flag to force overwrite these cookbooks:
+      Skipped uploading some cookbooks because they already exist on the remote server and are frozen. Re-run with the `--force` flag to force overwrite these cookbooks:
 
         * fake (1.0.0)
       """
@@ -190,8 +190,8 @@ Feature: berks upload
     When I successfully run `berks upload`
     Then the output should contain:
       """
-      Skipping fake (0.0.0) (already uploaded)
-      Skipped uploading some cookbooks because they already existed on the remote server. Re-run with the `--force` flag to force overwrite these cookbooks:
+      Skipping fake (0.0.0) (frozen)
+      Skipped uploading some cookbooks because they already exist on the remote server and are frozen. Re-run with the `--force` flag to force overwrite these cookbooks:
 
         * fake (0.0.0)
       """

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -683,7 +683,7 @@ module Berkshelf
 
         unless @skipped.empty?
           Berkshelf.formatter.msg "Skipped uploading some cookbooks because they" <<
-            " already existed on the remote server. Re-run with the `--force`" <<
+            " already exist on the remote server and are frozen. Re-run with the `--force`" <<
             " flag to force overwrite these cookbooks:" <<
             "\n\n" <<
             "  * " << @skipped.map { |c| "#{c.cookbook_name} (#{c.version})" }.join("\n  * ")

--- a/lib/berkshelf/formatters/human_readable.rb
+++ b/lib/berkshelf/formatters/human_readable.rb
@@ -57,7 +57,7 @@ module Berkshelf
       # @param [Berkshelf::CachedCookbook] cookbook
       # @param [Ridley::Connection] conn
       def skip(cookbook, conn)
-        Berkshelf.ui.info "Skipping #{cookbook.cookbook_name} (#{cookbook.version}) (already uploaded)"
+        Berkshelf.ui.info "Skipping #{cookbook.cookbook_name} (#{cookbook.version}) (frozen)"
       end
 
       # Output a list of outdated cookbooks and the most recent version


### PR DESCRIPTION
This addresses issue #882 by changing the skip messages to reference the fact that the cookbooks are frozen.
