### PR TITLE
Address issue #1400: Don't remove custom cookbooks

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -668,7 +668,13 @@ module Berkshelf
         #
         #   * https://tickets.opscode.com/browse/CHEF-4811
         #   * https://tickets.opscode.com/browse/CHEF-4810
-        FileSyncer.sync(scratch, destination, exclude: raw_metadata_files + EXCLUDED_VCS_FILES_WHEN_VENDORING)
+        exclude = raw_metadata_files.concat(EXCLUDED_VCS_FILES_WHEN_VENDORING)
+        sources = FileSyncer.glob(File.join(scratch, '*'))
+
+        sources.each do |src|
+          cookbook_name = File.basename(src)
+          FileSyncer.sync(src, File::join(destination, cookbook_name), exclude: exclude)
+        end
       end
 
       destination


### PR DESCRIPTION
Syncs individual cookbooks into the vendor location leaving the existing contents untouched.

Not sure how to test for this. The `bundle install` command fails on my environment when I attempt to run the test suite (Ubuntu 14.04 64bit).