### PR TITLE
Follow redirects

### DIFF
--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -2,6 +2,8 @@ require 'open-uri'
 require 'retryable'
 require 'addressable/uri'
 
+require_relative 'core_ext/openuri'
+
 module Berkshelf
   class CommunityREST < Faraday::Connection
     class << self
@@ -80,6 +82,8 @@ module Berkshelf
 
       builder = Faraday::Builder.new do |b|
         b.response :parse_json
+        b.response :follow_redirects
+
         b.request :retry,
           max: @retries,
           interval: @retry_interval,

--- a/lib/berkshelf/core_ext/openuri.rb
+++ b/lib/berkshelf/core_ext/openuri.rb
@@ -1,0 +1,36 @@
+#
+# Patch to allow open-uri to follow safe (http to https) and unsafe
+# redirections (https to http).
+#
+# Original gist URL:
+# https://gist.github.com/1271420
+#
+# Relevant issue:
+# http://redmine.ruby-lang.org/issues/3719
+#
+# Source here:
+# https://github.com/ruby/ruby/blob/trunk/lib/open-uri.rb
+#
+module OpenURI
+  class <<self
+    alias_method :open_uri_original, :open_uri
+
+    def redirectable_safe?(uri1, uri2)
+      uri1.scheme.downcase == uri2.scheme.downcase || (uri1.scheme.downcase == "http" && uri2.scheme.downcase == "https")
+    end
+
+    def redirectable_all?(uri1, uri2)
+      redirectable_safe?(uri1, uri2) || (uri1.scheme.downcase == "https" && uri2.scheme.downcase == "http")
+    end
+  end
+
+  # Patches the original open_uri method to follow all redirects
+  def self.open_uri(name, *rest, &block)
+    class << self
+      remove_method :redirectable?
+      alias_method  :redirectable?, :redirectable_all?
+    end
+
+    self.open_uri_original(name, *rest, &block)
+  end
+end


### PR DESCRIPTION
@reset this allows Berkshelf 2 to follow redirects from http -> https. There's a bug in Ruby core (issues and gists are linked in the provided code), that prevents redirects from being followed correctly.
