### PR TITLE
Berkshelf 3 overrides custom cookbooks w/ "locked_version" of community cookbooks.

### DIFF
--- a/lib/berkshelf/dependency.rb
+++ b/lib/berkshelf/dependency.rb
@@ -152,6 +152,12 @@ module Berkshelf
     # @return [Berkshelf::CachedCookbook]
     def download
       @cached_cookbook = location.download
+
+      if scm_location?
+        @locked_version = Solve::Version.new(@cached_cookbook.version)
+      end
+
+      @cached_cookbook
     end
 
     # Returns true if the dependency has already been downloaded. A dependency is downloaded when a

--- a/lib/berkshelf/resolver.rb
+++ b/lib/berkshelf/resolver.rb
@@ -41,11 +41,13 @@ module Berkshelf
       demands.push(demand)
     end
 
-    def add_explicit_dependencies(dependency)
-      unless cookbook = dependency.cached_cookbook
-        return nil
-      end
-
+    # Add dependencies of a locally cached cookbook which will take precedence over anything
+    # found in the universe.
+    #
+    # @param [Berkshelf::CachedCookbook] cookbook
+    #
+    # @return [Hash]
+    def add_explicit_dependencies(cookbook)
       graph.populate_local(cookbook)
     end
 

--- a/lib/berkshelf/resolver/graph.rb
+++ b/lib/berkshelf/resolver/graph.rb
@@ -10,6 +10,11 @@ module Berkshelf
         end
       end
 
+      # Add dependencies of a locally cached cookbook to the graph
+      #
+      # @param [Berkshelf::CachedCookbook] cookbook
+      #
+      # @return [Hash]
       def populate_local(cookbook)
         name    = cookbook.cookbook_name
         version = cookbook.version


### PR DESCRIPTION
I've been building out forks of community cookbooks that are specifically targeted at Ubuntu LTS 12.04 running on AWS. As such, I have a number of cookbooks that share the same name and largely the same functionality for cookbooks that rely on them. 

My `Berksfile`:

``` ruby
source "https://api.berkshelf.com"
# site :opscode

cookbook "wasatch", github: "sprintly/wasatch-chef", protocol: :ssh

cookbook "nodejs", github: "tvdinner/nodejs"
cookbook "npm", github: "tvdinner/npm"
cookbook "route53", github: "tvdinner/route53"
cookbook "redis", github: "tvdinner/redis"
cookbook "rabbitmq", github: "tvdinner/rabbitmq"
cookbook "sensu", github: "tvdinner/sensu"
```

My understanding of how Berkshelf works is that it would see that `npm` has `nodejs` in the `metadata.rb` file but would override the location with the references to `tvdinner/nodejs`. That almost appears to be the case. When I open up my `Berksfile.lock` I see the following:

```
    "nodejs": {
      "locked_version": "1.3.0",
      "git": "git://github.com/tvdinner/nodejs.git",
      "ref": "c806a1aeb4ea2fc5c26ebe5ae247ee672d08dcf2"
    },
    "npm": {
      "locked_version": "0.1.2",
      "git": "git://github.com/tvdinner/npm.git",
      "ref": "752a016a601d3356dacca2d36263248d7896aa32"
    },
    "route53": {
      "locked_version": "0.3.1",
      "git": "git://github.com/tvdinner/route53.git",
      "ref": "458c148fa705ab8e7180b5917615b6e502a0c510"
    },
```

If you look at the actual `metadata.rb`'s of those respective repos, you'll see that the versions are all below those.

Near as I can tell Berkshelf is overriding the `metadata.rb`'s version information with the cookbook site's version. 

This breaks most commands as the cookbook Berkshelf downloads is not the version it ends up looking for.
