### PR TITLE
Fixing some specs that fail on Windows

### DIFF
--- a/lib/berkshelf/mixin/git.rb
+++ b/lib/berkshelf/mixin/git.rb
@@ -13,7 +13,7 @@ module Berkshelf
       # @raise [String]
       #   the +$stdout+ from the command
       def git(command, error = true)
-        unless Berkshelf.which('git') || Berkshelf.which('git.exe')
+        unless Berkshelf.which('git') || Berkshelf.which('git.exe') || Berkshelf.which('git.bat')
           raise GitNotInstalled.new
         end
 

--- a/spec/unit/berkshelf/file_syncer_spec.rb
+++ b/spec/unit/berkshelf/file_syncer_spec.rb
@@ -180,7 +180,7 @@ module Berkshelf
         end
       end
 
-      context 'with deeply nested paths and symlinks' do
+      context 'with deeply nested paths and symlinks', :not_supported_on_windows do
         let(:source) do
           source = File.join(tmp_path, 'source')
           FileUtils.mkdir_p(source)

--- a/spec/unit/berkshelf/lockfile_spec.rb
+++ b/spec/unit/berkshelf/lockfile_spec.rb
@@ -5,16 +5,17 @@ describe Berkshelf::Lockfile do
   subject { Berkshelf::Lockfile.new(filepath: filepath) }
 
   describe '.from_berksfile' do
+    let(:lock_path) { File.absolute_path('/path/to/Bacon') }
     let(:berksfile) do
       double('Berksfile',
-        filepath: '/path/to/Bacon',
+        filepath: lock_path,
       )
     end
 
     subject { described_class.from_berksfile(berksfile) }
 
     it 'uses the basename of the Berksfile' do
-      expect(subject.filepath).to eq("/path/to/Bacon.lock")
+      expect(subject.filepath).to eq("#{lock_path}.lock")
     end
   end
 


### PR DESCRIPTION
The motivation for this is to make sure Berkshelf finds the git we're soon-to-be bundling inside the ChefDK. But we fixed a few other tests while we were in here.

\cc @reset @tylercloke @berkshelf/berks-core 