### PR TITLE
Have berks install bump only required cookbooks

### DIFF
--- a/lib/berkshelf/lockfile.rb
+++ b/lib/berkshelf/lockfile.rb
@@ -396,6 +396,10 @@ module Berkshelf
           raise OutdatedDependency.new(graphed, dependency)
         end
 
+        # Locking dependency version to the graphed version if
+        # constraints are satisfied by it.
+        dependency.locked_version = graphed.version
+
         if cookbook = dependency.cached_cookbook
           Berkshelf.log.debug "    Cached cookbook exists"
           Berkshelf.log.debug "    Checking dependencies on the cached cookbook"

--- a/spec/fixtures/berksfiles/default
+++ b/spec/fixtures/berksfiles/default
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+cookbook 'apt', '~> 2.0'
+cookbook 'jenkins', '~> 2.0'

--- a/spec/fixtures/berksfiles/default
+++ b/spec/fixtures/berksfiles/default
@@ -1,3 +1,4 @@
 source 'https://supermarket.chef.io'
 cookbook 'apt', '~> 2.0'
 cookbook 'jenkins', '~> 2.0'
+cookbook 'jenkins-config', path: '../cookbook-path/jenkins-config'

--- a/spec/fixtures/cookbook-path/jenkins-config/metadata.rb
+++ b/spec/fixtures/cookbook-path/jenkins-config/metadata.rb
@@ -1,0 +1,4 @@
+name 'jenkins-config'
+version '0.1.0'
+
+depends 'jenkins', '~> 2.0'

--- a/spec/fixtures/cookbook-store/jenkins-2.0.3/metadata.rb
+++ b/spec/fixtures/cookbook-store/jenkins-2.0.3/metadata.rb
@@ -1,0 +1,6 @@
+name 'jenkins'
+version '2.0.3'
+
+depends 'apt', '~> 2.0'
+depends 'runit', '~> 1.5'
+depends 'yum', '~> 3.0'

--- a/spec/fixtures/cookbook-store/jenkins-2.0.4/metadata.rb
+++ b/spec/fixtures/cookbook-store/jenkins-2.0.4/metadata.rb
@@ -1,0 +1,5 @@
+name 'jenkins'
+version '2.0.4'
+
+depends 'apt', '~> 2.0'
+depends 'runit', '~> 1.5'

--- a/spec/fixtures/lockfiles/default.lock
+++ b/spec/fixtures/lockfiles/default.lock
@@ -1,6 +1,8 @@
 DEPENDENCIES
   apt (~> 2.0)
   jenkins (~> 2.0)
+  jenkins-config
+    path: ../cookbook-path/jenkins-config
 
 GRAPH
   apt (2.3.6)
@@ -8,6 +10,9 @@ GRAPH
   jenkins (2.0.3)
     apt (~> 2.0)
     runit (~> 1.5)
+    yum (~> 3.0)
+  jenkins-config (0.1.0)
+    jenkins (~> 2.0)
     yum (~> 3.0)
   runit (1.5.8)
     build-essential (>= 0.0.0)

--- a/spec/fixtures/lockfiles/orphans.lock
+++ b/spec/fixtures/lockfiles/orphans.lock
@@ -1,0 +1,21 @@
+DEPENDENCIES
+  apt (~> 2.0)
+  jenkins (~> 2.0)
+  jenkins-config
+    path: ../cookbook-path/jenkins-config
+
+GRAPH
+  apt (2.3.6)
+  build-essential (1.4.2)
+  jenkins (2.0.3)
+    apt (~> 2.0)
+    runit (~> 1.5)
+  jenkins-config (0.1.0)
+    jenkins (~> 2.0)
+  runit (1.5.8)
+    build-essential (>= 0.0.0)
+  yum (3.0.6)
+  yum-epel (0.2.0)
+    yum (~> 3.0)
+  zum-foo (0.1.0)
+    yum (~> 3.0)

--- a/spec/unit/berkshelf/lockfile_spec.rb
+++ b/spec/unit/berkshelf/lockfile_spec.rb
@@ -292,6 +292,27 @@ describe Berkshelf::Lockfile do
       expect(subject).to_not have_dependency('apache2')
     end
   end
+
+  describe '#reduce!' do
+    let(:berksfile_path) { fixtures_path.join('berksfiles/default').to_s }
+    let(:berksfile) { Berkshelf::Berksfile.from_file(berksfile_path) }
+    subject { Berkshelf::Lockfile.new(filepath: filepath, berksfile: berksfile) }
+
+    before(:each) do
+      cs = fixtures_path.join('cookbook-store')
+      allow(Berkshelf::CookbookStore.instance).to receive(:storage_path).and_return(cs)
+    end
+
+    it 'uses the cookbook version specified in the lockfile' do
+      subject.reduce!
+      expect(subject.berksfile.dependencies[1].cached_cookbook.version).to eq('2.0.3')
+    end
+
+    it 'does not remove locks unnecessarily' do
+      expect(subject).to_not receive(:unlock)
+      subject.reduce!
+    end
+  end
 end
 
 describe Berkshelf::Lockfile::Graph do


### PR DESCRIPTION
Update algorithm used by `berks install` to remove orphan dependencies.