### PR TITLE
Add introductory docs for newcomers.

### DIFF
--- a/docs/berkshelf_for_newcomers.md
+++ b/docs/berkshelf_for_newcomers.md
@@ -1,0 +1,65 @@
+# Berkshelf for Newcomers
+
+Berkshelf is a tool to help manage cookbook dependencies.  If your cookbook depends on other cookbooks, Berkshelf lets you do the following:
+
+* download all cookbooks you depend on to your local machine for development and testing using `berks install`
+* upload your cookbook and all dependencies to your Chef server using `berks upload`
+* update your dependencies using `berks update`
+
+The above are the main Berkshelf commands that will comprise the bulk of your workflow.
+
+Berkshelf is included in the ChefDK (at least at v.0.10.0), and `chef generate cookbook` will set up your cookbook with the necessary files for Berkshelf usage.
+
+## A quick example
+
+Suppose you have a cookbook with the following `metadata.rb`:
+
+```
+name 'example_cookbook'
+description 'Installs/Configures example_cookbook'
+long_description 'Installs/Configures example_cookbook'
+version '0.1.0'
+
+depends 'apt', '~> 2.3'
+```
+
+To work on this cookbook locally, you need to download an `apt` cookbook matching the constraints.  Berkshelf handles this for you:
+
+```
+$ berks install
+Resolving cookbook dependencies...
+Fetching 'example_cookbook' from source at .
+Fetching cookbook index from https://supermarket.chef.io...
+Using example_cookbook (0.1.0) from source at .
+Using apt (2.9.2)
+```
+
+When done your work, you need to push both your cookbook and the apt cookbook up to your Chef server.  With Berkshelf:
+
+```
+$ berks upload
+Uploaded apt (2.9.2) to: 'https://your_chef_server_url'
+Uploaded example_cookbook (0.1.0) to: 'your_chef_server_url'
+```
+
+The above is a trivial example.  If your cookbook has several dependencies, which in turn have dependencies, Berkshelf handles it all automatically, significantly improving your workflow.
+
+## What's in the background
+
+* the cookbook's `metadata.rb` specifies the cookbook dependencies and required versions
+* the [Berksfile](http://berkshelf.com/v2.0/#the-berksfile) in your cookbook's root directory tells Berkshelf where to find cookbooks.  You can have multiple sources, or can pull individual cookbooks from specific locations, such as your own Supermarket, GitHub, or a file server.
+* `berks install` downloads cookbooks and their dependencies to the [Berkshelf](http://berkshelf.com/v2.0/#the-berkshelf), a place on your local disk.
+* a Berksfile.lock is generated on `berks install` which specifies the exact cookbook versions that were used at that point
+
+## Cookbook versioning
+
+Berkshelf relies on cookbook versioning to work correctly.  A cookbook's version is tracked in its `metadata.rb`, and should follow the guidelines outlined at http://semver.org/.
+
+# Further reading
+
+* The project homepage, http://http://berkshelf.com/v2.0/
+* https://sethvargo.com/berkshelf-workflow/
+
+--
+
+Good luck with Berkshelf!


### PR DESCRIPTION
I need to introduce Chef and Berkshelf to a number of employees in my company.  I read the official sites (http://berkshelf.com/ and http://berkshelf.com/v2.0/, as well as the README) and watched some videos, but needed a 30-second summary on what Berkshelf could do.  I put this together for my own training efforts, but felt that the community could benefit as well.

This doc:

* demonstrates immediately what Berkshelf can do, so a newcomer can understand what the benefit of the tool is without getting into the details of installation, config, etc
* assumes that the reader has gone through the Chef tutorials (https://learn.chef.io/tutorials/, "Learn to develop your infrastructure code locally").  Those tutorials cover Vagrant installation, etc, and also introduce Berkshelf briefly.
* (hopefully) clarifies the relationship between the metadata file and the berksfile.  The official Berkshelf sites (current and v2) implies that dependencies are listed in the Berksfile, whereas the docs at learn.chef.io say that dependencies should be listed in the metadata.rb.  I've sided with learn.chef.io, as I expect that newcomers to Chef will likely be going through that site at first.
* steals a bit from the official sites.  Only a bit, though.

I wasn't sure where to put this in the code, and so added a docs folder.  Let me know if it should go somewhere else; perhaps it belongs at http://berkshelf.com/v2.0/ instead.

If this is useful, please take it and use it.  No worries if it's not useful.  Ping if I can help.

Regards,
jz
