### PR TITLE
Allow archive redirects from http:// to https://

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'buff-shell_out',    '~> 0.1'
   s.add_dependency 'faraday',           '>= 0.8.5'
   s.add_dependency 'hashie',            '>= 2.0.2'
+  s.add_dependency 'httpclient',        '>= 2.3.4'
   s.add_dependency 'minitar',           '~> 0.5.4'
   s.add_dependency 'retryable',         '~> 1.3.3'
   s.add_dependency 'ridley',            '~> 1.6'


### PR DESCRIPTION
In case a community compatible cookbook server is deployed without SSL
encryption (internal network), redirects from http:// to https:// can
happen which are not allowed by open-uri.

This change uses httpclient library instead which provides the same
functionality without the redirect limitation.
