### PR TITLE
Remove gecode install instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,34 +11,6 @@ Manage a Cookbook or an Application's Cookbook dependencies
 
 **WARNING:** It is advised at this time that you [use Berkshelf 3](https://github.com/berkshelf/berkshelf/wiki/Howto:-Use-the-bleeding-edge). Berkshelf 2 is no longer being actively developed and has a number of significant issues related to dependency resolution that Berkshelf 3 fixes.
 
-### Manually install Gecode (temporary)
-
-The current release candidate of Vagrant Berkshelf requires you to have Gecode installed on your machine. In the future this process will be provided in an easy and automated fashion.
-
-#### OSX
-
-    $ cd $( brew --prefix )
-    $ git checkout 3c5ca25 Library/Formula/gecode.rb
-    $ brew install gecode
-
-#### Debian and Ubuntu
-
-    $ sudo apt-get install libgecode-dev
-
-##### Source
-
-    $ curl -O http://www.gecode.org/download/gecode-3.7.3.tar.gz
-    $ tar zxvf gecode-3.7.3.tar.gz
-    $ ./configure --disable-doc-dot \
-        --disable-doc-search \
-        --disable-doc-tagfile \
-        --disable-doc-chm \
-        --disable-doc-docset \
-        --disable-qt \
-        --disable-examples
-    $ make
-    $ (sudo) make install
-
 ### Gem Installation
 
 Add Berkshelf to your repository's `Gemfile`:


### PR DESCRIPTION
Gecode is installed via dep-selector-libgecode now so this step isn't
necessary.

Somewhat related is this: https://tickets.opscode.com/browse/CHEF-5207 which is a bug we'll fix (but until then, users most likely will only encounter if they're on newest ubuntu and following the instructions on the readme).
