### PR TITLE
Remove implicit default source

### DIFF
--- a/features/berksfile.feature
+++ b/features/berksfile.feature
@@ -2,6 +2,8 @@ Feature: Evaluating a Berksfile
   Scenario: Containing pure Ruby
     Given I write to "Berksfile" with:
       """
+      source 'https://api.berkshelf.com'
+
       if ENV['BACON']
         puts "If you don't got bacon..."
       else

--- a/features/commands/upload.feature
+++ b/features/commands/upload.feature
@@ -169,6 +169,7 @@ Feature: berks upload
     Given a cookbook named "fake"
     And the cookbook "fake" has the file "Berksfile" with:
       """
+      source 'https://api.berkshelf.com'
       metadata
       """
     And the Chef Server has frozen cookbooks:
@@ -182,6 +183,7 @@ Feature: berks upload
 
         * fake (0.0.0)
       """
+
   Scenario: When the syntax check is skipped
     Given a cookbook named "fake"
     And the cookbook "fake" has the file "recipes/default.rb" with:
@@ -200,6 +202,7 @@ Feature: berks upload
       """
     And the cookbook "fake" has the file "Berksfile" with:
       """
+      source 'https://api.berkshelf.com'
       metadata
       """
     And I cd to "fake"

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -3,13 +3,6 @@ require_relative "packager"
 module Berkshelf
   class Berksfile
     class << self
-      # The sources to use if no sources are explicitly provided
-      #
-      # @return [Array<Berkshelf::Source>]
-      def default_sources
-        @default_sources ||= [ Source.new(DEFAULT_API_URL) ]
-      end
-
       # Instantiate a Berksfile from the given options. This method is used
       # heavily by the CLI to reduce duplication.
       #
@@ -63,7 +56,7 @@ module Berkshelf
     def initialize(path, options = {})
       @filepath         = path
       @dependencies     = Hash.new
-      @sources          = Array.new
+      @sources          = Hash.new
 
       if options[:except] && options[:only]
         raise Berkshelf::ArgumentError, 'Cannot specify both :except and :only!'
@@ -169,13 +162,16 @@ module Berkshelf
     #
     # @return [Array<Berkshelf::Source>]
     def source(api_url)
-      new_source = Source.new(api_url)
-      @sources.push(new_source) unless @sources.include?(new_source)
+      @sources[api_url] = Source.new(api_url)
     end
 
     # @return [Array<Berkshelf::Source>]
     def sources
-      @sources.empty? ? self.class.default_sources : @sources
+      if @sources.empty?
+        raise NoAPISourcesDefined
+      else
+        @sources.values
+      end
     end
 
     # @param [Dependency] dependency

--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -540,4 +540,17 @@ module Berkshelf
             "dependency."
     end
   end
+
+  class NoAPISourcesDefined < BerkshelfError
+    status_code(146)
+
+    def initialize
+      super "Your Berksfile does not define any API sources! You must define " \
+        "at least one source in order to download cookbooks. To add the " \
+        "default Berkshelf API server, add the following code to the top of " \
+        "your Berksfile:" \
+        "\n\n" \
+        "    source 'https://api.berkshelf.com'"
+    end
+  end
 end

--- a/lib/berkshelf/formatters/human_readable.rb
+++ b/lib/berkshelf/formatters/human_readable.rb
@@ -67,7 +67,7 @@ module Berkshelf
         hash.keys.each do |name|
           hash[name].each do |source, newest|
             string = "  * #{newest.name} (#{newest.version})"
-            unless Berksfile.default_sources.map { |s| s.uri.to_s }.include?(source)
+            unless source == Berksfile::DEFAULT_API_URL
               string << " [#{source}]"
             end
             Berkshelf.ui.info string

--- a/spec/unit/berkshelf/berksfile_spec.rb
+++ b/spec/unit/berkshelf/berksfile_spec.rb
@@ -2,16 +2,6 @@ require 'spec_helper'
 
 describe Berkshelf::Berksfile do
   describe "ClassMethods" do
-    describe "::default_sources" do
-      subject { described_class.default_sources }
-
-      it "returns an array including the default sources" do
-        expect(subject).to be_a(Array)
-        expect(subject).to have(1).item
-        expect(subject.map(&:to_s)).to include("https://api.berkshelf.com")
-      end
-    end
-
     describe '::from_file' do
       let(:content) do
         <<-EOF.strip
@@ -152,14 +142,6 @@ describe Berkshelf::Berksfile do
       expect(subject.sources[1].to_s).to_not eq(new_source)
     end
 
-    context "when a source is explicitly specified" do
-      it "does not include the default sources in the list" do
-        subject.source(new_source)
-        expect(subject.sources).to have(1).item
-        expect(subject.sources).to_not include(described_class.default_sources)
-      end
-    end
-
     context "adding an invalid source" do
       let(:invalid_uri) { ".....$1233...." }
 
@@ -170,18 +152,26 @@ describe Berkshelf::Berksfile do
   end
 
   describe "#sources" do
-    it "returns an Array" do
-      expect(subject.sources).to be_a(Array)
-    end
-
-    it "contains a collection of Berkshelf::Source" do
-      subject.sources.each do |source|
-        expect(source).to be_a(Berkshelf::Source)
+    context "when there are no sources" do
+      it "raises an exception" do
+        expect {
+          subject.sources
+        }.to raise_error(Berkshelf::NoAPISourcesDefined)
       end
     end
 
-    it "includes the default sources" do
-      expect(subject.sources).to include(*described_class.default_sources)
+    context "when there are sources" do
+      before { subject.source("https://api.berkshelf.org") }
+
+      it "returns an Array" do
+        expect(subject.sources).to be_a(Array)
+      end
+
+      it "contains a collection of Berkshelf::Source" do
+        subject.sources.each do |source|
+          expect(source).to be_a(Berkshelf::Source)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
In some cases it would be useful to only pull in explicitly sourced cookbooks - for example, a company may not want to use any cookbooks that they have not reviewed.

Berkshelf currently uses the Opscode community site as a default, and explicitly setting `site :opscode` seems to be a common idiom in the documentation. Instead of this, either the default should be empty (requiring `site :opscode` to pull from the community site) or there should be a method to 'unset' the default (e.g. `site :none`). When there is no site set, cookbooks and dependencies with no explicit source should raise an error.

As far as I'm aware, `librarian-chef` does something similar, and when no `site` has been set cookbooks without explicit sources fail. I can check that this is the current behaviour of both if necessary.

It'd also be useful to set a path as the default site, allowing use of a cookbooks directory to supply dependencies, though I suspect this wouldn't work well with the 'berkshelf way'. The original discussion around this can be found here: https://stackoverflow.com/questions/19593231/how-can-i-make-berkshelf-use-a-local-path-as-the-default-site-or-unset-the-defa
