### PR TITLE
Remove double negations in "berks cookbook" flags

### DIFF
--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -26,10 +26,10 @@ module Berkshelf
       default: true,
       desc: 'Adds a .gitignore and runs git init in the cookbook directory'
 
-    class_option :skip_test_kitchen,
+    class_option :test_kitchen,
       type: :boolean,
-      default: false,
-      desc: 'Skip adding a testing environment to your cookbook'
+      default: true,
+      desc: 'Adds a testing environment to your cookbook'
 
     class_option :foodcritic,
       type: :boolean,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -64,7 +64,8 @@ module Berkshelf
 
     class_option :maintainer_email,
       type: :string,
-      default: Berkshelf.config.cookbook.email
+      default: Berkshelf.config.cookbook.email,
+      desc: 'Email of cookbook maintainer'
 
     def generate
       case options[:pattern]

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -59,7 +59,8 @@ module Berkshelf
 
     class_option :maintainer,
       type: :string,
-      default: Berkshelf.config.cookbook.copyright
+      default: Berkshelf.config.cookbook.copyright,
+      desc: 'Cookbook maintainer'
 
     class_option :maintainer_email,
       type: :string,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -43,7 +43,8 @@ module Berkshelf
 
     class_option :scmversion,
       type: :boolean,
-      default: false
+      default: false,
+      desc: 'Creates a Thorfile with SCMVersion support to manage versions for continuous integration'
 
     class_option :bundler,
       type: :boolean,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -41,9 +41,10 @@ module Berkshelf
       type: :boolean,
       default: false
 
-    class_option :no_bundler,
+    class_option :bundler,
       type: :boolean,
-      default: false
+      default: true,
+      desc: 'Generate a Gemfile and other Bundler specific support'
 
     class_option :license,
       type: :string,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -33,7 +33,8 @@ module Berkshelf
 
     class_option :foodcritic,
       type: :boolean,
-      default: false
+      default: false,
+      desc: 'Creates a Thorfile with Foodcritic support to lint test your cookbook'
 
     class_option :chef_minitest,
       type: :boolean,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -19,7 +19,7 @@ module Berkshelf
     class_option :vagrant,
       type: :boolean,
       default: true,
-      desc: 'Adds a Vagrantfile and adding supporting gems to the Gemfile'
+      desc: 'Adds a Vagrantfile and supporting gems to the Gemfile'
 
     class_option :git,
       type: :boolean,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -16,9 +16,10 @@ module Berkshelf
       type: :string,
       required: true
 
-    class_option :skip_vagrant,
+    class_option :vagrant,
       type: :boolean,
-      default: false
+      default: true,
+      desc: 'Adds a Vagrantfile and adding supporting gems to the Gemfile'
 
     class_option :skip_git,
       type: :boolean,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -34,7 +34,7 @@ module Berkshelf
     class_option :foodcritic,
       type: :boolean,
       default: false,
-      desc: 'Creates a Thorfile with Foodcritic support to lint test your cookbook'
+      desc: 'Adds a Thorfile with Foodcritic support to lint test your cookbook'
 
     class_option :chef_minitest,
       type: :boolean,
@@ -44,12 +44,12 @@ module Berkshelf
     class_option :scmversion,
       type: :boolean,
       default: false,
-      desc: 'Creates a Thorfile with SCMVersion support to manage versions for continuous integration'
+      desc: 'Adds a Thorfile with SCMVersion support to manage versions for continuous integration'
 
     class_option :bundler,
       type: :boolean,
       default: true,
-      desc: 'Generate a Gemfile and other Bundler specific support'
+      desc: 'Adds a Gemfile and other Bundler specific support'
 
     class_option :license,
       type: :string,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -53,7 +53,9 @@ module Berkshelf
 
     class_option :license,
       type: :string,
