### PR TITLE
berks vendor does not work if the path is nested

### DIFF
--- a/features/commands/vendor.feature
+++ b/features/commands/vendor.feature
@@ -46,3 +46,11 @@ Feature: Vendoring cookbooks to a directory
     And a directory named "cukebooks"
     When I run `berks vendor cukebooks`
     And the exit status should be "VendorError"
+
+  Scenario: vendoring into a nested directory
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'fake'
+      """
+    When I successfully run `berks vendor path/to/cukebooks`
+    Then the directory "path/to/cukebooks/fake" should contain version "1.0.0" of the "fake" cookbook

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -586,6 +586,9 @@ module Berkshelf
           "different filepath."
       end
 
+      # Ensure the parent directory exists, in case a nested path was given
+      FileUtils.mkdir_p(File.expand_path(File.join(destination, '..')))
+
       scratch          = Berkshelf.mktmpdir
       chefignore       = nil
       cached_cookbooks = install(options.slice(:except, :only))


### PR DESCRIPTION
```
berks vendor foo
```

works

```
berks vendor foo/bar
```

does not and fails with a file not found exception.
