### PR TITLE
Implement "downloading" for `file_store` sources

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -133,6 +133,10 @@ module Berkshelf
         end.first
 
         (unpack_dir + cookbook_directory).to_s
+      when :file_store
+        tmp_dir = Dir.mktmpdir
+        FileUtils.cp_r(remote_cookbook.location_path, tmp_dir)
+        File.join(tmp_dir, name)
       else
         raise RuntimeError, "unknown location type #{remote_cookbook.location_type}"
       end


### PR DESCRIPTION
- It might be better if `file_store` cookbooks were handled with `path` dependencies
- The cookbook is copied since the CookbookStore#import expects a temporary download path it can move

I'm sure there are some better ways about this but because this works and to get the ball rolling, I thought I'd push this up. Suggestions?
