### PR TITLE
Implement git/bundler style plugins (berks-foo)

### DIFF
--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -432,6 +432,14 @@ module Berkshelf
     end
     tasks['cookbook'].options = Berkshelf::CookbookGenerator.class_options
 
+    def self.handle_no_command_error(command, has_namespace = $thor_runner) #:nodoc:
+      if Berkshelf.which("berks-#{command}")
+        Kernel.exec("berks-#{command}", *ARGV.drop(1))
+      else
+        super
+      end
+    end
+
     private
 
       # Print a list of the given cookbooks. This is used by various

--- a/spec/unit/berkshelf/cli_spec.rb
+++ b/spec/unit/berkshelf/cli_spec.rb
@@ -21,5 +21,33 @@ module Berkshelf
         subject.upload('mysql')
       end
     end
+
+    describe 'command plugins' do
+      it 'runs berks-foo when called as berks foo' do
+        File.open(tmp_path.join("berks-foo"), 'w', 0755) do |file|
+          file.write("#!/bin/sh\necho 'it works'\n")
+        end
+
+        # We need to set the path to include our new plugin command
+        old_path = ENV['PATH']
+        ENV['PATH'] = "#{tmp_path}:#{ENV['PATH']}"
+
+        # fork because the command is expected to exit the process completely
+        pipe_me, pipe_peer = IO.pipe
+        pid = fork do
+          $stdout.reopen(pipe_peer)
+          # Run 'berks foo'
+          Berkshelf::Cli::Runner.new(['foo']).execute!
+        end
+        Process.waitpid(pid)
+        pipe_peer.close
+        output = pipe_me.read
+
+        # Restore the old path
+        ENV['PATH'] = old_path
+
+        expect(output).to eq "it works\n"
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1354

This implements a simple 'plugin' system to add additional commands in the
same way that git or bundler does so. If berkshelf is given an unknown
command, it first checks to see if berks-commandname exists in the path, and
runs it if so.
