### PR TITLE
Make the upload command follow the dependencies

### DIFF
--- a/lib/berkshelf/uploader.rb
+++ b/lib/berkshelf/uploader.rb
@@ -100,7 +100,7 @@ module Berkshelf
           cookbooks[dependency] ||= lockfile.retrieve(dependency)
         end
 
-        cookbooks.values.sort
+        cookbooks.values
       end
 
       # Validate that the given cookbook does not have "bad" files. Currently


### PR DESCRIPTION
By removing ‘sort’ here, the berks upload command will upload the
cookbooks using the generated dependency order instead of doing this in
alphabetical order.

As far as I can tell the extra ‘sort’ here is purely cosmetic, but we
run a (to be open sourced next week) tool called Chef-Guard that does
some additional checks in front of your Chef server which actually
needs the cookbooks to arrive in the correct order (in terms of
dependencies).

I know you just released a new version half a day ago, but as we are
now doing our final tests with Chef-Guard working towards a first
release it would really awesome if this can make it in a new release as
soon as possible.

Thanks!

If there are any questions or concerns, just ping me so I can explain
more about the use case.
