### PR TITLE
Rubocop'd

### DIFF
--- a/generator_files/Berksfile.erb
+++ b/generator_files/Berksfile.erb
@@ -1,4 +1,4 @@
-source "https://supermarket.getchef.com"
+source 'https://supermarket.getchef.com'
 <% if options[:chef_minitest] -%>
 
 group :integration do

--- a/generator_files/metadata.rb.erb
+++ b/generator_files/metadata.rb.erb
@@ -1,12 +1,11 @@
-name             '<%= name %>'
-maintainer       '<%= maintainer %>'
+name '<%= name %>'
+maintainer '<%= maintainer %>'
 maintainer_email '<%= maintainer_email %>'
-license          '<%= license_name %>'
-description      'Installs/Configures <%= name %>'
+license '<%= license_name %>'
+description 'Installs/Configures <%= name %>'
 long_description 'Installs/Configures <%= name %>'
 <% if options[:scmversion] -%>
-version          IO.read(File.join(File.dirname(__FILE__), 'VERSION'))
+version IO.read(File.join(File.dirname(__FILE__), 'VERSION'))
 <% else -%>
-version          '0.1.0'
+version '0.1.0'
 <% end -%>
-


### PR DESCRIPTION
Updated a couple of generator files with rubocop compliant changes.

The goal of this is to make the default generated files compliant to rubocop.

Vertical whitespacing (as demonstracted in metadata.rb.erb) is not rubocop compliant. While vertical whitespace might seem more readable for a generated file, it's almost never a good idea in code that will change (and as we all know, code changes!) Initially, vertical whitespace will look like this:

```
name             'my-face'
maintainer       'My Name'
maintainer_email 'myface@example.com'
license          'All rights reserved'
description      'Installs/Configures my-face'
long_description 'Installs/Configures my-face'
version          '0.1.0'

depends          'windows','~> 1.30.0'
```

Inevitably, vertical whitespace files will look like this.

```
name                    'my-face'
maintainer   'My Name'
maintainer_email      'myface@example.com'
license                'All rights reserved'
description   'Installs/Configures my-face'
long_description               'Installs/Configures my-face'

version                     '0.1.0'

depends   'windows','~> 1.30.0'
```

What you really want is something that's maintainable and enforceable. You want this:

```
name 'my-face'
maintainer 'My Name'
maintainer_email 'myface@example.com'
license 'All rights reserved'
description 'Installs/Configures my-face'
long_description 'Installs/Configures my-face'

version '0.1.0'

depends 'windows','~> 1.30.0'
```

The only way to really enforce this is to use a linter, ala Rubocop, to enforce a style standard through your build.

Can we please use rubocop as a standard? This is a generally accepted standard in the ruby community.
