### PR TITLE
correctly return the max version from searches

### DIFF
--- a/lib/berkshelf/source.rb
+++ b/lib/berkshelf/source.rb
@@ -53,7 +53,7 @@ module Berkshelf
       universe
         .select { |cookbook| cookbook.name =~ Regexp.new(name) }
         .group_by(&:name)
-        .collect { |name, versions| versions.max_by(&:version) }
+        .collect { |name, versions| versions.max_by { |v| Semverse::Version.new(v.version) } }
     end
 
     # Determine if this source is a "default" source, as defined in the

--- a/spec/unit/berkshelf/source_spec.rb
+++ b/spec/unit/berkshelf/source_spec.rb
@@ -38,5 +38,21 @@ module Berkshelf
         expect(instance).to_not be_default
       end
     end
+
+    describe "#search" do
+      let (:cookbooks) {[ 
+        APIClient::RemoteCookbook.new("cb1","1.0.8"),
+        APIClient::RemoteCookbook.new("cb1","1.0.22")
+      ]}
+
+      before do
+        allow_any_instance_of(APIClient::Connection).to receive(:universe).and_return(cookbooks)
+      end
+
+      it "returns the latest version" do
+        instance = described_class.new(Berksfile::DEFAULT_API_URL)
+        expect(instance.search("cb1")).to eq [cookbooks[1]]
+      end
+    end
   end
 end


### PR DESCRIPTION
Our internal cookbooks get reved on each push so the build numbers can grow rapidly. We are having issues where the string comparison on version breaks and returns an incorrect version. I think the submitted test illustrates this. Given two cookbook versions, 1.0.24 and 1.0.8, berks currently returns 1.0.8.

This PR uses `Semverse::Version` to do the comparison so that the versions are compared more accurately.