### PR TITLE
Fixed a regression when passing :ssh as the protocol for github locations.

### DIFF
--- a/lib/berkshelf/locations/github.rb
+++ b/lib/berkshelf/locations/github.rb
@@ -1,7 +1,12 @@
 module Berkshelf
   class GithubLocation < GitLocation
     def initialize(dependency, options = {})
-      options[:git] = "git://github.com/#{options.delete(:github)}.git"
+      if options[:protocol] == :ssh
+        uri = 'git@github.com:%{github}.git'
+      else
+        uri = 'git://github.com/%{github}.git'
+      end
+      options[:git] = uri % {:github => options.delete(:github)}
       super
     end
   end

--- a/spec/unit/berkshelf/locations/github_spec.rb
+++ b/spec/unit/berkshelf/locations/github_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+module Berkshelf
+  describe GithubLocation do
+    let(:dependency) { double(name: 'bacon') }
+
+    describe '.initialize' do
+      it 'sets the github uri' do
+        instance = described_class.new(dependency, github: 'berkshelf/berkshelf')
+        expect(instance.uri).to eq('git://github.com/berkshelf/berkshelf.git')
+      end
+
+      it 'uses SSH schema when protocol is passed' do
+        instance = described_class.new(dependency, github: 'berkshelf/berkshelf',
+          protocol: :ssh)
+        expect(instance.uri).to eq('git@github.com:berkshelf/berkshelf.git')
+      end
+    end 
+  end
+end


### PR DESCRIPTION
The `github:` option used to properly mangle the URI for the repository when you passed `protocol: :ssh`. A recent `bundle berks update` resulted in an unknown repo error. Added a regression test and basic spec coverage for the GithubLocation class as well as respecting the `protocol: :ssh` situation.
