### PR TITLE
Prefer https over http.

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -207,7 +207,7 @@ module Berkshelf
       if args.first == :opscode
         Berkshelf.formatter.deprecation "Your Berksfile contains a site location pointing to the Opscode Community " +
           "Site (site :opscode). Site locations have been replaced by the source location. Change this to: " +
-          "'source \"http://api.berkshelf.com\"' to remove this warning. For more information visit " +
+          "'source \"https://api.berkshelf.com\"' to remove this warning. For more information visit " +
           "https://github.com/berkshelf/berkshelf/wiki/deprecated-locations"
         source(DEFAULT_API_URL)
         return


### PR DESCRIPTION
When using the old format Berksfile with Berkshelf 3.x, the following deprecation message is displayed.

```
DEPRECATED: Your Berksfile contains a site location pointing to the Opscode Community Site (site :opscode). Site locations have been replaced by the source location. Change this to: 'source "http://api.berkshelf.com"' to remove this warning. For more information visit https://github.com/berkshelf/berkshelf/wiki/deprecated-locations
```

This change just modified the message so that it encourages the use of `https` over `http`.
