### PR TITLE
Make mercurial specs optional

### DIFF
--- a/spec/unit/berkshelf/locations/mercurial_location_spec.rb
+++ b/spec/unit/berkshelf/locations/mercurial_location_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Berkshelf::MercurialLocation do
+describe Berkshelf::MercurialLocation, :hg do
   include Berkshelf::RSpec::Mercurial
 
   let(:cookbook_uri) { mercurial_origin_for('fake_cookbook', is_cookbook: true, tags: ["1.0.0"], branches: ["mybranch"]) }

--- a/spec/unit/berkshelf/mercurial_spec.rb
+++ b/spec/unit/berkshelf/mercurial_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Berkshelf::Mercurial do
+describe Berkshelf::Mercurial, :hg do
   include Berkshelf::RSpec::Mercurial
 
   let(:hg) { Berkshelf::Mercurial }


### PR DESCRIPTION
We are in the process of integrating berks specs into the CI pipelines we're building for Chef DK. Mercurial specs are red for us and since we are not planning on shipping mercurial, we would like to have the option of turning of these specs if needed.

I think @sethvargo's PR https://github.com/berkshelf/berkshelf/pull/1021 is the right direction to go. Creating this PR to get us unblocked incase we can't get to that in time.
