### PR TITLE
Update Vagrantfile.erb

### DIFF
--- a/generator_files/Vagrantfile.erb
+++ b/generator_files/Vagrantfile.erb
@@ -62,9 +62,6 @@ Vagrant.configure("2") do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
-
   # The path to the Berksfile to use with Vagrant Berkshelf
   # config.berkshelf.berksfile_path = "./Berksfile"
 


### PR DESCRIPTION
This was fixed in 3.0, but not back ported to 2.x...

There are errors in the configuration of this machine. Please fix
the following errors and try again:

SSH:
- The following settings shouldn't exist: max_tries, timeout

...since 3.0 is still in beta, how about another 2.x release, since this breaks right off the bat out of the box?
