### PR TITLE
Fix typo in show cmd description

### DIFF
--- a/lib/berkshelf/commands/shelf.rb
+++ b/lib/berkshelf/commands/shelf.rb
@@ -19,7 +19,7 @@ module Berkshelf
     end
 
     method_option :version, aliases: '-v', type: :string, desc: 'Version to show'
-    desc 'show', 'Display showrmation about a cookbook in the Berkshelf shelf'
+    desc 'show', 'Display information about a cookbook in the Berkshelf shelf'
     def show(name)
       cookbooks = find(name, options[:version])
 


### PR DESCRIPTION
Fix typo in show cmd description
