### PR TITLE
add 'verify' command to Berkshelf

### DIFF
--- a/features/commands/verify.feature
+++ b/features/commands/verify.feature
@@ -1,0 +1,29 @@
+Feature: berks verify
+  Scenario: running verify when there is no Lockfile present
+    Given a cookbook named "sparkle_motion"
+    And I cd to "sparkle_motion"
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      metadata
+      """
+    And I run `berks verify`
+    Then the output should contain:
+      """
+      Lockfile not found! Run `berks install` to create the lockfile.
+      """
+    And the exit status should be "LockfileNotFound"
+
+  Scenario: running verify when there is a valid Lockfile present
+    Given a cookbook named "sparkle_motion"
+    And I cd to "sparkle_motion"
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      metadata
+      """
+    When I successfully run `berks install`
+    And I successfully run `berks verify`
+    Then the output should contain:
+      """
+      Verifying (1) cookbook(s)...
+      Verified.
+      """

--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -220,6 +220,7 @@ require_relative 'berkshelf/logger'
 require_relative 'berkshelf/resolver'
 require_relative 'berkshelf/source'
 require_relative 'berkshelf/source_uri'
+require_relative 'berkshelf/validator'
 
 Ridley.logger          = Berkshelf.logger
 Berkshelf.logger.level = Logger::WARN

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -619,6 +619,18 @@ module Berkshelf
       destination
     end
 
+    # Perform a validation with `Validator#validate` on each cached cookbook associated
+    # with the Lockfile of this Berksfile.
+    #
+    # This function will return true or raise the first errors encountered.
+    def verify
+      validate_lockfile_present!
+      validate_lockfile_trusted!
+      Berkshelf.formatter.msg "Verifying (#{lockfile.cached.length}) cookbook(s)..."
+      Validator.validate(lockfile.cached)
+      true
+    end
+
     # Visualize the current Berksfile as a "graph" using DOT.
     #
     # @param [String] outfile

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -389,6 +389,16 @@ module Berkshelf
 
     method_option :berksfile,
       type: :string,
+      default: nil
+    desc "verify", "Perform a quick validation on the contents of your resolved cookbooks"
+    def verify
+      berksfile = Berksfile.from_options(options)
+      berksfile.verify
+      Berkshelf.formatter.msg "Verified."
+    end
+
+    method_option :berksfile,
+      type: :string,
       default: nil,
       desc: 'Path to a Berksfile to operate off of.',
       aliases: '-b',

--- a/lib/berkshelf/lockfile.rb
+++ b/lib/berkshelf/lockfile.rb
@@ -39,7 +39,7 @@ module Berkshelf
     #   the Berksfile for this Lockfile
     attr_reader :berksfile
 
-    # @return [Hash]
+    # @return [Lockfile::Graph]
     #   the dependency graph
     attr_reader :graph
 
@@ -216,6 +216,11 @@ module Berkshelf
       end
     end
 
+    # @return [Array<CachedCookbook>]
+    def cached
+      graph.locks.values.collect { |dependency| dependency.cached_cookbook }
+    end
+
     # The list of dependencies constrained in this lockfile.
     #
     # @return [Array<Berkshelf::Dependency>]
@@ -258,6 +263,10 @@ module Berkshelf
     # @return [Dependency]
     def add(dependency)
       @dependencies[Dependency.name(dependency)] = dependency
+    end
+
+    def locks
+      graph.locks
     end
 
     # Retrieve information about a given cookbook that is in this lockfile.

--- a/lib/berkshelf/uploader.rb
+++ b/lib/berkshelf/uploader.rb
@@ -31,7 +31,7 @@ module Berkshelf
                   end
 
       # Perform all validations first to prevent partially uploaded cookbooks
-      cookbooks.each { |cookbook| validate_files!(cookbook) }
+      Validator.validate_files(cookbooks)
 
       upload(cookbooks)
       cookbooks
@@ -110,22 +110,6 @@ module Berkshelf
         else
           cookbooks.values.sort
         end
-      end
-
-      # Validate that the given cookbook does not have "bad" files. Currently
-      # this means including spaces in filenames (such as recipes)
-      #
-      # @param [CachedCookbook] cookbook
-      #  the Cookbook to validate
-      def validate_files!(cookbook)
-        path = cookbook.path.to_s
-
-        files = Dir.glob(File.join(path, '**', '*.rb')).select do |f|
-          parent = Pathname.new(path).dirname.to_s
-          f.gsub(parent, '') =~ /[[:space:]]/
-        end
-
-        raise InvalidCookbookFiles.new(cookbook, files) unless files.empty?
       end
   end
 end

