### PR TITLE
Pin aruba to 0.10.2

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'celluloid',            '= 0.16.0'
   s.add_dependency 'celluloid-io',         '~> 0.16.1'
 
-  s.add_development_dependency 'aruba',         '~> 0.6'
+  s.add_development_dependency 'aruba',         '~> 0.10.0' # Lock this here to avoid problems with public API changes
   s.add_development_dependency 'chef-zero',     '~> 4.0'
   s.add_development_dependency 'dep_selector',  '~> 1.0'
   s.add_development_dependency 'fuubar',        '~> 2.0'


### PR DESCRIPTION
When aruba was using 0.11 (the latest), builds would fail because names
of constants had changed in the API. This pins aruba to 0.10.2 in the
gemspec to ensure a working version is used.