### PR TITLE
fix expected berkshelf-api-server version

### DIFF
--- a/features/commands/search.feature
+++ b/features/commands/search.feature
@@ -11,6 +11,6 @@ Feature: berks search
     * the output should contain:
       """
       berkshelf-api (1.2.2)
-      berkshelf-api-server (2.1.0)
+      berkshelf-api-server (2.1.1)
       berkshelf-cookbook-fixture (1.0.0)
       """


### PR DESCRIPTION
Noticed a feature is breaking perhaps from a recent bump.