### PR TITLE
locked_version must be present for all items in Lockfile

### DIFF
--- a/lib/berkshelf/dependency.rb
+++ b/lib/berkshelf/dependency.rb
@@ -222,9 +222,7 @@ module Berkshelf
 
     def to_hash
       {}.tap do |h|
-        unless location.kind_of?(PathLocation)
-          h[:locked_version] = locked_version.to_s
-        end
+        h[:locked_version] = locked_version.to_s
 
         if location.kind_of?(PathLocation)
           h[:path] = location.relative_path(berksfile.filepath)


### PR DESCRIPTION
It looks like we're dynamically determining the locked_version of cookbooks using special types of locations. I have confirmed this true for path, I'll have to check git and friends.

The locked_version must be provided to ensure that the lockfile is portable and can be distributed with a package of cookbooks for application at a later date. This goes hand in hand with #933.

@sethvargo was this originally done to just to avoid rewriting the lockfile each time the version of the cookbook was bumped? 
