### PR TITLE
Add method_option to specify environment from_file for apply

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -566,7 +566,13 @@ module Berkshelf
     # @raise [ChefConnectionError] if you are locking cookbooks with an invalid or not-specified client configuration
     def apply(environment_name, options = {})
       conn        = ridley_connection(options)
-      environment = conn.environment.find(environment_name)
+
+      if options[:from_file]
+        environment_path = options[:from_file]
+        environment = conn.environment.from_file(environment_path)
+      else
+        environment = conn.environment.find(environment_name)
+      end
 
       if environment
         install

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -240,6 +240,11 @@ module Berkshelf
       type: :boolean,
       default: nil,
       desc: 'Disable/Enable SSL verification when locking cookbooks.'
+    method_option :from_file,
+      type: :string,
+      desc: 'Path to an environment to operate off of.',
+      aliases: '-f',
+      banner: 'PATH'
     desc 'apply ENVIRONMENT', 'Apply the cookbook version locks from Berksfile.lock to a Chef environment'
     def apply(environment_name)
       berksfile    = ::Berkshelf::Berksfile.from_file(options[:berksfile])


### PR DESCRIPTION
When using berks apply it would be nice to be able to use environment from_file 'berks apply foo -f environments/foo.json'.
