### PR TITLE
Handle when Celluloid.cores is nil

### DIFF
--- a/lib/berkshelf/installer.rb
+++ b/lib/berkshelf/installer.rb
@@ -10,7 +10,7 @@ module Berkshelf
     def initialize(berksfile)
       @berksfile  = berksfile
       @lockfile   = berksfile.lockfile
-      @worker     = Worker.pool(size: [(Celluloid.cores - 1), 2].max, args: [berksfile])
+      @worker     = Worker.pool(size: [(Celluloid.cores.to_i - 1), 2].max, args: [berksfile])
     end
 
     def build_universe


### PR DESCRIPTION
It is possible for Celluloid.cores to return nil instead of an integer on some platforms. This calls to_i which will turn nil into 0 which will cause the worker pool size to be 2. I'm not sure if this is the best solution and I've already made a better fix for Celluloid (celluloid/celluloid/pull/413) in the case where I was running into this.
