### PR TITLE
Added a warning about Berkshelf 2 being unsupported and a link to how to install 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Manage a Cookbook or an Application's Cookbook dependencies
 Installation
 ------------
 
-**WARNING:** It is advised at this time that you [use Berkshelf 3](https://github.com/berkshelf/berkshelf/wiki/Howto:-Use-the-bleeding-edge). Berkshelf 2 is no longer supported.
+**WARNING:** It is advised at this time that you [use Berkshelf 3](https://github.com/berkshelf/berkshelf/wiki/Howto:-Use-the-bleeding-edge). Berkshelf 2 is no longer being actively developed and has a number of significant issues related to dependency resolution that Berkshelf 3 fixes.
 
 Add Berkshelf to your repository's `Gemfile`:
 


### PR DESCRIPTION
Couldn't find the `berkshelf.com` GitHub pages in here. Point me at 'em and I'll update there as well.
