### PR TITLE
Bump dep-selector-libgecode to 1.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
     cucumber-core (1.5.0)
       gherkin (~> 4.0)
     cucumber-wire (0.0.1)
-    dep-selector-libgecode (1.3.0)
+    dep-selector-libgecode (1.3.1)
     dep_selector (1.0.3)
       dep-selector-libgecode (~> 1.0)
       ffi (~> 1.9)


### PR DESCRIPTION
Version 1.3.0 is failing omnibus healthchecks.  Bumping to 1.3.1 to
see if it resolves the issue.