### PR TITLE
Looking for wrong version

### DIFF
--- a/lib/berkshelf/cookbook_store.rb
+++ b/lib/berkshelf/cookbook_store.rb
@@ -95,6 +95,14 @@ module Berkshelf
     # @return [Array<Berkshelf::CachedCookbook>]
     def cookbooks(filter = nil)
       cookbooks = storage_path.children.collect do |path|
+        begin
+          Solve::Version.split(File.basename(path).slice(CachedCookbook::DIRNAME_REGEXP, 2))
+        rescue Solve::Errors::InvalidVersionFormat
+          # Skip cookbooks that were downloaded by an SCM location. These can not be considered
+          # complete cookbooks.
+          next
+        end
+
         CachedCookbook.from_store_path(path)
       end.compact
 


### PR DESCRIPTION
Beside this [issue](https://github.com/RiotGames/berkshelf/issues/906), I'm running into an issue where Berkshelf doesn't constrain itself to the available versions.

To reproduce:

```
git clone git@github.com:opscode-cookbooks/nginx.git
git checkout v2.0.4
```

Run berks and it'll blow up trying to grab `yum 2.4.3`:

```
berks                                                                                                                                                                  

DEPRECATED: Your Berksfile contains a site location pointing to the Opscode Community Site (site :opscode). Site locations have been replaced by the source location. Change this to: 'source "http://api.berkshelf.com" to remove this warning. For more information visit https://github.com/RiotGames/berkshelf/wiki/deprecated-locations

building universe...
Using nginx (2.0.4) path: '/private/tmp/nginx'
Using apt (2.3.0)
Using bluepill (2.3.0)
Using build-essential (1.4.2)
Using ohai (1.1.12)
Using runit (1.4.0)

Installing yum (2.4.3)
yum (2.4.3) not found in any sources
```

A quick look at yum reveals the [highest available is 2.4.2](http://cookbooks.opscode.com/api/v1/cookbooks/yum).

Any ideas?

PS: using Berkshelf (3.0.0.beta3) or master build, and also switched the deprecated location.
