### PR TITLE
Add a new `solver` Berksfile DSL option

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'retryable',            '~> 2.0'
   s.add_dependency 'ridley',               '~> 4.3'
   s.add_dependency 'solve',                '~> 2.0'
-  s.add_dependency 'dep_selector',         '~> 1.0'
   s.add_dependency 'thor',                 '~> 0.19'
   s.add_dependency 'octokit',              '~> 4.0'
   s.add_dependency 'celluloid',            '= 0.16.0'
@@ -50,6 +49,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'aruba',         '~> 0.6'
   s.add_development_dependency 'chef-zero',     '~> 4.0'
+  s.add_development_dependency 'dep_selector',  '~> 1.0'
   s.add_development_dependency 'fuubar',        '~> 2.0'
   s.add_development_dependency 'rake',          '~> 10.1'
   s.add_development_dependency 'rspec',         '~> 3.0'

--- a/features/commands/install.feature
+++ b/features/commands/install.feature
@@ -541,3 +541,100 @@ Feature: berks install
       """
       Using bacon (0.2.0)
       """
+
+  Scenario: when asking for the :ruby solver engine without precedence, no error is raised
+  Given I have a Berksfile pointing at the local Berkshelf API with:
+    """
+    cookbook 'example_cookbook', path: '../../spec/fixtures/cookbooks/example_cookbook-0.5.0'
+    solver :ruby
+    """
+  When I successfully run `berks install`
+  Then the output should contain:
+    """
+    Resolving cookbook dependencies...
+    """
+
+  Scenario: when asking for the :gecode solver engine without precedence, no error is raised
+  Given I have a Berksfile pointing at the local Berkshelf API with:
+    """
+    cookbook 'example_cookbook', path: '../../spec/fixtures/cookbooks/example_cookbook-0.5.0'
+    solver :gecode
+    """
+  When I successfully run `berks install`
+  Then the output should contain:
+    """
+    Resolving cookbook dependencies...
+    """
+
+  Scenario: when asking for an unknown solver engine without precedence, no error is raised
+  Given I have a Berksfile pointing at the local Berkshelf API with:
+    """
+    cookbook 'example_cookbook', path: '../../spec/fixtures/cookbooks/example_cookbook-0.5.0'
+    solver :unknown
+    """
+  When I successfully run `berks install`
+  Then the output should contain:
+    """
+    Resolving cookbook dependencies...
+    """
+
+  Scenario: when preferring the :gecode solver engine, no error is raised
+  Given I have a Berksfile pointing at the local Berkshelf API with:
+    """
+    cookbook 'example_cookbook', path: '../../spec/fixtures/cookbooks/example_cookbook-0.5.0'
+    solver :gecode, :preferred
+    """
+  When I successfully run `berks install`
+  Then the output should contain:
+    """
+    Resolving cookbook dependencies...
+    """
+
+  Scenario: when preferring an unknown solver engine, no error is raised
+  Given I have a Berksfile pointing at the local Berkshelf API with:
+    """
+    cookbook 'example_cookbook', path: '../../spec/fixtures/cookbooks/example_cookbook-0.5.0'
+    solver :unknown, :preferred
+    """
+  When I successfully run `berks install`
+  Then the output should contain:
+    """
+    Resolving cookbook dependencies...
+    """
+
+  Scenario: when requiring an unknown solver engine, an error is raised
+  Given I have a Berksfile pointing at the local Berkshelf API with:
+    """
+    cookbook 'example_cookbook', path: '../../spec/fixtures/cookbooks/example_cookbook-0.5.0'
+    solver :unknown, :required
+    """
+  When I run `berks install`
+  Then the output should contain:
+    """
+    Engine `unknown` is not supported.
+    """
+    And the exit status should be "ArgumentError"
+
+  Scenario: when requiring the :ruby solver engine, no error is raised
+  Given I have a Berksfile pointing at the local Berkshelf API with:
+    """
+    cookbook 'example_cookbook', path: '../../spec/fixtures/cookbooks/example_cookbook-0.5.0'
+    solver :ruby, :required
+    """
+  When I successfully run `berks install`
+  Then the output should contain:
+    """
+    Resolving cookbook dependencies...
+    """
+
+  Scenario: when requiring the :gecode solver engine, no error is raised
+  Given I have a Berksfile pointing at the local Berkshelf API with:
+    """
+    cookbook 'example_cookbook', path: '../../spec/fixtures/cookbooks/example_cookbook-0.5.0'
+    solver :gecode, :required
+    """
+  When I successfully run `berks install`
+  Then the output should contain:
+    """
+    Resolving cookbook dependencies...
+    """

