### PR TITLE
`berks install --quiet` mutes error output

### DIFF
--- a/lib/berkshelf/ui.rb
+++ b/lib/berkshelf/ui.rb
@@ -38,8 +38,6 @@ module Berkshelf
     end
 
     def error(message, color = :red)
-      return if quiet?
-
       message = set_color(message, *color) if color
       super(message)
     end

--- a/spec/unit/berkshelf/ui_spec.rb
+++ b/spec/unit/berkshelf/ui_spec.rb
@@ -112,8 +112,8 @@ describe Thor::Base.shell do
         subject.stub(:quiet?).and_return(true)
       end
 
-      it 'does not output anything', :not_supported_on_windows do
-        stdout.should_not_receive(:puts)
+      it "outputs an error message", :not_supported_on_windows do
+        stderr.should_receive(:puts)
         subject.error 'error!'
       end
     end


### PR DESCRIPTION
The  `--quiet` option seems to suppress all output, including errors.

I'm running `bundle exec berks install --quiet --path=.berkshelf`.

One of my cookbooks is not found.

Exit status is correct (103), but there is no error message.

What I would expect:
Cookbook 'foo' not found in any of the default locations

Is this by design, or a bug?

Thanks.
