### PR TITLE
Faild `berks install` with ENV['BERKSHELF_PATH']

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -26,7 +26,9 @@ Spork.prefork do
   end
 
   Before do
+
     # Legacy ENV variables until we can move over to all InProcess
+    Berkshelf.instance_variable_set(:@berkshelf_path, nil)
     ENV['BERKSHELF_PATH'] = berkshelf_path.to_s
     ENV['BERKSHELF_CONFIG'] = Berkshelf.config.path.to_s
     ENV['BERKSHELF_CHEF_CONFIG'] = chef_config_path.to_s
@@ -63,6 +65,7 @@ Spork.prefork do
   Before('@spawn') do
     aruba.config.command_launcher = :spawn
 
+    Berkshelf.instance_variable_set(:@berkshelf_path, nil)
     set_environment_variable('BERKSHELF_PATH', berkshelf_path.to_s)
     set_environment_variable('BERKSHELF_CONFIG', Berkshelf.config.path.to_s)
     set_environment_variable('BERKSHELF_CHEF_CONFIG', chef_config_path.to_s)

--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -69,8 +69,7 @@ module Berkshelf
     #
     # @return [String]
     def berkshelf_path
-      path = @berkshelf_path || ENV['BERKSHELF_PATH'] || '~/.berkshelf'
-      File.expand_path(path)
+      @berkshelf_path ||= File.expand_path(ENV['BERKSHELF_PATH'] || '~/.berkshelf')
     end
 
     # The Berkshelf configuration.

--- a/spec/unit/berkshelf_spec.rb
+++ b/spec/unit/berkshelf_spec.rb
@@ -27,6 +27,33 @@ module Berkshelf
     end
   end
 
+  describe '.berkshelf_path' do
+    before { Berkshelf.instance_variable_set(:@berkshelf_path, nil) }
+
+    context 'with default path' do
+      before do
+        @berkshelf_path = ENV['BERKSHELF_PATH']
+        ENV['BERKSHELF_PATH'] = nil
+      end
+
+      after do
+        ENV['BERKSHELF_PATH'] = @berkshelf_path
+      end
+
+      it 'is ~/.berkshelf' do
+        expect(Berkshelf.berkshelf_path).to eq File.expand_path('~/.berkshelf')
+        expect(Berkshelf.instance_variable_get(:@berkshelf_path)).to eq File.expand_path('~/.berkshelf')
+      end
+    end
+
+    context 'with ENV["BERKSHELF_PATH"]' do
+      it 'is ENV["BERKSHELF_PATH"]' do
+        expect(Berkshelf.berkshelf_path).to eq File.expand_path(ENV['BERKSHELF_PATH'])
+        expect(Berkshelf.instance_variable_get(:@berkshelf_path)).to eq File.expand_path(ENV['BERKSHELF_PATH'])
+      end
+    end
+  end
+
   describe '::log' do
     it 'returns Berkshelf::Logger' do
       expect(Berkshelf.log).to be_a(Berkshelf::Logger)


### PR DESCRIPTION
Install faild with `BERKSHELF_PATH` option.

I guess this is bug. Forget memoization to path(`Berkshelf.berkshelf_path`).

## Before

```shell
$ BERKSHELF_PATH=./config/vendor bundle exec berks install

(snip)

Git error: command `git fetch --force --tags "/private/var/folders/cj/_jc_cv4s42714h644b04x26m0000gn/T/d20160815-84760-vfaqiu/config/vendor/.cache/git/0e1399fa46874f1304803f7774f3ec5acf27e7e5"` failed. If this error persists, try removing the cache directory at '/private/var/folders/cj/_jc_cv4s42714h644b04x26m0000gn/T/d20160815-84760-vfaqiu/config/vendor/.cache/git/0e1399fa46874f1304803f7774f3ec5acf27e7e5'.Output from the command:

fatal: '/private/var/folders/cj/_jc_cv4s42714h644b04x26m0000gn/T/d20160815-84760-vfaqiu/config/vendor/.cache/git/0e1399fa46874f1304803f7774f3ec5acf27e7e5' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

This probrem is called `Berkshelf.berkshelf_path` every eval path from
https://github.com/berkshelf/berkshelf/blob/fa675460494f226438dd3fa3969786189a736193/lib/berkshelf/locations/git.rb#L58
at each modules directories.


## After

This PR fix it.

```shell
$ BERKSHELF_PATH=./config/vendor bundle exec berks install
(snip) # No error
```

Command is complete. Install cookbooks to ./config/vendor
