### PR TITLE
Fix `berks viz` when `pwd` contains spaces

### DIFF
--- a/lib/berkshelf/visualizer.rb
+++ b/lib/berkshelf/visualizer.rb
@@ -92,7 +92,7 @@ module Berkshelf
         raise GraphvizNotInstalled.new
       end
 
-      command = "dot -T png #{tempfile.path} -o #{outfile}"
+      command = "dot -T png #{tempfile.path} -o '#{outfile}'"
       response = shell_out(command)
 
       unless response.success?


### PR DESCRIPTION
On my OS X laptop, I have spaces in my `pwd` where I do cookbook work.  I tried doing `graph viz`, but it complained with the following:

```
$ berks viz
The Graphviz command `dot -T png /var/folders/x7/8sms15l54t11h6j6nlvgk8hh0000gn/T/dotdotfile20140828-72973-1wniqtf -o /Users/ameir/Aptana Studio 3 Workspace/Chef/cookbooks/my_cookbook/graph.png` failed to execute properly. Here is the standard error from the command:

Error: dot: can't open Studio
Error: dot: can't open 3
Error: dot: can't open Workspace/Chef/cookbooks/my_cookbook/graph.png
```

This PR simply adds quotes to fix this.
