### PR TITLE
prevent race conditions

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -75,7 +75,7 @@ module Berkshelf
         Celluloid.logger = nil unless ENV["DEBUG_CELLULOID"]
         Ridley.open(credentials) { |r| r.cookbook.download(name, version) }
       when :github
-        require 'octokit' unless defined?(Octokit)
+        Thread.exclusive { require 'octokit' unless defined?(Octokit) }
 
         tmp_dir      = Dir.mktmpdir
         archive_path = File.join(tmp_dir, "#{name}-#{version}.tar.gz")
@@ -119,7 +119,7 @@ module Berkshelf
 
         File.join(unpack_dir, cookbook_directory)
       when :uri
-        require 'open-uri' unless defined?(OpenURI)
+        Thread.exclusive { require 'open-uri' unless defined?(OpenURI) }
 
         tmp_dir      = Dir.mktmpdir
         archive_path = Pathname.new(tmp_dir) + "#{name}-#{version}.tar.gz"


### PR DESCRIPTION
Quite generally speaking, a `require` is something global.  If you call it in multithreaded situations, you are highly expected to get in trouble.  Berkshelf is not an exception.

`Berkshelf::Downloader#download` is called in parallel from workers.  That can cause simultaneous invocations of require, resulting a race condition.  For instance, I experience following backtrace while running my knife-solo:

```
[shyouhei@localhost mychef]# bundle exec knife solo cook localhost -o 'role[admin]'
Running Chef on localhost...
Checking Chef version...
Installing Berkshelf cookbooks to 'cookbooks'...
Resolving cookbook dependencies...
Fetching cookbook index from http://berks.localdomain...
Fetching cookbook index from https://supermarket.chef.io...
Installing common (1.1.10) from http://berks.localdomain ([github] https://github-enterprise.localdomain/cookbooks/common)
Installing ohai (2.0.6) from http://berks.localdomain ([github] https://github-enterprise.localdomain/cookbooks/ohai)
Installing dump-attributes (1.0.2) from http://berks.localdomain ([github] https://github-enterprise.localdomain/cookbooks/dump-attributes)
E, [2015-03-04T20:18:27.117765 #27807] ERROR -- : Actor crashed!
NameError: uninitialized constant Octokit::Client
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:94:in `try_download'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:36:in `block in download'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:35:in `each'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:35:in `download'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/installer.rb:105:in `install'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in `public_send'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in `dispatch'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:63:in `dispatch'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/cell.rb:60:in `block in invoke'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/cell.rb:71:in `block in task'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/actor.rb:357:in `block in task'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/tasks.rb:57:in `block in initialize'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/tasks/task_fiber.rb:15:in `block in create'
Installing snmp (0.1.3) from http:/berks.localdomain ([github] https:/github-enterprise.localdomain/cookbooks/snmp)
E, [2015-03-04T20:18:27.212009 #27807] ERROR -- : Actor crashed!
ArgumentError: wrong number of arguments (1 for 0)
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:94:in `initialize'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:94:in `new'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:94:in `try_download'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:36:in `block in download'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:35:in `each'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/downloader.rb:35:in `download'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/berkshelf-3.2.3/lib/berkshelf/installer.rb:105:in `install'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in `public_send'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:26:in `dispatch'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/calls.rb:63:in `dispatch'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/cell.rb:60:in `block in invoke'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/cell.rb:71:in `block in task'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/actor.rb:357:in `block in task'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/tasks.rb:57:in `block in initialize'
        /home/shyouhei/mychef/vendor/bundle/ruby/2.1.0/gems/celluloid-0.16.0/lib/celluloid/tasks/task_fiber.rb:15:in `block in create'
Installing pfsys-app (0.1.23) from http://berks.localdomain ([github] https://github-enterprise.localdomain/cookbooks/sys-app)
Installing pfsys-base (0.1.11) from http://berks.localdomain ([github] https://github-enterprise.localdomain/cookbooks/sys-base)
ERROR: knife encountered an unexpected error
This may be a bug in the 'solo cook' knife command or plugin
Please collect the output of this command with the `-VV` option before filing a bug report.
Exception: NameError: uninitialized constant Octokit::Client
E, [2015-03-04T20:18:37.914248 #27807] ERROR -- : Couldn't cleanly terminate all actors in 10 seconds!
```

That "uninitialized constant Octokit::Client" happens because a thread is touching a constant while another thread is `require`ing that exact file.  Situations like this must be prevented.

Further reading: http://m.onkey.org/thread-safety-for-your-rails (dated, but the outline about `require` doesn't change).