### PR TITLE
Make extensions loadable via berkshelf config.json

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -49,6 +49,8 @@ module Berkshelf
     #   Group(s) to include which will cause any dependencies marked as a member of the
     #   group to be installed and all others to be ignored
     def initialize(path, options = {})
+      Berkshelf.config.extensions.each(&method(:extension))
+
       @filepath         = File.expand_path(path)
       @dependencies     = Hash.new
       @sources          = Hash.new

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -75,6 +75,10 @@ module Berkshelf
       end
     end
 
+    attribute 'extensions',
+      type: Array,
+      default: [],
+      required: false
     attribute 'chef.chef_server_url',
       type: String,
       default: Berkshelf.chef_config.chef_server_url


### PR DESCRIPTION
Re: #1021 

Things you will want in every config should be able to be loaded via a config.json entry.

Perhaps we also want this for things like berks-api sources?
