### PR TITLE
Only exclude top-level metadata.rb file while vendoring

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -578,7 +578,7 @@ module Berkshelf
     # @return [String, nil]
     #   the expanded path cookbooks were vendored to or nil if nothing was vendored
     def vendor(destination)
-      Dir.mktmpdir do |scratch|
+      Dir.mktmpdir('vendor') do |scratch|
         chefignore       = nil
         cached_cookbooks = install
         raw_metadata_files = []

--- a/spec/unit/berkshelf/berksfile_spec.rb
+++ b/spec/unit/berkshelf/berksfile_spec.rb
@@ -396,9 +396,14 @@ describe Berkshelf::Berksfile do
     end
 
     it 'invokes FileSyncer with correct arguments' do
-      expect(Berkshelf::FileSyncer).to receive(:sync).with(/tmp/, destination, excludes)
+      expect(Berkshelf::FileSyncer).to receive(:sync).with(/vendor/, destination, excludes)
 
       subject.vendor(destination)
+    end
+
+    it 'excludes the top-level metadata.rb file' do
+      expect(excludes[:exclude].any? { |exclude| File.fnmatch?(exclude, 'my_cookbook/recipes/metadata.rb', File::FNM_DOTMATCH) }).to be(false)
+      expect(excludes[:exclude].any? { |exclude| File.fnmatch?(exclude, 'my_cookbook/metadata.rb', File::FNM_DOTMATCH) }).to be(true)
     end
   end
 end


### PR DESCRIPTION
This should fix issue #1344.
