### PR TITLE
Fix for tests on Windows

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -4,19 +4,25 @@ guard 'spork' do
   watch(%r{^features/support/}) { :cucumber }
 end
 
-guard 'yard', stdout: '/dev/null', stderr: '/dev/null' do
-  watch(%r{app/.+\.rb})
-  watch(%r{lib/.+\.rb})
-  watch(%r{ext/.+\.c})
+unless RUBY_PLATFORM =~ /mswin|mingw|windows/
+  guard 'yard', stdout: '/dev/null', stderr: '/dev/null' do
+    watch(%r{app/.+\.rb})
+    watch(%r{lib/.+\.rb})
+    watch(%r{ext/.+\.c})
+  end
 end
 
-guard 'rspec', cli: '--color --drb --format Fuubar', all_on_start: false, all_after_pass: false do
+rspec_cli = '--color --drb --format Fuubar'
+rspec_cli += ' --tag ~@api_client --tag ~@not_supported_on_windows' if RUBY_PLATFORM =~ /mswin|mingw|windows/
+guard 'rspec', cli: rspec_cli, all_on_start: false, all_after_pass: false do
   watch(%r{^spec/unit/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})          { |m| "spec/unit/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')       { 'spec' }
 end
 
-guard 'cucumber', cli: '--drb --format pretty --tags ~@no_run --tags ~@wip', all_on_start: false, all_after_pass: false do
+cucumber_cli = '--drb --format pretty --tags ~@no_run --tags ~@wip'
+cucumber_cli += ' --tags ~@spawn --tags ~@api_server' if RUBY_PLATFORM =~ /mswin|mingw|windows/
+guard 'cucumber', cli: cucumber_cli, all_on_start: false, all_after_pass: false do
   watch(%r{^features/.+\.feature$})
   watch(%r{^features/support/.+$})                      { 'features' }
   watch(%r{^features/step_definitions/(.+)_steps\.rb$}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'features' }

--- a/features/commands/apply.feature
+++ b/features/commands/apply.feature
@@ -1,3 +1,4 @@
+@api_server
 Feature: berks apply
   Scenario: Locking a cookbook version with dependencies
     Given the cookbook store contains a cookbook "fake" "1.0.0" with dependencies:

--- a/features/commands/package.feature
+++ b/features/commands/package.feature
@@ -1,3 +1,4 @@
+@api_server
 Feature: berks package
   Background:
     * the cookbook store has the cookbooks:

--- a/features/commands/update.feature
+++ b/features/commands/update.feature
@@ -1,3 +1,4 @@
+@api_server
 Feature: berks update
   Background:
     * the cookbook store has the cookbooks:

--- a/features/lockfile.feature
+++ b/features/lockfile.feature
@@ -1,3 +1,4 @@
+@api_server
 Feature: Creating and reading the Berkshelf lockfile
   Background:
     * the cookbook store has the cookbooks:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,12 +1,16 @@
 require 'spork'
 
+def windows?
+  !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
+end
+
 Spork.prefork do
   require 'aruba/cucumber'
   require 'aruba/in_process'
   require 'aruba/spawn_process'
   require 'cucumber/rspec/doubles'
-  require 'berkshelf/api/rspec'
-  require 'berkshelf/api/cucumber'
+  require 'berkshelf/api/rspec' unless windows?
+  require 'berkshelf/api/cucumber' unless windows?
 
   Dir['spec/support/**/*.rb'].each { |f| require File.expand_path(f) }
 
@@ -18,7 +22,7 @@ Spork.prefork do
 
   at_exit do
     Berkshelf::RSpec::ChefServer.stop
-    Berkshelf::API::RSpec::Server.stop
+    Berkshelf::API::RSpec::Server.stop unless windows?
   end
 
   Before do
@@ -50,7 +54,7 @@ Spork.prefork do
     ]
 
     Berkshelf::RSpec::ChefServer.start(port: CHEF_SERVER_PORT)
