### PR TITLE
Fixed README description of config file search

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ Ruby 1.9.1 and 1.9.2 are not officially supported. If you encounter problems, pl
 Berkshelf will search in specific locations for a configuration file. In order:
 
     $PWD/.berkshelf/config.json
-    $PWD/berkshelf/config.json
-    $PWD/berkshelf-config.json
-    $PWD/config.json
     ~/.berkshelf/config.json
 
 You are encouraged to keep project-specific configuration in the `$PWD/.berkshelf` directory. A default configuration file is generated for you, but you can update the values to suit your needs.


### PR DESCRIPTION
3 options were not really checked, as evident by [config.rb](https://github.com/berkshelf/berkshelf/blob/master/lib/berkshelf/config.rb#L18)
