### PR TITLE
Don't load Octokit until we need it

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -1,7 +1,6 @@
 require 'net/http'
 require 'zlib'
 require 'archive/tar/minitar'
-require 'octokit'
 
 module Berkshelf
   class Downloader
@@ -71,6 +70,8 @@ module Berkshelf
         Celluloid.logger = nil unless ENV["DEBUG_CELLULOID"]
         Ridley.open(credentials) { |r| r.cookbook.download(name, version) }
       when :github
+        require 'octokit' unless defined?(Octokit)
+
         tmp_dir      = Dir.mktmpdir
         archive_path = File.join(tmp_dir, "#{name}-#{version}.tar.gz")
         unpack_dir   = File.join(tmp_dir, "#{name}-#{version}")


### PR DESCRIPTION
Octokit takes between 0.7 and 0.8 seconds to load. Moving the require down into the stack decreased Berkshelf's total load time by almost a full second.
