### PR TITLE
fix syncing windows user directories on ruby 2.3

### DIFF
--- a/lib/berkshelf/file_syncer.rb
+++ b/lib/berkshelf/file_syncer.rb
@@ -58,6 +58,11 @@ module Berkshelf
         [exclude, "#{exclude}/*"]
       end.flatten
 
+      # let glob expand the source directory in case it is an abbreviated windows
+      # user directory: C:/Users/MATTWR~1/AppData/Local/Temp
+      # so that it matches the parent of source_files
+      source = glob(source).first
+      
       source_files = glob(File.join(source, '**/*'))
       source_files = source_files.reject do |source_file|
         basename = relative_path_for(source_file, source)


### PR DESCRIPTION
I recently installed the latest chef-dk from current and my kitchen converges were not copying any of my cookbooks to the test instance. After digging into this I discovered that the `FileSyncer` was not creating the correct destinationi directories when vendoring the cookbooks because the source directory was:

```
C:/Users/MATTWR~1/AppData/Local/Temp/vendor20160912-65252-1cu8qps
```

And then after globbing the files in that directory, the child paths were expanded. So when calculating the relative destibation the parent and child source directories did not match which created a very strange destination directory name.

This only reproduces on a windows machines with a username greater than four characters.