### PR TITLE
options for mv could be "force" but not for cp_r

### DIFF
--- a/lib/berkshelf/core_ext/file_utils.rb
+++ b/lib/berkshelf/core_ext/file_utils.rb
@@ -8,6 +8,7 @@ module FileUtils
     # @see {FileUtils::mv}
     # @see {safe_mv}
     def mv(src, dest, options = {})
+      options.delete(:force) if options.has_key?(:force)
       FileUtils.cp_r(src, dest, options)
       FileUtils.rm_rf(src)
     end


### PR DESCRIPTION
Sometimes, people use the FileUtils.mv with the option force, but this will cause error in the FileUtils.cp_r

The cp_r can copy with overwrite, so we can just remove the "force" option.