### PR TITLE
Removes the gzip middleware from Faraday builder.

### DIFF
--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -76,7 +76,6 @@ module Berkshelf
 
       options[:builder] ||= Faraday::RackBuilder.new do |b|
         b.response :parse_json
-        b.response :gzip
         b.response :follow_redirects
         b.request :retry,
           max: @retries,


### PR DESCRIPTION
This is related to the [same problem with berkshelf-api-client][0]. The
new upstream httpclient usage includes a transparent gzip layer so this
additional one is redundant.

[0]: https://github.com/berkshelf/berkshelf-api-client/pull/10