### PR TITLE
fix cucumber tests

### DIFF
--- a/features/commands/search.feature
+++ b/features/commands/search.feature
@@ -8,9 +8,10 @@ Feature: berks search
 
   Scenario: Searching for a cookbook by partial name
     * I successfully run `berks search berkshelf-`
-    * the output should contain:
+    * the results should have the cookbooks:
       """
       berkshelf-api (1.2.2)
       berkshelf-api-server (2.2.0)
       berkshelf-cookbook-fixture (1.0.0)
       """
+    * the results should each start with "berkshelf-"

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -2,3 +2,17 @@ Then /^the exit status should be "(.+)"$/ do |name|
   error = name.split('::').reduce(Berkshelf) { |klass, id| klass.const_get(id) }
   expect(last_command_started).to have_exit_status(error.status_code)
 end
+
+Then /^the results should have the cookbooks:$/ do |cookbooks|
+  list = last_command_started.stdout
+  cookbooks.split("\n").each do |cookbook|
+    expect(list).to  include(cookbook)
+  end
+end
+
+Then /^the results should each start with "(.+)"$/ do |prefix|
+  list = last_command_started.stdout
+  list.split("\n").each do |cookbook|
+    expect(cookbook).to  start_with(prefix)
+  end
+end


### PR DESCRIPTION
Someone added a cookbook to the supermarkect that starts with `berkshelf-` andn broke our tests. This PR ensures that the search results inclede each cookbook listed AND that each result starts with the expected prefix.