### PR TITLE
Update the chef-config pin to 12.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.6.0)
+    chef-config (12.7.2)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
     chef-zero (4.5.0)


### PR DESCRIPTION
This is the latest version of chef-config available.
If anybody (delivery) does a `require 'chef'` in their
`knife.rb` with the latest chefdk/chef, things will die
because chef pins hard to chef-config 12.7.2 while berkshelf
has loaded 12.6.0.