### PR TITLE
updates deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,23 @@ group :guard do
   end
 end
 
+group :development do
+  # these all deliberately float because berkshelf has a Gemfile.lock that
+  # equality pins them.  temporarily pin as necessary for API breaks.
+  gem 'aruba',         '>= 0.10.0'
+  gem 'chef-zero',     '>= 4.0'
+  gem 'dep_selector',  '>= 1.0'
+  gem 'fuubar',        '>= 2.0'
+  gem 'rake',          '>= 10.1'
+  gem 'rspec',         '>= 3.0'
+  gem 'spork',         '>= 0.9'
+  gem 'test-kitchen',  '>= 1.2'
+  gem 'webmock',       '>= 1.11'
+  gem 'yard',          '>= 0.8'
+  gem 'http',          '>= 0.9.8'
+  gem 'activesupport', '~> 4.0'  # pinning for ruby 2.1.x
+end
+
 group :changelog do
   gem 'github_changelog_generator', "1.11.3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,8 +25,6 @@ PATH
       buff-config (~> 1.0)
       buff-extensions (~> 1.0)
       buff-shell_out (~> 0.1)
-      celluloid (= 0.16.0)
-      celluloid-io (~> 0.16.1)
       cleanroom (~> 1.0)
       faraday (~> 0.9)
       httpclient (~> 2.7)
@@ -51,7 +49,7 @@ GEM
     archive (0.0.6)
       ffi (~> 1.9.3)
     artifactory (2.3.3)
-    aruba (0.10.2)
+    aruba (0.14.1)
       childprocess (~> 0.5.6)
       contracts (~> 0.9)
       cucumber (>= 1.3.19)
@@ -184,7 +182,7 @@ GEM
     hashdiff (0.3.0)
     hashie (3.4.4)
     hitimes (1.2.4)
-    http (0.9.9)
+    http (2.0.2)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 1.0.1)
@@ -259,7 +257,7 @@ GEM
     rack-mount (0.8.3)
       rack (>= 1.0.0)
     rainbow (2.1.0)
-    rake (10.5.0)
+    rake (11.2.2)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -294,7 +292,7 @@ GEM
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.1)
+    rspec-core (3.5.2)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -347,7 +345,7 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    webmock (1.24.6)
+    webmock (2.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -365,27 +363,27 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 4.0)
-  aruba (~> 0.10.0)
+  aruba (>= 0.10.0)
   berkshelf!
   berkshelf-api!
-  chef-zero (~> 4.0)
+  chef-zero (>= 4.0)
   coolline (~> 0.4.2)
-  dep_selector (~> 1.0)
-  fuubar (~> 2.0)
+  dep_selector (>= 1.0)
+  fuubar (>= 2.0)
   github_changelog_generator (= 1.11.3)
   growl
   guard (~> 1.8)
   guard-cucumber
   guard-rspec
   guard-spork
-  http (~> 0.9, >= 0.9.8)
-  rake (~> 10.1)
+  http (>= 0.9.8)
+  rake (>= 10.1)
   rb-fsevent
-  rspec (~> 3.0)
-  spork (~> 0.9)
-  test-kitchen (~> 1.2)
-  webmock (~> 1.11)
-  yard (~> 0.8)
+  rspec (>= 3.0)
+  spork (>= 0.9)
+  test-kitchen (>= 1.2)
+  webmock (>= 1.11)
+  yard (>= 0.8)
 
 BUNDLED WITH
    1.12.5

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -44,20 +44,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'solve',                '~> 2.0'
   s.add_dependency 'thor',                 '~> 0.19'
   s.add_dependency 'octokit',              '~> 4.0'
-  s.add_dependency 'celluloid',            '= 0.16.0'
-  s.add_dependency 'celluloid-io',         '~> 0.16.1'
   s.add_dependency 'mixlib-archive',       '~> 0.1'
-
-  s.add_development_dependency 'aruba',         '~> 0.10.0' # Lock this here to avoid problems with public API changes
-  s.add_development_dependency 'chef-zero',     '~> 4.0'
-  s.add_development_dependency 'dep_selector',  '~> 1.0'
-  s.add_development_dependency 'fuubar',        '~> 2.0'
-  s.add_development_dependency 'rake',          '~> 10.1'
-  s.add_development_dependency 'rspec',         '~> 3.0'
-  s.add_development_dependency 'spork',         '~> 0.9'
-  s.add_development_dependency 'test-kitchen',  '~> 1.2'
-  s.add_development_dependency 'webmock',       '~> 1.11'
-  s.add_development_dependency 'yard',          '~> 0.8'
-  s.add_development_dependency 'http',          '~> 0.9', '>= 0.9.8'
-  s.add_development_dependency 'activesupport', '~> 4.0'  # pinning for ruby 2.1.x
 end

--- a/features/step_definitions/utility_steps.rb
+++ b/features/step_definitions/utility_steps.rb
@@ -3,7 +3,9 @@ Given /^skip\s+"([^\"]+)"$/ do |msg|
 end
 
 Then /the output from \`(.+)\` should be the same as \`(.+)\`/ do |actual, expected|
-  run_simple(actual)
-  run_simple(expected)
-  expect(output_from(actual)).to eq(output_from(expected))
+  run(actual)
+  actual_output = last_command_started.stdout
+  run(expected)
+  expected_output = last_command_started.stdout
+  expect(actual_output).to eql(expected_output)
 end

--- a/spec/unit/berkshelf/validator_spec.rb
+++ b/spec/unit/berkshelf/validator_spec.rb
@@ -8,7 +8,7 @@ describe Berkshelf::Validator do
       allow(Dir).to receive(:glob).and_return(['/there are/spaces/in this/recipes/default.rb'])
       expect {
         subject.validate_files(cookbook)
-      }.to raise_error
+      }.to raise_error(Berkshelf::InvalidCookbookFiles)
     end
 
     it 'does not raise an error when the cookbook is valid' do


### PR DESCRIPTION
- moves deps to development group in the Gemfile.lock and stops
  double pinning in both places
- removes the celluloid dep since berkshelf's actual references to
  Celluloid are trivial and the dep creates additional ceremony
  when the downstream celluloid verisons are bumped (and this
  change does not bump the actual celluloid version used in the
  lockfile which proves the point).
- bumps everything that can be bumped right now
- fixes a cucumber issue with using deprecated + busted APIs
- also fixes a spec that issuing warnings