### PR TITLE
Include the forgotten :graphviz tag in visualizer_spec.

### DIFF
--- a/spec/unit/berkshelf/visualizer_spec.rb
+++ b/spec/unit/berkshelf/visualizer_spec.rb
@@ -27,7 +27,7 @@ module Berkshelf
         end
       end
 
-      context 'when the graphviz command succeeds' do
+      context 'when the graphviz command succeeds', :graphviz do
         it 'builds a png from a Lockfile' do
           outfile = tmp_path.join('test-graph.png').to_s
           lockfile = Lockfile.from_file(fixtures_path.join('lockfiles/default.lock').to_s)


### PR DESCRIPTION
We have detected this in our Chef DK tests which disable visualizer specs since graphviz is not included with Chef DK. Currently we are running berks specs like [this](https://github.com/opscode/chef-dk/blob/master/lib/chef-dk/command/verify.rb#L80). One of the examples are failing since it requires graphviz but not tagged correctly:

```
Failures:

  1) Berkshelf::Visualizer#to_png when the graphviz command succeeds builds a png from a Lockfile
     Failure/Error: Unable to find matching line from backtrace
     Berkshelf::GraphvizNotInstalled:
       Berkshelf::GraphvizNotInstalled
     # /opt/chefdk/embedded/apps/berkshelf/lib/berkshelf/visualizer.rb:92:in `to_png'
     # /opt/chefdk/embedded/apps/berkshelf/spec/unit/berkshelf/visualizer_spec.rb:35:in `block (4 levels) in <module:Berkshelf>'
```
