### PR TITLE
Sane defaults for OSX and keep current dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There is a [berkshelf bash completion script](https://raw.github.com/berkshelf/b
 
 Download the latest script
 
-    pushd `brew --prefix`/etc/bash_completion.d && curl https://raw.github.com/berkshelf/berkshelf/master/berkshelf-complete.sh > berkshelf-complete.sh && popd
+    (cd `brew --prefix`/etc/bash_completion.d && curl https://raw.github.com/berkshelf/berkshelf/master/berkshelf-complete.sh > berkshelf-complete.sh)
 
 And make sure you have this in your bash/zsh profile:
 


### PR DESCRIPTION
- wget doesn't appear to be on OSX by default, CURL is.
- `pushd/popd` so I go back to where I started from before I ran the command.
