### PR TITLE
Add docs about proxy config and various other edits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,1 @@
-rvm:
-  - 1.9.3
-  - ruby-head
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-script: 'jekyll --no-auto --no-server'
+script: jekyll build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# berkshelf.com
+
+This branch of berkshelf contains the content for http://berkshelf.com. It uses
+the [jekyll](http://jekyllrb.com/) static site generator.
+
+## Running Locally
+
+Ruby and the bundler gem are required.
+
+Run `bundle install`, `bundle exec jekyll serve --watch`, and open
+http://localhost:4000 in your browser.

--- a/_includes/index.md
+++ b/_includes/index.md
@@ -1,8 +1,8 @@
 ## Getting Started
 
-Berkshelf is now included as part of the [Chef-DK](https://downloads.chef.io/chef-dk/). This is fastest, easiest, and the recommended installation method for getting up and running with Berkshelf.
+Berkshelf is now included as part of the [ChefDK](https://downloads.chef.io/chef-dk/). This is fastest, easiest, and the recommended installation method for getting up and running with Berkshelf.
 
-Ensure that the Chef-DK is added to *the front* of your path
+Ensure that the ChefDK is added to *the front* of your path
 
     $ PATH=$HOME/.chefdk/gem/ruby/2.1.0/bin:/opt/chefdk/bin:$PATH
 
@@ -96,7 +96,9 @@ This will output all of the cookbooks to `pwd/berks-cookbooks`
 
 ## Configuring Berkshelf
 
-Berkshelf will run with a default configuration unless you explicitly generate one. By default, Berkshelf uses the values found in your Knife configuration (if you have one).
+Berkshelf will run with a default configuration unless you explicitly generate
+one. By default, Berkshelf uses the values found in your
+[Chef configuration](https://docs.chef.io/config_rb.html) (if you have one).
 
 You can override this default behavior by create a configuration file and placing it at `~/.berkshelf/config.json`
 
@@ -118,6 +120,11 @@ You can override this default behavior by create a configuration file and placin
 * `github` - an array of hashes containing Github credentials to authenticate against downloading cached Github cookbooks.
 
 > The configuration values are notated in 'dotted path' format. These translate to a nested JSON structure.
+
+### Proxy settings
+
+Berkshelf will use proxy settings from a Chef configuration file and will use
+the `http_proxy` and `https_proxy` environment variables if they are set.
 
 ## Vagrant with Berkshelf
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
     <div class="wrapper">
       <header>
         <div id='prod-versions'>
-          <a class="current" href="/">v3.0</a>
+          <a class="current" href="/">Current Version</a> /
           <a href="/v2.0/">v2.0</a>
         </div>
         <h1 class="header"><a href="./index.html">Berkshelf</a></h1>


### PR DESCRIPTION
* Add a README.md
* Say "Current Version" instead of "3.0" in the nav
* Call it "ChefDK" not "Chef-DK"
* Call it "Chef configuration" (with a link to the chef docs) not "Knife
  configuration"
* Update .travis.yml to work with newer jekyll