-    Berkshelf::API::RSpec::Server.start(port: BERKS_API_PORT, endpoints: endpoints)
+    Berkshelf::API::RSpec::Server.start(port: BERKS_API_PORT, endpoints: endpoints) unless windows?
 
     @aruba_io_wait_seconds = Cucumber::JRUBY ? 7 : 5
     @aruba_timeout_seconds = Cucumber::JRUBY ? 35 : 15

--- a/lib/berkshelf/locations/git_location.rb
+++ b/lib/berkshelf/locations/git_location.rb
@@ -102,7 +102,7 @@ module Berkshelf
 
       def clone
         tmp_clone = File.join(self.class.tmpdir, uri.gsub(/[\/:]/,'-'))
-
+        FileUtils.mkdir_p(File.join(File.split(tmp_clone).shift))
         unless File.exists?(tmp_clone)
           Berkshelf::Git.clone(uri, tmp_clone)
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,13 @@
 require 'spork'
 
+def windows?
+  !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
+end
+
 Spork.prefork do
   require 'rspec'
   require 'webmock/rspec'
-  require 'berkshelf/api/rspec'
+  require 'berkshelf/api/rspec' unless windows?
 
   Dir['spec/support/**/*.rb'].each { |f| require File.expand_path(f) }
 
@@ -13,7 +17,7 @@ Spork.prefork do
     config.include Berkshelf::RSpec::ChefServer
     config.include Berkshelf::RSpec::Git
     config.include Berkshelf::RSpec::PathHelpers
-    config.include Berkshelf::API::RSpec
+    config.include Berkshelf::API::RSpec unless windows?
 
     config.expect_with :rspec do |c|
       c.syntax = :expect
@@ -27,7 +31,7 @@ Spork.prefork do
     config.before(:suite) do
       WebMock.disable_net_connect!(allow_localhost: true, net_http_connect_on_start: true)
       Berkshelf::RSpec::ChefServer.start
-      Berkshelf::API::RSpec::Server.start
+      Berkshelf::API::RSpec::Server.start unless windows?
       Berkshelf.set_format(:null)
       Berkshelf.ui.mute!
     end
@@ -41,7 +45,7 @@ Spork.prefork do
     end
 
     config.before(:each) do
-      Berkshelf::API::RSpec::Server.clear_cache
+      Berkshelf::API::RSpec::Server.clear_cache unless windows?
       clean_tmp_path
       Berkshelf.initialize_filesystem
       Berkshelf::CookbookStore.instance.initialize_filesystem

--- a/spec/support/git.rb
+++ b/spec/support/git.rb
@@ -21,23 +21,23 @@ module Berkshelf
 
           Dir.chdir(path) do
             shell_out "git config receive.denyCurrentBranch ignore"
-            shell_out "echo '# a change!' >> content_file"
+            shell_out "echo \"# a change!\" >> content_file"
             shell_out "git add ."
-            shell_out "git commit -am 'A commit.'"
+            shell_out "git commit -am \"A commit.\""
 
             options[:tags].each do |tag|
-              shell_out "echo '#{tag}' > content_file"
+              shell_out "echo \"#{tag}\" > content_file"
               shell_out "git add content_file"
-              shell_out "git commit -am '#{tag} content'"
-              shell_out "git tag '#{tag}' 2> /dev/null"
+              shell_out "git commit -am \"#{tag} content\""
+              shell_out "git tag \"#{tag}\""
             end if options[:tags]
 
             options[:branches].each do |branch|
-              shell_out "git checkout -b #{branch} master 2> /dev/null"
-              shell_out "echo '#{branch}' > content_file"
+              shell_out "git checkout -b #{branch} master"
+              shell_out "echo \"#{branch}\" > content_file"
               shell_out "git add content_file"
-              shell_out "git commit -am '#{branch} content'"
-              shell_out "git checkout master 2> /dev/null"
+              shell_out "git commit -am \"#{branch} content\""
+              shell_out "git checkout master"
             end if options[:branches]
           end
         end

