### PR TITLE
improved Metadata.rb and Metdata.json handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,8 @@ and run:
 
 Bundler will install all gems and their dependencies required for testing and developing.
 
+For RSpec tests of validator to pass, install [graphviz](http://www.graphviz.org).
+
 ### Running unit (RSpec) and acceptance (Cucumber) tests
 
 We use Chef Zero - an in-memory Chef Server for running tests. It is automatically managed by the Specs and Cukes. Simply run:

--- a/features/commands/info.feature
+++ b/features/commands/info.feature
@@ -97,3 +97,32 @@
         Cookbook 'fake' (1.0.0) not found in the cookbook store!
         """
       And the exit status should be "CookbookNotFound"
+
+   @github_1345
+    Scenario: When the cookbook is a vendored cookbook
+      Given the cookbook store has the cookbooks:
+        | fake | 1.0.0 |
+      And I have a Berksfile pointing at the local Berkshelf API with:
+        """
+        cookbook 'fake', '1.0.0'
+        """
+      And I write to "Berksfile.lock" with:
+        """
+        DEPENDENCIES
+          fake (= 1.0.0)
+
+        GRAPH
+          fake (1.0.0)
+        """
+      And the cookbook store cookbook "fake" "1.0.0" is vendored
+      When I successfully run `berks info fake`
+      Then the output should contain:
+        """
+                Name: fake
+             Version: 1.0.0
+         Description: A fabulous new cookbook
+              Author: YOUR_COMPANY_NAME
+               Email: YOUR_EMAIL
+             License: none
+        """
+

--- a/features/step_definitions/filesystem_steps.rb
+++ b/features/step_definitions/filesystem_steps.rb
@@ -269,3 +269,11 @@ Then(/^the directory "(.*?)" should contain version "(.*?)" of the "(.*?)" cookb
   expect(cookbook.version).to eq(version)
   expect(cookbook.cookbook_name).to eq(name)
 end
+
+Given(/^the cookbook store cookbook "(.*?)" "(.*?)" is vendored$/) do |name, version|
+  cookbook_path = File.join(cookbook_store.storage_path, "#{name}-#{version}")
+  cookbook = Berkshelf::CachedCookbook.from_path(cookbook_path)
+  cookbook.compile_metadata()
+  metadata_file = File.join(cookbook_path, "metadata.rb")
+  File.unlink(metadata_file) if File.file?(metadata_file)
+end

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -159,10 +159,20 @@ module Berkshelf
     # @option options [String] :path
     #   path to the metadata file
     def metadata(options = {})
-      path          = options[:path] || File.dirname(filepath)
-      metadata_path = File.expand_path(File.join(path, 'metadata.rb'))
-      metadata      = Ridley::Chef::Cookbook::Metadata.from_file(metadata_path)
-
+      path = options[:path] || File.dirname(filepath)
+      metadata = nil
+      ['metadata.json', 'metadata.rb'].each do |metadata_file|
+        metadata_path = File.expand_path(File.join(path, metadata_file))
+        if File.file?(metadata_path)
+          if metadata_path.end_with?('.json')
+            json = JSON.load(IO.read(metadata_path))
+            metadata = Ridley::Chef::Cookbook::Metadata.from_hash(json)
+          else
+            metadata = Ridley::Chef::Cookbook::Metadata.from_file(metadata_path)
+          end
+        end
+        break unless metadata.nil?
+      end
       add_dependency(metadata.name, nil, path: path, metadata: true)
     end
     expose :metadata
@@ -255,10 +265,6 @@ module Berkshelf
         if !(@dependencies[name].groups & groups).empty?
           raise DuplicateDependencyDefined.new(name)
         end
-      end
-
-      if options[:path]
-        metadata_file = File.join(options[:path], 'metadata.rb')
       end
 
       options[:constraint] = constraint

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -161,7 +161,7 @@ module Berkshelf
     def metadata(options = {})
       path = options[:path] || File.dirname(filepath)
       metadata = nil
-      ['metadata.json', 'metadata.rb'].each do |metadata_file|
+      ['metadata.rb', 'metadata.json'].each do |metadata_file|
         metadata_path = File.expand_path(File.join(path, metadata_file))
         if File.file?(metadata_path)
           if metadata_path.end_with?('.json')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,11 @@ def windows?
   !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
 end
 
+# OSX
+def darwin?
+  !!(RUBY_PLATFORM =~ /darwin/)
+end
+
 Spork.prefork do
   require 'rspec'
   require 'cleanroom/rspec'


### PR DESCRIPTION
This is a proposed fix for #1345, which lets 'berks info' and 'berks upload' succeed when running with a vendored BERKSHELF_PATH.

There are a couple of comments added where I wanted to remove code that didn't seem to be doing anything. Since I'm a new to ruby, I would appreciate some feedback on those.

There is a change to setting Berkshelf's @berkshelf_path, because on OS X, the environment variable was never listened to. I'm not confident on this one, but without this change, I couldn't ever 'berks install' into ENV['BERKSHELF_PATH'].

There's a change to an rspec test that fails on mac because the value of the scratch dir is os-dependent. There's possibly a nicer way to mark up tests to not run on darwin? But, instead, I if-deffed on detection of darwin.

Cukes and rspec tests look ok, but it's possible we should have better coverage, especially around BERKSHELF_PATH which wasn't working for me on OS X?

Anyways, please take a look and let me know what you think.
