### PR TITLE
properly identify a cookbook on disk by it's metadata

### DIFF
--- a/lib/berkshelf/core_ext/pathname.rb
+++ b/lib/berkshelf/core_ext/pathname.rb
@@ -1,20 +1,18 @@
 class Pathname
-  # Returns true or false if the path of the instantiated
-  # Pathname or a parent directory contains a Tryhard Pack
-  # data directory.
+  # Returns true or false if the path contains a "metadata.json" or a "metadata.rb" file.
   #
   # @return [Boolean]
   def cookbook?
-    self.join('metadata.rb').exist?
+    join("metadata.json").exist? || join("metadata.rb").exist?
   end
   alias_method :chef_cookbook?, :cookbook?
 
-  # Ascend the directory structure from the given path to find a
-  # the root of a Chef Cookbook. If no Cookbook is found, nil is returned
+  # Ascend the directory structure from the given path to find  the root of a
+  # Cookbook. If no Cookbook is found, nil is returned.
   #
   # @return [Pathname, nil]
   def cookbook_root
-    self.ascend do |potential_root|
+    ascend do |potential_root|
       if potential_root.cookbook?
         return potential_root
       end

--- a/spec/unit/berkshelf/core_ext/pathname_spec.rb
+++ b/spec/unit/berkshelf/core_ext/pathname_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Pathname do
+  describe "#cookbook?" do
+    let(:cookbook_path) { tmp_path }
+    let(:metadata_rb) { tmp_path.join("metadata.rb") }
+    let(:metadata_json) { tmp_path.join("metadata.json") }
+
+    subject { Pathname.new(cookbook_path) }
+
+    context "when the path contains a metadata.json file" do
+      before { FileUtils.touch(metadata_json) }
+      its(:cookbook?) { should be_true }
+    end
+
+    context "when the path contains a metadata.rb file" do
+      before { FileUtils.touch(metadata_rb) }
+      its(:cookbook?) { should be_true }
+    end
+
+    context "when the path does not contain a metadata.json or metadata.rb file" do
+      before { FileUtils.rm_f(metadata_rb) && FileUtils.rm_f(metadata_json) }
+      its(:cookbook?) { should be_false }
+    end
+  end
+
+  describe "#cookbook_root" do
+    let(:root_path) { fixtures_path.join("cookbooks", "example_cookbook") }
+    let(:cookbook_path) { root_path }
+    subject { Pathname.new(cookbook_path) }
+
+    context "when in the root of a cookbook" do
+      its(:cookbook_root) { should eql(root_path) }
+    end
+
+    context "when in the structure of a cookbook" do
+      let(:cookbook_path) { root_path.join("recipes") }
+      its(:cookbook_root) { should eql(root_path) }
+    end
+
+    context "when not within the structure of a cookbook" do
+      let(:cookbook_path) { "/" }
+      its(:cookbook_root) { should be_nil }
+    end
+  end
+end


### PR DESCRIPTION
This will fix issues where cookbooks would be installed multiple times and potential crashes when vendoring or packaging cookbooks.
