### PR TITLE
allow user to change git url handler

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -135,5 +135,10 @@ module Berkshelf
       type: Array,
       default: [],
       required: false
+    attribute 'github.transport',
+      # git, ssh, or https
+      type: String,
+      default: 'git',
+      required: false
   end
 end

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -136,7 +136,7 @@ module Berkshelf
       default: [],
       required: false
     attribute 'github.protocol',
-      # git, ssh, or https
+      # :git, :ssh, or :https
       type: Symbol,
       default: :git,
       required: false

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -135,10 +135,10 @@ module Berkshelf
       type: Array,
       default: [],
       required: false
-    attribute 'github.transport',
+    attribute 'github.protocol',
       # git, ssh, or https
-      type: String,
-      default: 'git',
+      type: Symbol,
+      default: :git,
       required: false
   end
 end

--- a/lib/berkshelf/locations/github.rb
+++ b/lib/berkshelf/locations/github.rb
@@ -2,13 +2,14 @@ module Berkshelf
   class GithubLocation < GitLocation
     HOST = 'github.com'
     def initialize(dependency, options = {})
-      transport = Berkshelf::Config.instance.github.transport || 'git'
-      case transport.downcase
-      when 'ssh'
+      protocol = Berkshelf::Config.instance.github.protocol || :git
+      case protocol
+      when :ssh
         options[:git] = "git@#{HOST}:#{options.delete(:github)}.git"
-      when 'https'
+      when :https
         options[:git] = "https://#{HOST}/#{options.delete(:github)}.git"
       else
+        # if some bizarre value is provided, treat it as :git
         options[:git] = "git://#{HOST}/#{options.delete(:github)}.git"
       end
       super

--- a/lib/berkshelf/locations/github.rb
+++ b/lib/berkshelf/locations/github.rb
@@ -1,7 +1,16 @@
 module Berkshelf
   class GithubLocation < GitLocation
+    HOST = 'github.com'
     def initialize(dependency, options = {})
-      options[:git] = "git://github.com/#{options.delete(:github)}.git"
+      transport = Berkshelf::Config.instance.github.transport || 'git'
+      case transport.downcase
+      when 'ssh'
+        options[:git] = "git@#{HOST}:#{options.delete(:github)}.git"
+      when 'https'
+        options[:git] = "https://#{HOST}/#{options.delete(:github)}.git"
+      else
+        options[:git] = "git://#{HOST}/#{options.delete(:github)}.git"
+      end
       super
     end
   end


### PR DESCRIPTION
This PR addresses #1503 and allows the user to select what transport protocol a github directive in a Berksfile uses.  In many environments the clear-text git protocol is blocked (port 9418), so if a Berksfile has indicated github: 'some/repo' at any point, a user is going to have to fork and maintain their own version so they can switch to the long form git: option to utilize ssh or https. This PR makes the protocol  dynamic via the github.protocol item in the config file.  Supported protocols are :git (default), :ssh, and :https