### PR TITLE
Add version information to edges of berks viz

### DIFF
--- a/lib/berkshelf/visualizer.rb
+++ b/lib/berkshelf/visualizer.rb
@@ -62,7 +62,7 @@ module Berkshelf
       nodes.each do |node|
         adjacencies(node).each do |edge|
           edge.each do |name, version|
-            if version == Semverse::DEFAULT_CONSTRAINT then
+            if version == Semverse::DEFAULT_CONSTRAINT
               label = ""
             else
               label = " #{version}"

--- a/spec/unit/berkshelf/visualizer_spec.rb
+++ b/spec/unit/berkshelf/visualizer_spec.rb
@@ -30,11 +30,11 @@ module Berkshelf
       context 'when the graphviz command succeeds' do
         it 'builds a png from a Lockfile' do
           outfile = tmp_path.join('test-graph.png').to_s
-          lockfile = Lockfile.from_file fixtures_path.join('lockfiles/default.lock').to_s
+          lockfile = Lockfile.from_file(fixtures_path.join('lockfiles/default.lock').to_s)
 
           Visualizer.from_lockfile(lockfile).to_png(outfile)
 
-          expect(File.exists? outfile).to be true
+          expect(File.exists?(outfile)).to be true
         end
       end
     end


### PR DESCRIPTION
This branch patch successfully adds version information to the edges of the nodes in `berks viz`.

Unfortunately, the berkshelf README doesn't include information on how to run the tests and I am new to ruby so I don't know how to get started. If that information is added somewhere, and this functionality is wanted, I'd be happy to clean this up to get it included upstream.
