### PR TITLE
Fix logging

### DIFF
--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -37,11 +37,10 @@ module Berkshelf
   DEFAULT_FILENAME = 'Berksfile'.freeze
 
   class << self
-    include Berkshelf::Mixin::Logging
+    include Mixin::Logging
 
     attr_writer :berkshelf_path
     attr_accessor :ui
-    attr_accessor :logger
 
     # @return [Pathname]
     def root
@@ -151,7 +150,7 @@ module Berkshelf
       Celluloid.logger = nil unless ENV["DEBUG_CELLULOID"]
       Ridley.open(ridley_options, &block)
     rescue Ridley::Errors::RidleyError => ex
-      log_exception(ex)
+      log.exception(ex)
       raise ChefConnectionError, ex # todo implement
     end
 
@@ -215,5 +214,5 @@ require_relative 'berkshelf/source'
 require_relative 'berkshelf/source_uri'
 require_relative 'berkshelf/ui'
 
-Ridley.logger = Berkshelf.logger = Logger.new(STDOUT)
+Ridley.logger = Berkshelf.logger
 Berkshelf.logger.level = Logger::WARN

--- a/lib/berkshelf/logger.rb
+++ b/lib/berkshelf/logger.rb
@@ -1,12 +1,18 @@
 module Berkshelf
-  Logger = Ridley.logger
-
-  Logger.class.class_eval do
+  class Logger < Ridley::Logging::Logger
     alias_method :fatal, :error
 
     def deprecate(message)
       trace = caller.join("\n\t")
       warn "DEPRECATION WARNING: #{message}\n\t#{trace}"
+    end
+
+    # Log an exception and its backtrace to FATAL
+    #
+    # @param [Exception] ex
+    def exception(ex)
+      log.fatal("#{ex.class}: #{ex}")
+      log.fatal(ex.backtrace.join("\n")) unless ex.backtrace.nil?
     end
   end
 end

--- a/lib/berkshelf/mixin/logging.rb
+++ b/lib/berkshelf/mixin/logging.rb
@@ -1,17 +1,12 @@
 module Berkshelf
   module Mixin
     module Logging
-      def log
-        Berkshelf::Logger
-      end
+      attr_writer :logger
 
-      # Log an exception and its backtrace to FATAL
-      #
-      # @param [Exception] ex
-      def log_exception(ex)
-        log.fatal("#{ex.class}: #{ex}")
-        log.fatal(ex.backtrace.join("\n")) unless ex.backtrace.nil?
+      def logger
+        @logger ||= Berkshelf::Logger.new(STDOUT)
       end
+      alias_method :log, :logger
     end
   end
 end

--- a/spec/unit/berkshelf/logger_spec.rb
+++ b/spec/unit/berkshelf/logger_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Berkshelf::Logger do
-  %w(info warn error fatal debug deprecate).each do |meth|
+  %w(info warn error fatal debug deprecate exception).each do |meth|
     describe "##{meth}" do
       it 'responds' do
-        expect(Berkshelf::Logger).to respond_to(meth.to_sym)
+        expect(subject).to respond_to(meth.to_sym)
       end
     end
   end

--- a/spec/unit/berkshelf/mixin/logging_spec.rb
+++ b/spec/unit/berkshelf/mixin/logging_spec.rb
@@ -5,19 +5,15 @@ describe Berkshelf::Mixin::Logging do
     Class.new { include Berkshelf::Mixin::Logging }.new
   end
 
-  describe '#log' do
+  describe '#logger' do
     it 'returns the Berkshelf::Logger' do
-      expect(subject.log).to eq(Berkshelf::Logger)
+      expect(subject.logger).to be_a(Berkshelf::Logger)
     end
   end
 
-  describe '#log_exception' do
-    it 'logs the exception and backtrace as fatal' do
-      ex = Exception.new('msg')
-      ex.stub(:backtrace).and_return(['one', 'two'])
-      subject.log.should_receive(:fatal).exactly(2).times
-
-      subject.log_exception(ex)
+  describe '#log' do
+    it 'returns the Berkshelf::Logger' do
+      expect(subject.log).to be_a(Berkshelf::Logger)
     end
   end
 end

--- a/spec/unit/berkshelf_spec.rb
+++ b/spec/unit/berkshelf_spec.rb
@@ -29,7 +29,7 @@ module Berkshelf
 
   describe '::log' do
     it 'returns Berkshelf::Logger' do
-      expect(Berkshelf.log).to eq(Berkshelf::Logger)
+      expect(Berkshelf.log).to be_a(Berkshelf::Logger)
     end
   end
 end


### PR DESCRIPTION
The previous implementation of the logger was never actually setting Berkshelf's logger when you said `Berkshelf.logger = x`. This commit makes the Berkshelf::Logger inherit from Ridley's logger and actually
works now :).
