### PR TITLE
add ConfigurationError

### DIFF
--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -15,6 +15,7 @@ module Berkshelf
   class InternalError < BerkshelfError; set_status_code(99); end
   class ArgumentError < InternalError; end
   class AbstractFunction < InternalError; end
+  class ConfigurationError < InternalError; end
 
   class BerksfileNotFound < BerkshelfError
     set_status_code(100)


### PR DESCRIPTION
I got error like:

```ruby
NameError: uninitialized constant Berkshelf::Downloader::ConfigurationError
	/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.2/lib/berkshelf/downloader.rb:91:in `try_download'
	/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.2/lib/berkshelf/downloader.rb:36:in `block in download'
	/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.2/lib/berkshelf/downloader.rb:35:in `each'
	/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.2/lib/berkshelf/downloader.rb:35:in `download'
	/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/berkshelf-3.2.2/lib/berkshelf/installer.rb:105:in `install'
```

ConfigurationError was not defined with this commit https://github.com/berkshelf/berkshelf/commit/2e37272984229ab5a04cddf93de93822dbc87788. 