--- a/spec/support/mercurial.rb
+++ b/spec/support/mercurial.rb
@@ -8,7 +8,7 @@ module Berkshelf
       include Berkshelf::RSpec::PathHelpers
 
       def mercurial_origin_for(repo, options = {})
-        "file://localhost#{generate_fake_mercurial_remote(repo, options)}"
+        File.join("file://localhost", generate_fake_mercurial_remote(repo, options))
       end
 
       def generate_fake_mercurial_remote(uri, options = {})
@@ -19,21 +19,21 @@ module Berkshelf
         Dir.chdir(repo_path) do
           ENV['HGUSER'] = 'test_user'
           shell_out "hg init"
-          shell_out "echo '# a change!' >> content_file"
+          shell_out "echo \"# a change!\" >> content_file"
           if options[:is_cookbook]
-            shell_out "echo '#cookbook' >> metadata.rb"
+            shell_out "echo \"#cookbook\" >> metadata.rb"
           end
           shell_out "hg add ."
-          shell_out "hg commit -m 'A commit.'"
+          shell_out "hg commit -m \"A commit.\""
           options[:tags].each do |tag|
-            shell_out "echo '#{tag}' > content_file"
-            shell_out "hg commit -m '#{tag} content'"
-            shell_out "hg tag '#{tag}'"
+            shell_out "echo \"#{tag}\" > content_file"
+            shell_out "hg commit -m \"#{tag} content\""
+            shell_out "hg tag \"#{tag}\""
           end if options.has_key? :tags
           options[:branches].each do |branch|
             shell_out "hg branch #{branch}"
-            shell_out "echo '#{branch}' > content_file"
-            shell_out "hg commit -m '#{branch} content'"
+            shell_out "echo \"#{branch}\" > content_file"
+            shell_out "hg commit -m \"#{branch} content\""
             shell_out "hg up default"
           end if options.has_key? :branches
         end

--- a/spec/unit/berkshelf/api_client_spec.rb
+++ b/spec/unit/berkshelf/api_client_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Berkshelf::APIClient do
+describe Berkshelf::APIClient, :api_client do
   let(:instance) { described_class.new("http://localhost:26210") }
 
   describe "#universe" do

--- a/spec/unit/berkshelf/berksfile_spec.rb
+++ b/spec/unit/berkshelf/berksfile_spec.rb
@@ -68,7 +68,13 @@ describe Berkshelf::Berksfile do
     end
 
     it 'merges the default options into specified options' do
-      subject.should_receive(:add_dependency).with(name, constraint, path: '/Users/reset', group: [])
+      subject.should_receive(:add_dependency)do |arg_name, arg_constraint, arg_options|
+        expect(arg_name).to eq(name)
+        expect(arg_constraint).to eq(constraint)
+        expect(arg_options[:path]).to match(%r{/Users/reset})
+        expect(arg_options[:group]).to eq([])
+      end
+
       subject.cookbook(name, constraint, path: '/Users/reset')
     end
 
@@ -560,7 +566,7 @@ describe Berkshelf::Berksfile do
     context 'when the dependency does not exist' do
       it 'raises a CookbookNotFound exception' do
         expect {
-          subject.package('non-existent', output: '/tmp')
+          subject.package('non-existent', output: Dir.tmpdir)
         }.to raise_error(Berkshelf::CookbookNotFound)
       end
     end
@@ -568,7 +574,7 @@ describe Berkshelf::Berksfile do
     context 'when the dependency exists' do
       let(:dependency) { double('dependency') }
       let(:cached) { double('cached', path: '/foo/bar', cookbook_name: 'cookbook') }
-      let(:options) { { output: '/tmp' } }
+      let(:options) { { output: Dir.tmpdir } }
 
       before do
         FileUtils.stub(:cp_r)
