### PR TITLE
Use Net::HTTP.new instead of Net::HTTP.start

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -101,12 +101,13 @@ module Berkshelf
           return nil
         end
 
-        Net::HTTP.start(url.host, use_ssl: url.scheme == "https",
-          verify_mode: (options[:ssl_verify].nil? || options[:ssl_verify]) ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE) do |http|
-          resp = http.get(url.request_uri)
-          return nil unless resp.is_a?(Net::HTTPSuccess)
-          open(archive_path, "wb") { |file| file.write(resp.body) }
-        end
+        # We use Net::HTTP.new and then get here, because Net::HTTP.get does not support proxy settings.
+        http = Net::HTTP.new(url.host,
+                             use_ssl: url.scheme == "https",
+                             verify_mode: (options[:ssl_verify].nil? || options[:ssl_verify]) ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE)
+        resp = http.get(url.request_uri)
+        return nil unless resp.is_a?(Net::HTTPSuccess)
+        open(archive_path, "wb") { |file| file.write(resp.body) }
 
         tgz = Zlib::GzipReader.new(File.open(archive_path, "rb"))
         Archive::Tar::Minitar.unpack(tgz, unpack_dir)


### PR DESCRIPTION
(see https://www.jethrocarr.com/2014/08/14/ruby-nethttp-proxies/)