### PR TITLE
Use httpclient instead of nethttp

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'buff-shell_out',       '~> 0.1'
   s.add_dependency 'cleanroom',            '~> 1.0'
   s.add_dependency 'faraday',              '~> 0.9.0'
-  s.add_dependency 'httpclient',           '~> 2.5.3'
+  s.add_dependency 'httpclient',           '~> 2.6.0'
   s.add_dependency 'minitar',              '~> 0.5.4'
   s.add_dependency 'retryable',            '~> 2.0'
   s.add_dependency 'ridley',               '~> 4.0'

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'buff-shell_out',       '~> 0.1'
   s.add_dependency 'cleanroom',            '~> 1.0'
   s.add_dependency 'faraday',              '~> 0.9.0'
+  s.add_dependency 'httpclient',           '~> 2.5.3'
   s.add_dependency 'minitar',              '~> 0.5.4'
   s.add_dependency 'retryable',            '~> 2.0'
   s.add_dependency 'ridley',               '~> 4.0'

--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -83,7 +83,7 @@ module Berkshelf
           interval: @retry_interval,
           exceptions: [Faraday::Error::TimeoutError]
 
-        b.adapter :net_http
+        b.adapter :httpclient
       end
 
       super(api_uri, options)


### PR DESCRIPTION
This changes the default http adapter from net_http to httpclient and addresses this issue in berkshelf:

berkshelf/berkshelf#1341

Of the avaialble Faraday adapters, httpclient is the only pure-ruby solution that supports the NO_PROXY environment variable. This is essential for folks who have a private supermarket instance behind their firewall and only have access to the public supermarket through a proxy.

Currently, you can access public supermarket (by defining proxy vars) or private (by undefining same), but not both in a single berkshelf run.

This requires an updated berkshelf-api-client as well, see associated PR:

https://github.com/berkshelf/berkshelf-api-client/pull/5

I'm open to suggestions on how (or even it is feasible) to test this, beyond the existing cucumber suite continuing to work.  Faraday doesn't expose the adapter via getter, and adding an expectation that HTTPClient gets initialized seems like we're testing Faraday's code.