### PR TITLE
minimum viable depsolving exception handling fix

### DIFF
--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -69,11 +69,13 @@ module Berkshelf
     attr_reader :demands
 
     # @param [Array<Dependency>] demands
-    def initialize(demands)
+    def initialize(demands, original_exception)
       @demands = demands
+      @original_exception = original_exception
     end
 
     def to_s
+      @original_exception.to_s +
       "Unable to find a solution for demands: #{demands.join(', ')}"
     end
   end

--- a/lib/berkshelf/resolver.rb
+++ b/lib/berkshelf/resolver.rb
@@ -79,8 +79,8 @@ module Berkshelf
 
         dependency
       end
-    rescue Solve::Errors::NoSolutionError
-      raise NoSolutionError.new(demands)
+    rescue Solve::Errors::NoSolutionError => e
+      raise NoSolutionError.new(demands, e)
     end
 
     # Retrieve the given demand from the resolver


### PR DESCRIPTION
If you typo the "chef-client" cookbook as "chef_client" this code
produces:

```
  Unable to satisfy constraints on package chef_client, which does not
  exist, due to solution constraint (sk_role_base = 0.0.16). Solution
  constraints that may result in a constraint on chef_client:
  [(sk_role_base = 0.0.16) -> (chef_client >= 0.0.0)]
  Missing artifacts: chef_client
  Demand that cannot be met: (sk_role_base = 0.0.16)
  Unable to find a solution for demands: sk_role_base (0.0.16)
```

Previous code only prints:

```
  Unable to find a solution for demands: sk_role_base (0.0.16)
```

Which is useless to figure out what you need to fix.
