### PR TITLE
Improved error msg for unknown compression types.

### DIFF
--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -16,7 +16,7 @@ module Berkshelf
         elsif is_tar_file(target)
           Archive::Tar::Minitar.unpack(target, destination)
         else
-          raise Berkshelf::UnknownCompressionType.new(target)
+          raise Berkshelf::UnknownCompressionType.new(target, destination)
         end
 
         FileUtils.rm_rf Dir.glob("#{destination}/**/PaxHeader")

--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -321,12 +321,13 @@ module Berkshelf
   class UnknownCompressionType < BerkshelfError
     set_status_code(131)
 
-    def initialize(destination)
+    def initialize(target, destination)
+      @target = target
       @destination = destination
     end
 
     def to_s
-      "The file at '#{@destination}' is not a known compression type"
+      "The file at '#{@target}' is not a known compression type, and cannot be decompressed into '#{@destination}'"
     end
 
     alias_method :message, :to_s


### PR DESCRIPTION
Addresses #1432.

The variables were a little mixed up before, so I flipped the names back so
that they're consistent.