### PR TITLE
Fixing _PaxHeader_ error on berks upload

### DIFF
--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -18,6 +18,7 @@ module Berkshelf
         else
           raise Berkshelf::UnknownCompressionType.new(target)
         end
+        FileUtils.rm_rf Dir.glob("#{destination}/**/PaxHeader")
         destination
       end
 


### PR DESCRIPTION
```
E, [2014-10-09T17:07:36.832664 #19439] ERROR -- : Cookbook file attributes/PaxHeader/groups.rb has a ruby syntax error:
E, [2014-10-09T17:07:36.832905 #19439] ERROR -- : ~/.berkshelf/cookbooks/zap-0.6.0/attributes/PaxHeader/groups.rb:1: syntax error, unexpected tIDENTIFIER, expecting end-of-input
```

Minitar creates PaxHeader directories while installing (unpacking) the cookbooks into the berkshelf cache.
This will remove those directories when they are created
