### PR TITLE
Ensure Berksfile.lock goes along with vendored cookbooks

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -639,6 +639,8 @@ module Berkshelf
         FileUtils.cp_r(files, cookbook_destination)
       end
 
+      FileUtils.cp(lockfile.filepath, File.join(scratch, Lockfile::DEFAULT_FILENAME))
+
       FileUtils.mv(scratch, destination)
       destination
     end


### PR DESCRIPTION
This will allow you to tar the entire vendor directory and ship it over to an Operations team. They can then upload the contents of that artifact and run `berks apply` using the lockfile to lock an environment.
