### PR TITLE
force encoding to UTF-8

### DIFF
--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -17,6 +17,8 @@ require_relative 'berkshelf/core_ext'
 require_relative 'berkshelf/thor_ext'
 
 module Berkshelf
+  Encoding.default_external = Encoding::UTF_8
+
   require_relative 'berkshelf/version'
   require_relative 'berkshelf/errors'
 


### PR DESCRIPTION
the universe of cookbooks uses UTF-8 by default, so anything using
berkshelf has to use UTF-8 by default.