### PR TITLE
ssl.verify option is ignored

### DIFF
--- a/lib/berkshelf/source.rb
+++ b/lib/berkshelf/source.rb
@@ -10,7 +10,7 @@ module Berkshelf
     # @param [String, Berkshelf::SourceURI] uri
     def initialize(uri)
       @uri        = SourceURI.parse(uri)
-      @api_client = APIClient.new(uri)
+      @api_client = APIClient.new(uri, :ssl => {:verify => Berkshelf::Config.instance.ssl.verify})
       @universe   = nil
     end
 


### PR DESCRIPTION
Setting ssl.verify=false is ignored when fetching cookbook index.

```
$ berks install
DL is deprecated, please use Fiddle
Resolving cookbook dependencies...
Fetching cookbook index from https://api.berkshelf.com...
c:/Ruby200/lib/ruby/2.0.0/net/http.rb:918:in `connect': SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (Faraday::SSLError)
        from c:/Ruby200/lib/ruby/2.0.0/net/http.rb:918:in `block in connect'
        from c:/Ruby200/lib/ruby/2.0.0/timeout.rb:66:in `timeout'
        from c:/Ruby200/lib/ruby/2.0.0/net/http.rb:918:in `connect'
        from c:/Ruby200/lib/ruby/2.0.0/net/http.rb:862:in `do_start'
        from c:/Ruby200/lib/ruby/2.0.0/net/http.rb:851:in `start'
        from c:/Ruby200/lib/ruby/2.0.0/net/http.rb:1367:in `request'
        from c:/Ruby200/lib/ruby/2.0.0/net/http.rb:1126:in `get'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/faraday-0.9.0/lib/faraday/adapter/net_http.rb:78:in `perform_request'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/faraday-0.9.0/lib/faraday/adapter/net_http.rb:39:in `call'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/faraday-0.9.0/lib/faraday/request/retry.rb:87:in `call'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/faraday-0.9.0/lib/faraday/response.rb:8:in `call'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/faraday-0.9.0/lib/faraday/response.rb:8:in `call'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/faraday-0.9.0/lib/faraday/rack_builder.rb:139:in `build_response'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/faraday-0.9.0/lib/faraday/connection.rb:377:in `run_request'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/faraday-0.9.0/lib/faraday/connection.rb:140:in `get'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/berkshelf-api-client-1.2.0/lib/berkshelf/api_client/connection.rb:62:in `universe'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/berkshelf-3.1.2/lib/berkshelf/source.rb:22:in `build_universe'
        from c:/Ruby200/lib/ruby/gems/2.0.0/gems/berkshelf-3.1.2/lib/berkshelf/installer.rb:21:in `block (2 levels) in build_universe'
```

~/.berkshelf/config.json

``` json
{
  "ssl": {
    "verify": false
  }
}
```
