### PR TITLE
Support downloading universe from chef servers

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.8.0'
 
   s.add_dependency 'addressable',          '~> 2.3', '>= 2.3.4'
-  s.add_dependency 'berkshelf-api-client', '~> 2.0'
+  s.add_dependency 'berkshelf-api-client', '~> 2.0', '>= 2.0.2'
   s.add_dependency 'buff-config',          '~> 1.0'
   s.add_dependency 'buff-extensions',      '~> 1.0'
   s.add_dependency 'buff-shell_out',       '~> 0.1'
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'httpclient',           '~> 2.7'
   s.add_dependency 'minitar',              '~> 0.5', '>= 0.5.4'
   s.add_dependency 'retryable',            '~> 2.0'
-  s.add_dependency 'ridley',               '~> 4.4', '>= 4.4.3'
+  s.add_dependency 'ridley',               '~> 4.5'
   s.add_dependency 'solve',                '~> 2.0'
   s.add_dependency 'thor',                 '~> 0.19'
   s.add_dependency 'octokit',              '~> 4.0'

--- a/lib/berkshelf/source.rb
+++ b/lib/berkshelf/source.rb
@@ -5,13 +5,40 @@ module Berkshelf
     include Comparable
 
     # @return [Berkshelf::SourceURI]
-    attr_reader :uri
+    attr_accessor :uri
+
+    # @return [Berkshelf::APIClient]
+    attr_accessor :api_client
+
+    attr_accessor :source
 
     # @param [String, Berkshelf::SourceURI] uri
-    def initialize(uri)
-      @uri        = SourceURI.parse(uri)
-      @api_client = APIClient.new(uri, ssl: {verify: Berkshelf::Config.instance.ssl.verify})
+    def initialize(source)
+      @source = source
       @universe   = nil
+    end
+
+    def api_client
+      @api_client ||= begin
+                        if source == :chef_server
+                          APIClient.chef_server(
+                            ssl: {verify: Berkshelf::Config.instance.ssl.verify},
+                            client_name: Berkshelf::Config.instance.chef.node_name,
+                            server_url: Berkshelf::Config.instance.chef.chef_server_url,
+                            client_key: Berkshelf::Config.instance.chef.client_key,
+                          )
+                        else
+                          APIClient.new(uri, ssl: {verify: Berkshelf::Config.instance.ssl.verify})
+                        end
+                      end
+    end
+
+    def uri
+      @uri ||= if source == :chef_server
+                 SourceURI.parse(Berkshelf::Config.instance.chef.chef_server_url)
+               else
+                 SourceURI.parse(source)
+               end
     end
 
     # Forcefully obtain the universe from the API endpoint and assign it to {#universe}. This
@@ -53,7 +80,7 @@ module Berkshelf
       universe
         .select { |cookbook| cookbook.name =~ Regexp.new(name) }
         .group_by(&:name)
-        .collect { |name, versions| versions.max_by { |v| Semverse::Version.new(v.version) } }
+        .collect { |_, versions| versions.max_by { |v| Semverse::Version.new(v.version) } }
     end
 
     # Determine if this source is a "default" source, as defined in the
@@ -96,9 +123,5 @@ module Berkshelf
       uri == other.uri
     end
 
-    private
-
-      # @return [Berkshelf::APIClient]
-      attr_reader :api_client
   end
 end


### PR DESCRIPTION
This adds a special magical `source` type, `:chef_server`, that causes berkshelf to use universe from one's currently configured chef server