@@ -583,7 +589,7 @@ describe Berkshelf::Berksfile do
       end
 
       it 'returns the output path' do
-        expect(subject.package('non-existent', options)).to eq('/tmp/non-existent.tar.gz')
+        expect(subject.package('non-existent', options)).to eq(File.join(Dir.tmpdir, 'non-existent.tar.gz'))
       end
     end
   end

--- a/spec/unit/berkshelf/config_spec.rb
+++ b/spec/unit/berkshelf/config_spec.rb
@@ -37,7 +37,7 @@ describe Berkshelf::Config do
       end
 
       it "points to a location within it" do
-        expect(Berkshelf::Config.path).to eq('/tmp/config.json')
+        expect(Berkshelf::Config.path).to match(%r{/tmp/config.json})
       end
     end
   end

--- a/spec/unit/berkshelf/locations/git_location_spec.rb
+++ b/spec/unit/berkshelf/locations/git_location_spec.rb
@@ -81,7 +81,7 @@ describe Berkshelf::GitLocation do
       it 'raises a CookbookNotFound error' do
         subject.stub(:clone).and_return {
           FileUtils.mkdir_p(fake_remote)
-          Dir.chdir(fake_remote) { |dir| `git init; echo hi > README; git add README; git commit README -m 'README'`; dir }
+          Dir.chdir(fake_remote) { |dir| `git init && echo hi > README && git add README && git commit README -m 'README'`; dir }
         }
 
         expect { subject.download }.to raise_error(Berkshelf::CookbookNotFound)

--- a/spec/unit/berkshelf/resolver/graph_spec.rb
+++ b/spec/unit/berkshelf/resolver/graph_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Berkshelf::Resolver::Graph do
+describe Berkshelf::Resolver::Graph, :not_supported_on_windows do
   subject { described_class.new }
 
   describe "#populate" do

--- a/spec/unit/berkshelf/ui_spec.rb
+++ b/spec/unit/berkshelf/ui_spec.rb
@@ -29,7 +29,7 @@ describe Thor::Base.shell do
         subject.stub(:quiet?).and_return(true)
       end
 
-      it 'does not output anything' do
+      it 'does not output anything', :not_supported_on_windows do
         stdout.should_not_receive(:puts)
         subject.say 'message'
       end
@@ -66,7 +66,7 @@ describe Thor::Base.shell do
       end
 
       it 'prints to stdout' do
-        stdout.should_receive(:puts).with("\e[1m\e[32m           5\e[0m  message")
+        stdout.should_receive(:puts).with(windows? ? "           5  message" : "\e[1m\e[32m           5\e[0m  message")
         stdout.should_receive(:flush).with(no_args())
         subject.say_status 5, 'message'
       end
@@ -112,7 +112,7 @@ describe Thor::Base.shell do
         subject.stub(:quiet?).and_return(true)
       end
 
-      it 'does not output anything' do
+      it 'does not output anything', :not_supported_on_windows do
         stdout.should_not_receive(:puts)
         subject.error 'error!'
       end
@@ -124,7 +124,7 @@ describe Thor::Base.shell do
       end
 
       it 'prints to stderr' do
-        stderr.should_receive(:puts).with("\e[31merror!\e[0m")
+        stderr.should_receive(:puts).with(windows? ? "error!" : "\e[31merror!\e[0m")
         subject.error 'error!'
       end
     end


### PR DESCRIPTION
Currently RSpec and Cucumber tests are failing on Windows. Partially due to Berkshelf::API not running on Windows. The rest are mainly differences in paths and shell commands.

This pull request contains fixes to get all tests to pass. With the exception of one change in GitLocation this only touches the tests.

The change in clone was needed because Git on Windows by default does not create the leading directories in a destination path. I just copied the line from MercurialLocation to resolve this.

The added tags (api_client, api_server and not_supported_on_windows) are filtered in the Guardfile. I've disabled Yard runs because it tries to fork() which doesn't work on Windows.
