### PR TITLE
Berks package not producing tarballs compatible with chef-solo

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -565,10 +565,8 @@ module Berkshelf
       packager.validate!
 
       outdir = Dir.mktmpdir do |temp_dir|
-        source = Berkshelf.ui.mute do
-          vendor(File.join(temp_dir, 'cookbooks'))
-        end
-        packager.run(source)
+        Berkshelf.ui.mute { vendor(File.join(temp_dir, 'cookbooks')) }
+        packager.run(temp_dir)
       end
 
       Berkshelf.formatter.package(outdir)


### PR DESCRIPTION
This seems to be a regression of #749 in that the tarball does not contain a cookbooks directory

The current code looks like this:

``` ruby
    def package(path)
      packager = Packager.new(path)
      packager.validate!

      outdir = Dir.mktmpdir do |temp_dir|
        source = Berkshelf.ui.mute do
          vendor(File.join(temp_dir, 'cookbooks'))
        end
        packager.run(source)
      end

      Berkshelf.formatter.package(outdir)
      outdir
    end
```

looks like it would work as required if changed to

``` ruby
        packager.run(outdir)
```

It's a simple change and i could look into submitting a pull request only I'll have a learning curve to go through in order to verify it.
