### PR TITLE
Added some logic so it can handle multiple Github configurations

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -123,9 +123,9 @@ module Berkshelf
       type: Boolean,
       default: true,
       required: true
-    attribute 'github.access_token',
-      type: String,
-      default: '',
+    attribute 'github',
+      type: Array,
+      default: "",
       required: false
   end
 end


### PR DESCRIPTION
With this added logic you can use multiple Github organisations and/or
Github Enterprise organisations. This code doesn’t change the default
behaviour, but it does change the Github config section from being a
string with a single entry (access_token), to an array with one (just
the one ‘access_token’ entry) or several entries (depending on your
config/setup).

This PR is dependent on https://github.com/berkshelf/berkshelf-api/pull/81 because it needs the extended location_path entry.
