### PR TITLE
Lock down rspec at a fully functional version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :guard do
   gem 'guard-cucumber'
   gem 'guard-rspec'
   gem 'guard-spork'
+  gem 'rspec',         '<3'
 
   require 'rbconfig'
 


### PR DESCRIPTION
Rspec 3, which is currently installed by performing a `bundle install`, is incompatible with the version of spork installed by the same (see [stackoverflow](http://stackoverflow.com/questions/24030907/spork-0-9-2-and-rspec-3-0-0-uninitialized-constant-rspeccorecommandline-n)). Restricting rspec to less than 3, installs a compatible version.
