### PR TITLE
removing Gemfile.lock from gitignore

### DIFF
--- a/generator_files/gitignore.erb
+++ b/generator_files/gitignore.erb
@@ -9,7 +9,6 @@ Berksfile.lock
 /cookbooks
 
 # Bundler
-Gemfile.lock
 bin/*
 .bundle/*
 


### PR DESCRIPTION
according to http://bundler.io/rationale.html

Gemfile.lock **MUST** be committed.
