### PR TITLE
Correct usage of Net::HTTP.new

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -102,9 +102,9 @@ module Berkshelf
         end
 
         # We use Net::HTTP.new and then get here, because Net::HTTP.get does not support proxy settings.
-        http = Net::HTTP.new(url.host,
-                             use_ssl: url.scheme == "https",
-                             verify_mode: (options[:ssl_verify].nil? || options[:ssl_verify]) ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE)
+        http = Net::HTTP.new(url.host, url.port)
+        http.use_ssl = url.scheme == "https"
+        http.verify_mode = (options[:ssl_verify].nil? || options[:ssl_verify]) ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
         resp = http.get(url.request_uri)
         return nil unless resp.is_a?(Net::HTTPSuccess)
         open(archive_path, "wb") { |file| file.write(resp.body) }


### PR DESCRIPTION
Related to this change: https://github.com/berkshelf/berkshelf/pull/1467

`Net::HTTP.new` doesn't accept `use_ssl` and `verify_mode` attributes.

so it results in an error:

```
E, [2016-03-10T11:42:05.846034 #11863] ERROR -- : Actor crashed!
NoMethodError: undefined method `to_i' for {:use_ssl=>true, :verify_mode=>1}:Hash
```

because this hash `{:use_ssl=>true, :verify_mode=>1}` goes to Net::HTTP internal `port` variables.

This PR fixes this issue by setting `http.use_ssl` and `http.verify_mode` using correct methods.