-      default: Berkshelf.config.cookbook.license
+      default: Berkshelf.config.cookbook.license,
+      desc: 'License of the cookbook',
+      enum: LICENSES
 
     class_option :maintainer,
       type: :string,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -21,9 +21,10 @@ module Berkshelf
       default: true,
       desc: 'Adds a Vagrantfile and adding supporting gems to the Gemfile'
 
-    class_option :skip_git,
+    class_option :git,
       type: :boolean,
-      default: false
+      default: true,
+      desc: 'Adds a .gitignore and runs git init in the cookbook directory'
 
     class_option :skip_test_kitchen,
       type: :boolean,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -38,7 +38,8 @@ module Berkshelf
 
     class_option :chef_minitest,
       type: :boolean,
-      default: false
+      default: false,
+      desc: 'Adds chef minitest'
 
     class_option :scmversion,
       type: :boolean,

--- a/lib/berkshelf/cookbook_generator.rb
+++ b/lib/berkshelf/cookbook_generator.rb
@@ -54,7 +54,7 @@ module Berkshelf
     class_option :license,
       type: :string,
       default: Berkshelf.config.cookbook.license,
-      desc: 'License of the cookbook',
+      desc: 'Cookbook license',
       enum: LICENSES
 
     class_option :maintainer,

--- a/lib/berkshelf/init_generator.rb
+++ b/lib/berkshelf/init_generator.rb
@@ -45,10 +45,10 @@ module Berkshelf
       default: false,
       desc: 'Creates a Thorfile with SCMVersion support to manage versions for continuous integration'
 
-    class_option :no_bundler,
+    class_option :bundler,
       type: :boolean,
-      default: false,
-      desc: 'Skips generation of a Gemfile and other Bundler specific support'
+      default: true,
+      desc: 'Generate a Gemfile and other Bundler specific support'
 
     class_option :cookbook_name,
       type: :string
@@ -92,7 +92,7 @@ module Berkshelf
         create_file target.join('VERSION'), '0.1.0'
       end
 
-      unless options[:no_bundler]
+      if options[:bundler]
         template 'Gemfile.erb', target.join('Gemfile')
       end
 

--- a/lib/berkshelf/init_generator.rb
+++ b/lib/berkshelf/init_generator.rb
@@ -21,10 +21,10 @@ module Berkshelf
       type: :boolean,
       default: true
 
-    class_option :skip_vagrant,
+    class_option :vagrant,
       type: :boolean,
-      default: false,
-      desc: 'Skips adding a Vagrantfile and adding supporting gems to the Gemfile'
+      default: true,
+      desc: 'Adds a Vagrantfile and adding supporting gems to the Gemfile'
 
     class_option :skip_git,
       type: :boolean,
@@ -102,7 +102,7 @@ module Berkshelf
         end
       end
 
-      unless options[:skip_vagrant]
+      if options[:vagrant]
         template 'Vagrantfile.erb', target.join('Vagrantfile')
       end
     end

--- a/lib/berkshelf/init_generator.rb
+++ b/lib/berkshelf/init_generator.rb
@@ -24,7 +24,7 @@ module Berkshelf
     class_option :vagrant,
       type: :boolean,
       default: true,
-      desc: 'Adds a Vagrantfile and adding supporting gems to the Gemfile'
+      desc: 'Adds a Vagrantfile and supporting gems to the Gemfile'
 
     class_option :git,
       type: :boolean,
@@ -34,21 +34,22 @@ module Berkshelf
     class_option :foodcritic,
       type: :boolean,
       default: false,
-      desc: 'Creates a Thorfile with Foodcritic support to lint test your cookbook'
+      desc: 'Adds a Thorfile with Foodcritic support to lint test your cookbook'
 
     class_option :chef_minitest,
       type: :boolean,
-      default: false
+      default: false,
+      desc: 'Adds chef minitest'
 
     class_option :scmversion,
       type: :boolean,
       default: false,
-      desc: 'Creates a Thorfile with SCMVersion support to manage versions for continuous integration'
+      desc: 'Adds a Thorfile with SCMVersion support to manage versions for continuous integration'
 
     class_option :bundler,
       type: :boolean,
       default: true,
