### PR TITLE
Removed Outdated Vagrant configuration

### DIFF
--- a/generator_files/Vagrantfile.erb
+++ b/generator_files/Vagrantfile.erb
@@ -73,9 +73,6 @@ Vagrant.configure("2") do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
-
   # The path to the Berksfile to use with Vagrant Berkshelf
   # config.berkshelf.berksfile_path = "./Berksfile"
 


### PR DESCRIPTION
The Vagrantfile has errors causing the VM not to start with the below
error

SSH:
- The following settings shouldn't exist: max_tries, timeout

I removed the below:

  config.ssh.max_tries = 40
  config.ssh.timeout   = 120
