### PR TITLE
visualise full set of Faraday ssl/X509 parameters to configuration

### DIFF
--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -69,7 +69,7 @@ module Berkshelf
     # @option options [Float] :retry_interval (0.5)
     #   how often we should pause between retries
     def initialize(uri = V1_API, options = {})
-      options         = options.reverse_merge(retries: 5, retry_interval: 0.5, ssl: { verify: Berkshelf::Config.instance.ssl.verify })
+      options         = options.reverse_merge(retries: 5, retry_interval: 0.5, ssl: Berkshelf::Config.instance.ssl)
       @api_uri        = uri
       @retries        = options.delete(:retries)
       @retry_interval = options.delete(:retry_interval)

--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -66,9 +66,7 @@ module Berkshelf
           server_url: remote_cookbook.location_path,
           client_name: Berkshelf::Config.instance.chef.node_name,
           client_key: Berkshelf::Config.instance.chef.client_key,
-          ssl: {
-            verify: Berkshelf::Config.instance.ssl.verify
-          }
+          ssl: Berkshelf::Config.instance.ssl
         }
         # @todo  Something scary going on here - getting an instance of Kitchen::Logger from test-kitchen
         # https://github.com/opscode/test-kitchen/blob/master/lib/kitchen.rb#L99

--- a/lib/berkshelf/source.rb
+++ b/lib/berkshelf/source.rb
@@ -10,7 +10,7 @@ module Berkshelf
     # @param [String, Berkshelf::SourceURI] uri
     def initialize(uri)
       @uri        = SourceURI.parse(uri)
-      @api_client = APIClient.new(uri, ssl: {verify: Berkshelf::Config.instance.ssl.verify})
+      @api_client = APIClient.new(uri, ssl: Berkshelf::Config.instance.ssl)
       @universe   = nil
     end
 


### PR DESCRIPTION
Not entirely sure if this is the most expeditious place to implement this: but basically created a coerce_ssl function for all str->OpenSSL::X509 conversions; and then use the full config.ssl hash everywhere ...
