### PR TITLE
For issue #883: make --halt-on-frozen apply only to top-level cookbooks

### DIFF
--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -195,7 +195,8 @@ module Berkshelf
     method_option :halt_on_frozen,
       type: :boolean,
       default: false,
-      desc: 'Halt uploading and exit if the Chef Server has a frozen version of the cookbook(s).'
+      desc: 'Halt uploading and exit if a given cookbook is found frozen on the Chef Server, '\
+            'or if any cookbook is frozen if none are given.'
     desc 'upload [COOKBOOKS]', 'Upload the cookbook specified in the Berksfile to the Chef Server'
     def upload(*cookbook_names)
       berksfile = Berkshelf::Berksfile.from_file(options[:berksfile])


### PR DESCRIPTION
This is a draft patch without tests for discussion purposes and to get the ball rolling (for issue #883).
