### PR TITLE
Add -v to list option to show path.  Always show path in json format.

### DIFF
--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -71,6 +71,7 @@ module Berkshelf
         h[:license]       = license unless license.blank?
         h[:platforms]     = platforms.to_hash unless platforms.blank?
         h[:dependencies]  = dependencies.to_hash unless dependencies.blank?
+        h[:path ]         = path unless path.blank?
       end
     end
 

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -289,12 +289,16 @@ module Berkshelf
       type: :array,
       desc: 'Only cookbooks that are in these groups.',
       aliases: '-o'
+    method_option :verbose,
+      type: :boolean,
+      desc: 'Give more information about the cookbooks (eg. path)',
+      aliases: '-v'
     desc 'list', 'List cookbooks and their dependencies specified by your Berksfile'
     def list
       berksfile = Berksfile.from_file(options[:berksfile])
       cookbooks = berksfile.list(options.symbolize_keys)
 
-      Berkshelf.formatter.list(cookbooks)
+      Berkshelf.formatter.list(cookbooks, options[:verbose])
     end
 
     method_option :berksfile,

--- a/lib/berkshelf/formatters/human_readable.rb
+++ b/lib/berkshelf/formatters/human_readable.rb
@@ -96,13 +96,17 @@ module Berkshelf
       # Output a list of cookbooks using {Berkshelf.ui}
       #
       # @param [Hash<Dependency, CachedCookbook>] list
-      def list(list)
+      def list(list, verbose = false)
         if list.empty?
           Berkshelf.ui.info "There are no cookbooks installed by your Berksfile"
         else
           Berkshelf.ui.info "Cookbooks installed by your Berksfile:"
           list.each do |dependency, cookbook|
-            Berkshelf.ui.info("  * #{cookbook.cookbook_name} (#{cookbook.version})")
+            info = "  * #{cookbook.cookbook_name} (#{cookbook.version})"
+            if verbose
+              info = info + " [#{cookbook.path}]"
+            end
+            Berkshelf.ui.info(info)
           end
         end
       end

--- a/lib/berkshelf/formatters/json.rb
+++ b/lib/berkshelf/formatters/json.rb
@@ -116,6 +116,7 @@ module Berkshelf
         list.each do |dependency, cookbook|
           cookbooks[cookbook.cookbook_name] ||= {}
           cookbooks[cookbook.cookbook_name][:version] = cookbook.version
+          cookbooks[cookbook.cookbook_name][:path] = cookbook.path
           if dependency.location
             cookbooks[cookbook.cookbook_name][:location] = dependency.location
           end


### PR DESCRIPTION
PR against master branch as requested in #1011.
- Provide the path to the cached cookbook when requesting json format for `berks list` or `berks show`
- Add `-v` option to `berks list` to show the path in the format `* cookbook_name (version) [path]`
