### PR TITLE
Support for update_lockfile command line option

### DIFF
--- a/features/lockfile.feature
+++ b/features/lockfile.feature
@@ -272,3 +272,24 @@ Feature: Creating and reading the Berkshelf lockfile
       Error reading the Berkshelf lockfile `Berksfile.lock` (JSON::ParserError)
       """
     And the exit status should be "LockfileParserError"
+
+
+  Scenario: Installing with a cookbook in the excluding group and with the update_lockfile to false doesn't update lockfile
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'fake', '1.0.0'
+
+      group :wadus do
+        cookbook 'wadus', '1.0.0'
+      end
+      """
+    Given the cookbook store has the cookbooks:
+      | fake | 1.0.0 |
+      | wadus | 1.0.0 |
+    Given the Lockfile has:
+      | fake | 1.0.0 |
+      | wadus | 1.0.0 |
+    When I successfully run `berks install -e wadus -l false`
+    Then the Lockfile should have:
+      | fake | 1.0.0 |
+      | wadus | 1.0.0 |

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -180,6 +180,10 @@ module Berkshelf
       desc: 'Path to install cookbooks to (i.e. vendor/cookbooks).',
       aliases: '-p',
       banner: 'PATH'
+    method_option :update_lockfile,
+      type: :boolean,
+      desc: 'Avoid updating lockfile',
+      aliases: '-l'
     desc 'install', 'Install the cookbooks specified in the Berksfile'
     def install
       berksfile = Berkshelf::Berksfile.from_file(options[:berksfile])

--- a/lib/berkshelf/installer.rb
+++ b/lib/berkshelf/installer.rb
@@ -56,7 +56,7 @@ module Berkshelf
       end
 
       verify_licenses!(lock_deps)
-      lockfile.update(lock_deps)
+      lockfile.update(lock_deps) unless options[:update_lockfile] == false
       cached_cookbooks
     end
 


### PR DESCRIPTION
This PR supports the update_lockfile command line option to avoid lockfile updating. This is useful when installing and excluding some groups for installing them.
