### PR TITLE
Celluloid worker pool requires at least 2 cores

### DIFF
--- a/lib/berkshelf/installer.rb
+++ b/lib/berkshelf/installer.rb
@@ -10,7 +10,7 @@ module Berkshelf
     def initialize(berksfile)
       @berksfile  = berksfile
       @lockfile   = berksfile.lockfile
-      @worker     = Worker.pool(size: [(Celluloid.cores - 1), 1].max, args: [berksfile])
+      @worker     = Worker.pool(size: [(Celluloid.cores - 1), 2].max, args: [berksfile])
     end
 
     def build_universe


### PR DESCRIPTION
@reset this is broken :frowning: 

``` text
Failures:

  1) Berkshelf::Installer#build_universe sends the message #universe on each source
     Failure/Error: subject { described_class.new(berksfile) }
     ArgumentError:
       minimum pool size is 2
     # (celluloid):0:in `remote procedure call'
     # /opt/chefdk/embedded/apps/berkshelf/lib/berkshelf/installer.rb:13:in `initialize'
     # /opt/chefdk/embedded/apps/berkshelf/spec/unit/berkshelf/installer_spec.rb:6:in `new'
     # /opt/chefdk/embedded/apps/berkshelf/spec/unit/berkshelf/installer_spec.rb:6:in `block (2 levels) in <top (required)>'
     # /opt/chefdk/embedded/apps/berkshelf/spec/unit/berkshelf/installer_spec.rb:19:in `block (3 levels) in <top (required)>'
```
