### PR TITLE
Update Vagrantfile generator default vm box

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -107,7 +107,7 @@ module Berkshelf
       default: false
     attribute 'vagrant.vm.box',
       type: String,
-      default: 'chef/ubuntu-14.04',
+      default: 'bento/ubuntu-14.04',
       required: true
     # @todo Deprecated, remove?
     attribute 'vagrant.vm.box_url',

--- a/spec/unit/berkshelf/init_generator_spec.rb
+++ b/spec/unit/berkshelf/init_generator_spec.rb
@@ -28,7 +28,7 @@ describe Berkshelf::InitGenerator do
         file 'Vagrantfile' do
           contains %(recipe[some_cookbook::default])
           contains %(config.omnibus.chef_version = 'latest')
-          contains %(config.vm.box = 'chef/ubuntu-14.04')
+          contains %(config.vm.box = 'bento/ubuntu-14.04')
         end
         file 'chefignore'
       }


### PR DESCRIPTION
It seems that Chef is now using the bento project to generate their base
boxes for vagrant. These boxes are all listed under
bento/distro-version, instead of chef/distro-version. The current config
for vm.box is causing vagrant up to fail. This commit updates the
config.vm.box variable and an associated test to reflect this change.

http://chef.github.io/bento/