-      desc: 'Generate a Gemfile and other Bundler specific support'
+      desc: 'Adds a Gemfile and other Bundler specific support'
 
     class_option :cookbook_name,
       type: :string

--- a/lib/berkshelf/init_generator.rb
+++ b/lib/berkshelf/init_generator.rb
@@ -26,10 +26,10 @@ module Berkshelf
       default: true,
       desc: 'Adds a Vagrantfile and adding supporting gems to the Gemfile'
 
-    class_option :skip_git,
+    class_option :git,
       type: :boolean,
-      default: false,
-      desc: 'Skips adding a .gitignore and running git init in the cookbook directory'
+      default: true,
+      desc: 'Adds a .gitignore and runs git init in the cookbook directory'
 
     class_option :foodcritic,
       type: :boolean,
@@ -72,7 +72,7 @@ module Berkshelf
         copy_file 'chefignore', target.join(Ridley::Chef::Chefignore::FILENAME)
       end
 
-      unless options[:skip_git]
+      if options[:git]
         template 'gitignore.erb', target.join('.gitignore')
 
         unless File.exists?(target.join('.git'))

--- a/lib/berkshelf/init_generator.rb
+++ b/lib/berkshelf/init_generator.rb
@@ -54,10 +54,10 @@ module Berkshelf
       type: :string
 
     if defined?(Kitchen::Generator::Init)
-      class_option :skip_test_kitchen,
+      class_option :test_kitchen,
         type: :boolean,
-        default: false,
-        desc: 'Skip adding a testing environment to your cookbook'
+        default: true,
+        desc: 'Adds a testing environment to your cookbook'
     end
 
     def generate
@@ -97,7 +97,7 @@ module Berkshelf
       end
 
       if defined?(Kitchen::Generator::Init)
-        unless options[:skip_test_kitchen]
+        if options[:test_kitchen]
           Kitchen::Generator::Init.new([], {}, destination_root: target).invoke_all
         end
       end

--- a/spec/unit/berkshelf/init_generator_spec.rb
+++ b/spec/unit/berkshelf/init_generator_spec.rb
@@ -149,7 +149,7 @@ describe Berkshelf::InitGenerator do
 
   context 'when skipping git' do
     before(:each) do
-      generator = Berkshelf::InitGenerator.new([target], skip_git: true)
+      generator = Berkshelf::InitGenerator.new([target], git: false)
       capture(:stdout) { generator.invoke_all }
     end
 

--- a/spec/unit/berkshelf/init_generator_spec.rb
+++ b/spec/unit/berkshelf/init_generator_spec.rb
@@ -115,10 +115,10 @@ describe Berkshelf::InitGenerator do
     end
   end
 
-  context 'with the bundler option true' do
+  context 'with the bundler option false' do
     before(:each) do
       capture(:stdout) {
-        Berkshelf::InitGenerator.new([target], no_bundler: true).invoke_all
+        Berkshelf::InitGenerator.new([target], bundler: false).invoke_all
       }
     end
 

--- a/spec/unit/berkshelf/init_generator_spec.rb
+++ b/spec/unit/berkshelf/init_generator_spec.rb
@@ -163,7 +163,7 @@ describe Berkshelf::InitGenerator do
   context 'when skipping vagrant' do
     before(:each) do
       capture(:stdout) {
-        Berkshelf::InitGenerator.new([target], skip_vagrant: true).invoke_all
+        Berkshelf::InitGenerator.new([target], vagrant: false).invoke_all
       }
     end
 


### PR DESCRIPTION
Thor generated som double negation flags which has confused me for some time. This pullrequest refactors so that the autogenerated --no- flags are kept, but without it being double negations.

An alternative to this would be to disable the thor --no- flags.

For some reason the default value of booleans are only shown when it is true. I haven't figured out how to change that.

There is some code duplication between init_generator.rb and coobook_generator.rb, which probably should get refactored at some point.