### PR TITLE
Add ability to set the default solver in global berks config

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -67,7 +67,7 @@ module Berkshelf
 
       # defaults for what solvers to use
       @required_solver  = nil
-      @preferred_solver = :gecode
+      @preferred_solver = Berkshelf.config.default_resolver.to_sym
 
       if options[:except] && options[:only]
         raise ArgumentError, 'Cannot specify both :except and :only!'

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -99,6 +99,9 @@ module Berkshelf
     attribute 'cookbook.license',
       type: String,
       default: Berkshelf.chef_config.cookbook_license
+    attribute 'default_resolver',
+      type: String,
+      default: 'gecode'
     attribute 'allowed_licenses',
       type: Array,
       default: Array.new

--- a/spec/unit/berkshelf/berksfile_spec.rb
+++ b/spec/unit/berkshelf/berksfile_spec.rb
@@ -424,6 +424,20 @@ describe Berkshelf::Berksfile do
       expect(subject.required_solver).to equal(:b)
     end
 
+    context 'when the default_solver is set in the berks config file' do
+      let(:berkshelf_config) do
+        double(RbConfig, default_resolver: "override")
+      end
+
+      before do
+        allow(Berkshelf).to receive(:config).and_return(berkshelf_config)
+      end
+
+      it "sets the preferred solver from berks config file" do
+        expect(subject.preferred_solver).to equal(:override)
+      end
+    end
+
     it "raises an exception with a bad precedence" do
       expect { subject.solver(:foo, :bar) }.to raise_error(/Invalid solver precedence ':bar'/)
     end


### PR DESCRIPTION
- Moves the default berkshelf solver preference into the global config
- Keeps same default to :gecode