### PR TITLE
Fix extra whitespace when commented line is empty

### DIFF
--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -75,7 +75,7 @@ module Berkshelf
     private
 
       def commented(content)
-        content.split("\n").collect { |s| "# #{s}" }.join("\n")
+        content.split("\n").collect { |s| s == "" ? "#" : "# #{s}"}.join("\n")
       end
 
       def license_name


### PR DESCRIPTION
This just fixes a little pet pieve of mine.
Right now when using commented(foo), if there is an empty line in foo it will generate a line with extra whitespace "# " instead of just "#"
