### PR TITLE
Port 'Apply environment file artifact' to version 3

### DIFF
--- a/features/step_definitions/berksfile_steps.rb
+++ b/features/step_definitions/berksfile_steps.rb
@@ -37,3 +37,16 @@ Given /^I have a Berksfile at "(.+)" pointing at the local Berkshelf API with:$/
       """
   }
 end
+
+Given(/^I have a Berksfile\.lock set up to apply$/) do
+  steps %Q{
+    Given I have a Berksfile pointing at the local Berkshelf API
+    And the cookbook store has the cookbooks:
+      | fake | 1.0.0 |
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'fake', '1.0.0'
+      """
+    And I successfully run `berks install`
+  }
+end

--- a/features/step_definitions/chef_server_steps.rb
+++ b/features/step_definitions/chef_server_steps.rb
@@ -58,3 +58,10 @@ Then(/^the version locks in the "(.*?)" environment should be:$/) do |name, lock
     expect(list[cookbook]).to eq(version)
   end
 end
+
+Then(/^in the "([^"]*)" environment, I should have these override attributes:$/) do |name, attributes|
+  chef_environment_attributes = chef_environment_override_attributes(name)
+  attributes.raw.each do |attribute, value|
+    expect(chef_environment_attributes[attribute]).to eq(value)
+  end
+end

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -218,6 +218,11 @@ module Berkshelf
       type: :boolean,
       default: nil,
       desc: 'Disable/Enable SSL verification when locking cookbooks.'
+    method_option :from_file,
+      type: :string,
+      desc: 'overwrite environment attributes when using apply using local environment file',
+      aliases: '-f',
+      banner: 'PATH'
     desc 'apply ENVIRONMENT', 'Apply version locks from Berksfile.lock to a Chef environment'
     def apply(environment_name)
       unless File.exist?(options[:lockfile])

--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -310,6 +310,19 @@ module Berkshelf
     alias_method :message, :to_s
   end
 
+  class EnvironmentFileNotFound < BerkshelfError
+    #Status code was 137 in v2, but that's taken now by InvalidSourceURI
+    set_status_code(150)
+
+    def initialize(environment_path)
+      @environment_path = environment_path
+    end
+
+    def to_s
+      "Local environment file #{@environment_path} not found."
+    end
+  end
+
   class ChefConnectionError < BerkshelfError
     set_status_code(130)
 

--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -323,6 +323,19 @@ module Berkshelf
     end
   end
 
+  class EnvironmentFileForWrongEnvironment < BerkshelfError
+    set_status_code(151)
+
+    def initialize(file_environment_name, expected_name)
+      @file_environment_name = file_environment_name
+      @expected_name = expected_name
+    end
+
+    def to_s
+      "Local environment file is for '#{@file_environment_name}' environment - expected '#{@expected_name}'."
+    end
+  end
+
   class ChefConnectionError < BerkshelfError
     set_status_code(130)
 

--- a/lib/berkshelf/lockfile.rb
+++ b/lib/berkshelf/lockfile.rb
@@ -203,6 +203,9 @@ module Berkshelf
     # @raise [EnvironmentFileNotFound]
     #   if you are uploading environment from local file and that file doesn't
     #   exist
+    # @raise [EnvironmentFileForWrongEnvironment]
+    #   if you try to upload from a local file containing a name that doesn't
+    #   match your environment parameter
     def apply(name, options = {})
       Berkshelf.ridley_connection(options) do |connection|
         if options[:from_file]

--- a/lib/berkshelf/lockfile.rb
+++ b/lib/berkshelf/lockfile.rb
@@ -209,11 +209,18 @@ module Berkshelf
           environment_path = options[:from_file]
           begin
             environment = connection.environment.from_file(environment_path)
-          rescue Errno::ENOENT # Just rescue missing files
+          rescue Errno::ENOENT # Just rescue missing file exceptions
             raise EnvironmentFileNotFound.new(environment_path)
           end
+          if environment.name && environment.name != ""
+            if environment.name != name
+              raise EnvironmentFileForWrongEnvironment.new(environment.name, name)
+            end
+          else
+            environment.name = name
+          end
         else
-          environment = connection.environment.find(environment_name)
+          environment = connection.environment.find(name)
         end
 
         raise EnvironmentNotFound.new(name) if environment.nil?

--- a/spec/support/chef_server.rb
+++ b/spec/support/chef_server.rb
@@ -76,10 +76,18 @@ module Berkshelf::RSpec
       load_data(:environments, name, hash)
     end
 
-    def chef_environment_locks(name)
-      JSON.parse(chef_server.data_store.get(['environments', name]))['cookbook_versions']
+    def chef_environment_json_data(name)
+      JSON.parse(chef_server.data_store.get(['environments', name]))
     rescue ChefZero::DataStore::DataNotFoundError
       {}
+    end
+
+    def chef_environment_locks(name)
+      chef_environment_json_data(name)['cookbook_versions'] || {}
+    end
+
+    def chef_environment_override_attributes(name)
+      chef_environment_json_data(name)['override_attributes'] || {}
     end
 
     def chef_node(name, hash = {})


### PR DESCRIPTION
As mentioned in #1188, the `berks apply --from-file` feature was for v2 stable only. I've ported it to v3, added a check to make sure that environment names match, and added tests around all that.

I'm not certain which exit status codes I should have used - I grabbed 150 and 151 because they appeared to be available and 137 was taken by another error.
