### PR TITLE
Missing CHANGELOG.md

### DIFF
--- a/generator_files/CHANGELOG.md.erb
+++ b/generator_files/CHANGELOG.md.erb
@@ -1,0 +1,5 @@
+# <%= name %> cookbook CHANGELOG
+This file is used to list changes made in each version of the <%= name %> cookbook.
+
+## v0.1.0 (<%= Time.now.strftime('%Y-%m-%d') %>)
+- Initial release of <%= name %>

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -68,6 +68,7 @@ module Berkshelf
       template 'metadata.rb.erb', target.join('metadata.rb')
       template license_file, target.join('LICENSE')
       template 'README.md.erb', target.join('README.md')
+      template 'CHANGELOG.md.erb', target.join('CHANGELOG.md')
 
       Berkshelf::InitGenerator.new([target], options.merge(default_options)).invoke_all
     end

--- a/spec/unit/berkshelf/cookbook_generator_spec.rb
+++ b/spec/unit/berkshelf/cookbook_generator_spec.rb
@@ -46,6 +46,10 @@ describe Berkshelf::CookbookGenerator do
           contains '    "recipe[sparkle_motion::default]"'
           contains 'Author:: YOUR_NAME (<YOUR_EMAIL>)'
         end
+        file 'CHANGELOG.md' do
+          contains '# sparkle_motion cookbook CHANGELOG'
+          contains "## v0.1.0 (#{Time.now.strftime('%Y-%m-%d')})"
+        end
         file 'metadata.rb' do
           contains "name             'sparkle_motion'"
           contains "maintainer       'YOUR_NAME'"


### PR DESCRIPTION
Hi, 

Could you please add following to generator_files: CHANGELOG.md? 

certain gems need it and it is not created automatically with berkshelf, it can be only created with knife but knife is really poor when comparing it with berkshelf possibilities around cookbook creation.
