### PR TITLE
remove Berksfile and Berksfile.lock from generated chefignore file

### DIFF
--- a/generator_files/chefignore
+++ b/generator_files/chefignore
@@ -69,8 +69,6 @@ Procfile
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 


### PR DESCRIPTION
We recommend stripping the Berksfile or Berksfile.lock from cookbooks uploaded to the Chef Server - this is wrong. These files need to be redistributed to cookbook authors and available for tools who consume them.

Currently cookbooks retrieved via a Chef Server endpoint of a Berkshelf-API server will not contain the expected Berksfile and, if an Environment Cookbook, the Berksfile.lock.
