### PR TITLE
update generator for Vagrant 1.5.x

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -20,10 +20,6 @@ Feature: Reading a Berkshelf configuration file
           "box_url": "http://files.vagrantup.com/lucid64.box",
           "forward_port": {
             "12345": "54321"
-          },
-          "network": {
-            "bridged": true,
-            "hostonly": "12.34.56.78"
           }
         }
       }
@@ -35,8 +31,7 @@ Feature: Reading a Berkshelf configuration file
       | config.vm.box = "my_box" |
       | config.vm.box_url = "http://files.vagrantup.com/lucid64.box" |
       | config.vm.network :forwarded_port, guest: 12345, host: 54321 |
-      | config.vm.network :private_network, ip: "12.34.56.78" |
-      | config.vm.network :public_network |
+      | config.vm.network :private_network, type: "dhcp" |
     And the exit status should be 0
 
   Scenario: Using a Berkshelf configuration file that sets the vagrant-omnibus plugin chef version
@@ -53,10 +48,6 @@ Feature: Reading a Berkshelf configuration file
           "box_url": "http://files.vagrantup.com/lucid64.box",
           "forward_port": {
             "12345": "54321"
-          },
-          "network": {
-            "bridged": true,
-            "hostonly": "12.34.56.78"
           }
         }
       }
@@ -68,8 +59,7 @@ Feature: Reading a Berkshelf configuration file
       | config.vm.box = "my_box" |
       | config.vm.box_url = "http://files.vagrantup.com/lucid64.box" |
       | config.vm.network :forwarded_port, guest: 12345, host: 54321 |
-      | config.vm.network :private_network, ip: "12.34.56.78" |
-      | config.vm.network :public_network |
+      | config.vm.network :private_network, type: "dhcp" |
     And the exit status should be 0
 
   Scenario: Using a Berkshelf configuration file that sets the vagrant-omnibus plugin chef version to latest
@@ -86,10 +76,6 @@ Feature: Reading a Berkshelf configuration file
           "box_url": "http://files.vagrantup.com/lucid64.box",
           "forward_port": {
             "12345": "54321"
-          },
-          "network": {
-            "bridged": true,
-            "hostonly": "12.34.56.78"
           }
         }
       }
@@ -101,8 +87,7 @@ Feature: Reading a Berkshelf configuration file
       | config.vm.box = "my_box" |
       | config.vm.box_url = "http://files.vagrantup.com/lucid64.box" |
       | config.vm.network :forwarded_port, guest: 12345, host: 54321 |
-      | config.vm.network :private_network, ip: "12.34.56.78" |
-      | config.vm.network :public_network |
+      | config.vm.network :private_network, type: "dhcp" |
 
   Scenario: Using a partial Berkshelf configuration file
     Given I have a Berkshelf config file containing:

--- a/generator_files/Gemfile.erb
+++ b/generator_files/Gemfile.erb
@@ -2,13 +2,17 @@ source 'https://rubygems.org'
 
 gem 'berkshelf'
 
-# Uncomment these lines (and the ones in the generated Vagrantfile) if you want
-# to live on the Edge:
+# Uncomment these lines if you want to live on the Edge:
 #
-# gem "berkshelf", github: "berkshelf/berkshelf"
-# gem "vagrant", github: "mitchellh/vagrant", tag: "v1.3.5"
-# gem "vagrant-berkshelf", github: "berkshelf/vagrant-berkshelf"
-# gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus", tag: "v1.1.2"
+# group :development do
+#   gem "berkshelf", github: "berkshelf/berkshelf"
+#   gem "vagrant", github: "mitchellh/vagrant", tag: "v1.5.2"
+# end
+#
+# group :plugins do
+#   gem "vagrant-berkshelf", github: "berkshelf/vagrant-berkshelf"
+#   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
+# end
 
 <% if options[:foodcritic] -%>
 gem 'thor-foodcritic'

--- a/generator_files/Vagrantfile.erb
+++ b/generator_files/Vagrantfile.erb
@@ -1,13 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Uncomment these lines (and the ones in the generated Gemfile) if you want
-# to live on the Edge:
-#
-# Vagrant.require_plugin "vagrant-berkshelf"
-# Vagrant.require_plugin "vagrant-omnibus"
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
 
-Vagrant.configure("2") do |config|
+Vagrant.require_version ">= 1.5.0"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
@@ -36,20 +35,7 @@ Vagrant.configure("2") do |config|
   # via the IP. Host-only networks can talk to the host machine as well as
   # any other machines on the same network, but cannot be accessed (through this
   # network interface) by any external networks.
-<% if berkshelf_config.vagrant.vm.network.hostonly.present? -%>
-  config.vm.network :private_network, ip: "<%= berkshelf_config.vagrant.vm.network.hostonly %>"
-<% else %>
-  config.vm.network :private_network, ip: "192.168.33.10"
-<% end -%>
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-<% if berkshelf_config.vagrant.vm.network.bridged -%>
-  config.vm.network :public_network
-<% else %>
-  # config.vm.network :public_network
-<% end -%>
+  config.vm.network :private_network, type: "dhcp"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -104,12 +104,6 @@ module Berkshelf
     attribute 'vagrant.vm.forward_port',
       type: Hash,
       default: Hash.new
-    attribute 'vagrant.vm.network.bridged',
-      type: Boolean,
-      default: false
-    attribute 'vagrant.vm.network.hostonly',
-      type: String,
-      default: '33.33.33.10'
     attribute 'vagrant.vm.provision',
       type: String,
       default: 'chef_solo'


### PR DESCRIPTION
This also simplifies the Berkshelf configuration by removing some less common options that
a power user will just carve out of the Vagrantfile themselves.

@sethvargo 
