### PR TITLE
Add lifecycle command for bumping the local version

### DIFF
--- a/features/lifecycle.feature
+++ b/features/lifecycle.feature
@@ -208,3 +208,42 @@ Feature: Lifecycle commands
       """
     * the output should not contain "Using ekaf (1.0.0)"
     * the output should contain "Using fake (1.0.0)"
+
+  Scenario: Bumping the version of a local cookbook
+    * I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      metadata
+      """
+    * I write to "metadata.rb" with:
+      """
+      name 'fake'
+      version '1.0.0'
+      """
+    * I successfully run `berks install`
+    * the file "Berksfile.lock" should contain:
+      """
+      DEPENDENCIES
+        fake
+          path: .
+          metadata: true
+
+      GRAPH
+        fake (1.0.0)
+      """
+    * I write to "metadata.rb" with:
+      """
+      name 'fake'
+      version '1.0.1'
+      """
+    * I successfully run `berks install`
+    * the file "Berksfile.lock" should contain:
+      """
+      DEPENDENCIES
+        fake
+          path: .
+          metadata: true
+
+      GRAPH
+        fake (1.0.1)
+      """
+    * the output should contain "Using fake (1.0.1)"


### PR DESCRIPTION
This is the issue that @rteabeault listed in #1063, but these cucumber tests are passing locally.

@rteabeault - do you have any more reproduction information?