--- a/lib/berkshelf/validator.rb
+++ b/lib/berkshelf/validator.rb
@@ -1,0 +1,37 @@
+module Berkshelf
+  module Validator
+    class << self
+      # Perform a complete cookbook validation checking:
+      #   * File names for inappropriate characters
+      #   * Invalid Ruby syntax
+      #   * Invalid ERB templates
+      #
+      # @param [Array<CachedCookbook>, CachedCookbook] cookbooks
+      #   the Cookbook(s) to validate
+      def validate(cookbooks)
+        Array(cookbooks).each do |cookbook|
+          validate_files(cookbook)
+          cookbook.validate
+        end
+      end
+
+      # Validate that the given cookbook does not have "bad" files. Currently
+      # this means including spaces in filenames (such as recipes)
+      #
+      # @param [Array<CachedCookbook>, CachedCookbook] cookbooks
+      #  the Cookbook(s) to validate
+      def validate_files(cookbooks)
+        Array(cookbooks).each do |cookbook|
+          path = cookbook.path.to_s
+
+          files = Dir.glob(File.join(path, '**', '*.rb')).select do |f|
+            parent = Pathname.new(path).dirname.to_s
+            f.gsub(parent, '') =~ /[[:space:]]/
+          end
+
+          raise InvalidCookbookFiles.new(cookbook, files) unless files.empty?
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/berkshelf/uploader_spec.rb
+++ b/spec/unit/berkshelf/uploader_spec.rb
@@ -43,35 +43,6 @@ module Berkshelf
       end
     end
 
-    describe '#validate_files!' do
-      before { Uploader.send(:public, :validate_files!) }
-
-      let(:cookbook) { double('cookbook', cookbook_name: 'cookbook', path: 'path') }
-
-      it 'raises an error when the cookbook has spaces in the files' do
-        allow(Dir).to receive(:glob).and_return(['/there are/spaces/in this/recipes/default.rb'])
-        expect {
-          subject.validate_files!(cookbook)
-        }.to raise_error
-      end
-
-      it 'does not raise an error when the cookbook is valid' do
-        allow(Dir).to receive(:glob).and_return(['/there-are/no-spaces/in-this/recipes/default.rb'])
-        expect {
-          subject.validate_files!(cookbook)
-        }.to_not raise_error
-      end
-
-      it 'does not raise an exception with spaces in the path' do
-        allow(Dir).to receive(:glob).and_return(['/there are/spaces/in this/recipes/default.rb'])
-        allow_any_instance_of(Pathname).to receive(:dirname).and_return('/there are/spaces/in this')
-
-        expect {
-          subject.validate_files!(cookbook)
-        }.to_not raise_error
-      end
-    end
-
     describe '#run' do
       let(:options) { Hash.new }
 

--- a/spec/unit/berkshelf/validator_spec.rb
+++ b/spec/unit/berkshelf/validator_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Berkshelf::Validator do
+  describe '#validate_files' do
+    let(:cookbook) { double('cookbook', cookbook_name: 'cookbook', path: 'path') }
+
+    it 'raises an error when the cookbook has spaces in the files' do
+      allow(Dir).to receive(:glob).and_return(['/there are/spaces/in this/recipes/default.rb'])
+      expect {
+        subject.validate_files(cookbook)
+      }.to raise_error
+    end
+
+    it 'does not raise an error when the cookbook is valid' do
+      allow(Dir).to receive(:glob).and_return(['/there-are/no-spaces/in-this/recipes/default.rb'])
+      expect {
+        subject.validate_files(cookbook)
+      }.to_not raise_error
+    end
+
+    it 'does not raise an exception with spaces in the path' do
+      allow(Dir).to receive(:glob).and_return(['/there are/spaces/in this/recipes/default.rb'])
+      allow_any_instance_of(Pathname).to receive(:dirname).and_return('/there are/spaces/in this')
+
+      expect {
+        subject.validate_files(cookbook)
+      }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
This will perform a ruby syntax, erb syntax, and file name verification on all cookbooks installed by a given Berksfile.

Right now this only grabs the first error and displays it. We can collect all exceptions and output a digest at a later point.

/cc @sethvargo 
