### PR TITLE
Suppress default location

### DIFF
--- a/lib/berkshelf/source.rb
+++ b/lib/berkshelf/source.rb
@@ -50,7 +50,7 @@ module Berkshelf
     # @return [true, false]
     #   true if this a default source, false otherwise
     def default?
-      uri.to_s == Berksfile::DEFAULT_API_URL
+      @default_ ||= @uri.host == URI.parse(Berksfile::DEFAULT_API_URL).host
     end
 
     # @param [String] name

--- a/spec/unit/berkshelf/source_spec.rb
+++ b/spec/unit/berkshelf/source_spec.rb
@@ -28,6 +28,11 @@ module Berkshelf
         expect(instance).to be_default
       end
 
+      it 'returns true when the scheme is different' do
+        instance = described_class.new('http://api.berkshelf.com')
+        expect(instance).to be_default
+      end
+
       it 'returns false when the source is not the default' do
         instance = described_class.new('http://localhost:8080')
         expect(instance).to_not be_default


### PR DESCRIPTION
I introduced a bug at some point. The output now includes:

``` text
Installing java (1.20.0) from http://api.berkshelf.com ([opscode] http://cookbooks.opscode.com/api/v1)
```

but should really be:

``` text
Installing java (1.20.0)
```
