### PR TITLE
Don't exclude CHANGELOG* files from the tarball

### DIFF
--- a/generator_files/chefignore
+++ b/generator_files/chefignore
@@ -75,7 +75,6 @@ tmp
 # Cookbooks #
 #############
 CONTRIBUTING
-CHANGELOG*
 
 # Strainer #
 ############


### PR DESCRIPTION
These files are used by supermarket for display the changelog tab and notify the changes to the cookbook followers
