### PR TITLE
remove duplicate faraday dependency

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable',       '~> 2.3.4'
   s.add_dependency 'buff-shell_out',    '~> 0.1'
   s.add_dependency 'chozo',             '>= 0.6.1'
-  s.add_dependency 'faraday',           '~> 0.8.5'
   s.add_dependency 'hashie',            '>= 2.0.2'
   s.add_dependency 'minitar',           '~> 0.5.4'
   s.add_dependency 'retryable',         '~> 1.3.3'
@@ -42,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solve',             '~> 0.8.2'
   s.add_dependency 'thor',              '~> 0.18.0'
   s.add_dependency 'rbzip2',            '~> 0.2.0'
-  s.add_dependency 'faraday',           '~> 0.8.0' # lock tranisitive dependency of Ridley
+  s.add_dependency 'faraday',           '~> 0.8.5' # lock tranisitive dependency of Ridley
 
   s.add_development_dependency 'aruba',         '~> 0.5'
   s.add_development_dependency 'cane',          '~> 2.5'


### PR DESCRIPTION
Bundler 1.6.0 fails to install berkshelf v2.0.16 due to a duplicated `faraday` dep in the gemspec.  This PR removed the duplicate line, and set the dependency to the highest version of the two existing ones (`0.8.5`)

```
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    duplicate dependency on faraday (~> 0.8.0), (~> 0.8.5) use:
    add_runtime_dependency 'faraday', '~> 0.8.0', '~> 0.8.5'
    from /opt/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.0/lib/bundler/gem_helper.rb:57:in `build_gem'
    from /opt/rubies/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.0/lib/bundler/gem_helper.rb:39:in `block in install'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/rake-0.9.6/lib/rake/task.rb:228:in `call'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/rake-0.9.6/lib/rake/task.rb:228:in `block in execute'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/rake-0.9.6/lib/rake/task.rb:223:in `each'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/rake-0.9.6/lib/rake/task.rb:223:in `execute'
    from /var/cache/omnibus/src/berkshelf/Thorfile:13:in `build'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/runner.rb:36:in `method_missing'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/command.rb:29:in `run'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/command.rb:128:in `run'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    from /opt/opscode-analytics/embedded/lib/ruby/gems/2.1.0/gems/thor-0.18.1/bin/thor:6:in `<top (required)>'
    from /opt/opscode-analytics/embedded/bin/thor:23:in `load'
    from /opt/opscode-analytics/embedded/bin/thor:23:in `<main>'
```
