### PR TITLE
Run Chef proxy tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
+addons:
+  apt:
+    packages:
+      - chef
+      - git
+      - graphviz
+      - libarchive12
+      - libarchive-dev
+      - libgecode-dev
+    sources:
+      - chef-stable-precise
+cache:
+  - apt
+  - bundler
+dist: precise
+env:
+  global: USE_SYSTEM_GECODE=1
 language: ruby
-rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
 notifications:
   irc:
     channels:
@@ -15,12 +28,31 @@ notifications:
 branches:
   only:
     - master
-env: USE_SYSTEM_GECODE=1
 bundler_args: --without guard --jobs 7
-before_install:
-  - sudo apt-get install -qq libarchive12 libarchive-dev libgecode-dev graphviz
 before_script:
   - echo "StrictHostKeyChecking no" > ~/.ssh/config
   - git config --global user.email "ci@berkshelf.com"
   - git config --global user.name "Berkshelf"
+matrix:
+  include:
+    - rvm: 2.0.0
+    - rvm: 2.1
+    - rvm: 2.2
+    - rvm: 2.2
+      before_install:
+        # Failures in the berkshelf-api gemspec were happening with bundler 1.8
+        - gem install bundler --version=1.10.6
+        # Needed until https://github.com/travis-ci/apt-package-whitelist/pull/1820 is merged
+        - sudo apt-get update
+        - sudo apt-get -y install squid3
+      sudo: required
+      env:
+        - PROXY_TESTS_DIR=/tmp/proxy_tests
+        - PROXY_TESTS_REPO=$PROXY_TESTS_DIR/repo
+        - rvmsudo_secure_path=1
+      script:
+        - git clone https://github.com/chef/proxy_tests.git
+        - cd proxy_tests && chef-client -z -o proxy_tests::render && cd ..
+        - rvmsudo -E bundle exec bash $PROXY_TESTS_DIR/run_tests.sh berkshelf \* \* /tmp/out.txt
+      after_script: cat /tmp/out.txt
 script: bundle exec thor spec:ci


### PR DESCRIPTION
This makes it so that Travis runs tests from
[chef/proxy_tests](https://github.com/chef/proxy_tests) to ensure
Berkshelf behaves with proxies in an expected way.

Also use the travis apt addon to install packages, turn on package and
gem caching, and ensure the we build on precise.