--- a/spec/unit/berkshelf/berksfile_spec.rb
+++ b/spec/unit/berkshelf/berksfile_spec.rb
@@ -9,6 +9,7 @@ describe Berkshelf::Berksfile do
         cookbook 'mysql'
         cookbook 'nginx', '< 0.101.2'
         cookbook 'ssh_known_hosts2', :git => 'https://github.com/erikh/chef-ssh_known_hosts2.git'
+        solver :foo, :required
         EOF
       end
       let(:berksfile) { tmp_path.join('Berksfile') }
@@ -404,6 +405,31 @@ describe Berkshelf::Berksfile do
     it 'excludes the top-level metadata.rb file' do
       expect(excludes[:exclude].any? { |exclude| File.fnmatch?(exclude, 'my_cookbook/recipes/metadata.rb', File::FNM_DOTMATCH) }).to be(false)
       expect(excludes[:exclude].any? { |exclude| File.fnmatch?(exclude, 'my_cookbook/metadata.rb', File::FNM_DOTMATCH) }).to be(true)
+    end
+  end
+
+  describe '#solver' do
+
+    let(:solver_precedence) { :please_dont_exist }
+
+    it "defaults to nil required solver and :gecode preferred solver" do
+      expect(subject.preferred_solver).to equal(:gecode)
+      expect(subject.required_solver).to equal(nil)
+    end
+
+    it "adds preferred and required solvers" do
+      subject.solver(:a, :preferred)
+      subject.solver(:b, :required)
+      expect(subject.preferred_solver).to equal(:a)
+      expect(subject.required_solver).to equal(:b)
+    end
+
+    it "raises an exception with a bad precedence" do
+      expect { subject.solver(:foo, :bar) }.to raise_error(/Invalid solver precedence ':bar'/)
+    end
+
+    it "is a DSL method" do
+      expect(subject).to have_exposed_method(:solver)
     end
   end
 end

--- a/spec/unit/berkshelf/resolver_spec.rb
+++ b/spec/unit/berkshelf/resolver_spec.rb
@@ -4,6 +4,11 @@ describe Berkshelf::Resolver do
   let(:berksfile) { double('berksfile') }
   let(:demand) { Berkshelf::Dependency.new(berksfile, "mysql", constraint: "= 1.2.4") }
 
+  before(:each) do
+    allow(berksfile).to receive(:required_solver).and_return(nil)
+    allow(berksfile).to receive(:preferred_solver).and_return(nil)
+  end
+
   describe "ClassMethods" do
     describe "::initialize" do
       it 'adds the specified dependencies to the dependencies hash' do
@@ -58,5 +63,27 @@ describe Berkshelf::Resolver do
     end
   end
 
-  describe "#resolve"
+  describe "#resolve" do
+    describe 'given a missing required solver' do
+      before do
+        allow(berksfile).to receive(:required_solver).and_return(:xyzzy)
+        allow(berksfile).to receive(:preferred_solver).and_return(nil)
+      end
+
+      it 'should raise an exception about missing required resolver :xyzzy' do
+        expect { subject.compute_solver_engine(berksfile) }.to raise_error(/Engine `xyzzy` is not supported/)
+      end
+    end
+
+    describe 'given a missing preferred solver' do
+      before do
+        allow(berksfile).to receive(:required_solver).and_return(nil)
+        allow(berksfile).to receive(:preferred_solver).and_return(:xyzzy)
+      end
+
+      it 'should not raise an exception about missing preferred resolver :xyzzy' do
+        expect { subject.compute_solver_engine(berksfile) }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add a new option to the Berksfile `solver`, that accepts one or two symbols as parameters:
```
solver :foo # defaults to :preferred
solver :bar, :preferred # attempts to set 'solve' gem's solver engine to :bar, silently accepts failure
solver :baz, :required # attempts to set 'solve' gem's solver engine to :baz, raises an error on failure
solver :xyz, :badvalue # always raises an exception
```

This additional instruction allows Berkshelf users to choose what dependency resolver they would like to use, from [any that are supported by berkshelf/solve](https://github.com/berkshelf/solve#selecting-a-resolver) -- namely, `:ruby` (solve gem default) or `:gecode` (chef default). This also builds on the work done in #1475 to support the latest solve gem version.

Be warned that changing to a non-default dependency solver may introduce subtle bugs caused by Chef Server and local Berkshelf using different dependency solvers. This could lead to slightly different dependencies being selected depending on where the dependency constraints are being resolved.