### PR TITLE
Atomically move git located cookbook to cache

### DIFF
--- a/lib/berkshelf/locations/git.rb
+++ b/lib/berkshelf/locations/git.rb
@@ -66,9 +66,9 @@ module Berkshelf
       # Validate the scratched path is a valid cookbook
       validate_cached!(scratch_path)
 
-      # If we got this far, we should copy
+      # If we got this far, we should atomically move
       FileUtils.rm_rf(install_path) if install_path.exist?
-      FileUtils.cp_r(scratch_path, install_path)
+      FileUtils.mv(scratch_path, install_path)
 
       # Remove the git history
       FileUtils.rm_rf(File.join(install_path, '.git'))


### PR DESCRIPTION
This will decrease race conditions when running multiple berks
installation.

Fix #1597

Change-Id: Ie7c19f1e74fb4ed21f401b51b83ffe8297e4ce1f