### PR TITLE
Don't save the lockfile on reduction

### DIFF
--- a/lib/berkshelf/installer.rb
+++ b/lib/berkshelf/installer.rb
@@ -163,8 +163,6 @@ module Berkshelf
           lockfile.unlock(dependency)
         end
       end
-
-      lockfile.save
     end
 
     def berksfile_dependencies


### PR DESCRIPTION
This is the result of a stupid bug where, if for some reason a lockfile conversion doesn't fail, but included an unsolvable graph, you are left with an ugly lockfile that is only partially filled.

/cc @schisamo 
