### PR TITLE
Change 'berkshelf shelf uninstall' -> 'berks shelf uninstall'

### DIFF
--- a/lib/berkshelf/cookbook_store.rb
+++ b/lib/berkshelf/cookbook_store.rb
@@ -121,7 +121,7 @@ module Berkshelf
         msg << "of a name attribute as a bug.\n\n"
         msg << "You can remove each cookbook in #{skipped_cookbooks} from the Berkshelf shelf "
         msg << "by using the `berks shelf uninstall` command:\n\n"
-        msg << "    $ berkshelf shelf uninstall <name>"
+        msg << "    $ berks shelf uninstall <name>"
         Berkshelf.log.warn msg
       end
 


### PR DESCRIPTION
When cookbooks don't have the `name` attribute in metadata.rb, you get an error like the one below.  The command it gives has a typo, so this PR simply fixes that.

```
[2014-08-27T13:33:49.838597 #81539]  WARN -- : Skipping cookbooks ["cookbook1-0.0.10", "cookbook2-0.0.1"]. Berkshelf can only interact with cookbooks which have defined the `name` attribute in their metadata.rb. If you are the maintainer of any of the ab
ove cookbooks, please add the name attribute to your cookbook. If you are not the maintainer, please file an issue or report the lack of a name attribute as a bu
g.

You can remove each cookbook in ["cookbook1-0.0.10", "cookbook2-0.0.1"] from the Berkshelf shelf
 by using the `berks shelf uninstall` command:
    $ berkshelf shelf uninstall <name>
```

Notice that `berkshelf` should be `berks`.
