### PR TITLE
Add rubocop.yml to cookbook skeleton

### DIFF
--- a/generator_files/rubocop.yml
+++ b/generator_files/rubocop.yml
@@ -1,0 +1,11 @@
+LineLength:
+  Max: 200
+
+HashSyntax:
+  EnforcedStyle: ruby19
+
+SingleSpaceBeforeFirstArg:
+  Enabled: false
+
+TrailingComma:
+  Enabled: false

--- a/lib/berkshelf/init_generator.rb
+++ b/lib/berkshelf/init_generator.rb
@@ -17,6 +17,10 @@ module Berkshelf
       type: :boolean,
       default: true
 
+    class_option :rubocop,
+      type: :boolean,
+      default: false
+
     class_option :chefignore,
       type: :boolean,
       default: true
@@ -67,6 +71,10 @@ module Berkshelf
 
       template 'Berksfile.erb', target.join('Berksfile')
       template 'Thorfile.erb', target.join('Thorfile')
+
+      if options[:rubocop]
+        copy_file 'rubocop.yml', target.join('.rubocop.yml')
+      end
 
       if options[:chefignore]
         copy_file 'chefignore', target.join(Ridley::Chef::Chefignore::FILENAME)


### PR DESCRIPTION
The option defaults to false.
I think this is a valid option to have, as most of the Opscode cookbooks also use rubocop for linting.
