### PR TITLE
exception info swallowed when git protocol doesn't work

### DIFF
--- a/lib/berkshelf/git.rb
+++ b/lib/berkshelf/git.rb
@@ -152,7 +152,6 @@ module Berkshelf
       #
       # @return [Boolean]
       def validate_uri(uri)
-
         unless uri.is_a?(String)
           return false
         end

--- a/lib/berkshelf/location.rb
+++ b/lib/berkshelf/location.rb
@@ -137,19 +137,7 @@ module Berkshelf
       end
     end
 
-    class ScmLocation < Location::Base
-      class << self
-        # Create a temporary directory for the cloned repository within Berkshelf's
-        # temporary directory
-        #
-        # @return [String]
-        #   the path to the created temporary directory
-        def tmpdir
-          @tmpdir ||= Berkshelf.mktmpdir
-        end
-      end
-    end
-
+    class ScmLocation < Location::Base; end
   end
 end
 

--- a/spec/unit/berkshelf/locations/git_location_spec.rb
+++ b/spec/unit/berkshelf/locations/git_location_spec.rb
@@ -12,12 +12,6 @@ describe Berkshelf::GitLocation do
         }.to raise_error(Berkshelf::InvalidGitURI)
       end
     end
-
-    describe "::tmpdir" do
-      it 'creates a temporary directory within the Berkshelf temporary directory' do
-        expect(described_class.tmpdir).to include(Berkshelf.tmp_dir)
-      end
-    end
   end
 
   let(:storage_path) { Berkshelf::CookbookStore.instance.storage_path }
@@ -79,7 +73,7 @@ describe Berkshelf::GitLocation do
       subject { described_class.new(dependency, git: "file://#{fake_remote}.git") }
 
       it 'raises a CookbookNotFound error' do
-        subject.stub(:clone).and_return {
+        Berkshelf::Git.stub(:clone).and_return {
           FileUtils.mkdir_p(fake_remote)
           Dir.chdir(fake_remote) { |dir| `git init && echo hi > README && git add README && git commit README -m 'README'`; dir }
         }
@@ -98,7 +92,7 @@ describe Berkshelf::GitLocation do
     end
 
     context 'given a value for tag' do
-      let(:tag) { '1.0.0' }
+      let(:tag) { 'v1.0.0' }
 
       subject do
         described_class.new(dependency, git: 'git://github.com/RiotGames/berkshelf-cookbook-fixture.git', tag: tag)

--- a/spec/unit/berkshelf/locations/mercurial_location_spec.rb
+++ b/spec/unit/berkshelf/locations/mercurial_location_spec.rb
@@ -16,12 +16,6 @@ describe Berkshelf::MercurialLocation do
     end
   end
 
-  describe '::tmpdir' do
-    it 'creates a temporary directory within the Berkshelf temporary directory' do
-      expect(described_class.tmpdir).to include(Berkshelf.tmp_dir)
-    end
-  end
-
   subject { described_class.new(dependency, hg: cookbook_uri) }
 
   describe '#download' do


### PR DESCRIPTION
Berkshelf seems to swallow helpful exception info in certain circumstances (even when `--debug` mode is enabled).  For example, if the "git" protocol isn't working on a WiFi network, you get this:

```
$ berks install -d
Failed to download 'nexus' from github: 'RiotGames/nexus-cookbook' with branch: '2.2.0' over protocol: 'git'
Cookbook 'nexus' not found in any of the default locations
```

If you do a bare `git clone` in contrast, the problem is much clearer:

```
$ git clone git://github.com/RiotGames/nexus-cookbook.git
Cloning into 'nexus-cookbook'...
fatal: unable to connect to github.com:
github.com[0: 192.30.252.129]: errno=Connection refused
```

Better would be if Berkshelf captures this helpful info, lets it bubble up, and then displays it.  This would have helped in at least a couple reported issues (e.g. issue #877 and issue #791) and possibly more.
