### PR TITLE
updating httpclient version dep to ~> 2.7.0

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'buff-shell_out',       '~> 0.1'
   s.add_dependency 'cleanroom',            '~> 1.0'
   s.add_dependency 'faraday',              '~> 0.9.0'
-  s.add_dependency 'httpclient',           '~> 2.6.0'
+  s.add_dependency 'httpclient',           '~> 2.7.0'
   s.add_dependency 'minitar',              '~> 0.5.4'
   s.add_dependency 'retryable',            '~> 2.0'
   s.add_dependency 'ridley',               '~> 4.3'


### PR DESCRIPTION
This will get rid of the 'warning: already initialized constant HTTPClient::CookieManager' warning in ChefDK