### PR TITLE
fix chefignore for files in sub directories

### DIFF
--- a/features/commands/vendor.feature
+++ b/features/commands/vendor.feature
@@ -109,3 +109,23 @@ Feature: Vendoring cookbooks to a directory
     When I successfully run `berks vendor path/to/cukebooks`
     Then the directory "path/to/cukebooks/fake" should contain version "1.0.0" of the "fake" cookbook
 
+  Scenario: vendoring with a chefignore file and an excluded file in a sub directory
+    Given a cookbook named "chefignore_subdirectories"
+    And I cd to "chefignore_subdirectories"
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      metadata
+      """
+    And I write to "chefignore" with:
+      """
+      *~
+      """
+    And an empty file named "test0"
+    And an empty file named "test1~"
+    And an empty file named "subdir/test2~"
+    When I successfully run `berks vendor vendor`
+    And I cd to "vendor/chefignore_subdirectories"
+    And a file named "test0" should exist
+    And a file named "test1~" should not exist
+    And a file named "subdir/test2~" should not exist
+

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -587,7 +587,10 @@ module Berkshelf
 
           # Dir.glob does not support backslash as a File separator
           src   = cookbook.path.to_s.gsub('\\', '/')
-          files = FileSyncer.glob(File.join(src, '*'))
+          # List all files and empty directories recursively
+          files = FileSyncer.glob(File.join(src, '**/*')).reject do |dir|
+            File.directory?(dir) and Dir.entries(dir) != [".", ".."]
+          end
 
           chefignore = Ridley::Chef::Chefignore.new(cookbook.path.to_s) rescue nil
           chefignore.apply!(files) if chefignore


### PR DESCRIPTION
It was broken since berkshelf 3.0.0:
1bfc97d64d38443e3326e85bd002c48399739c34 introduced the `vendor` command with the bug, and a2fcb18f41958af2b44e0b23547aa8cd07c24d8e re-implemented the `package` command using the bugged `vendor` one.

The chefignore patterns were only applied to the direct files and directories of the root, not in sub directories. Now we list all files (and empty directories) then apply the chefignore to this list.

Also add a Scenario for the command vendor feature to specifically test this.

This fixes issue #1317.

I'm not sure about Windows support and the already existing `src = cookbook.path.to_s.gsub('\\', '/')` seems dubious: we should probably patch the ignore patterns instead. I don't have a Windows machine to test this. But it should not be worse than before this patch.
