### PR TITLE
Community site error message missing remote cookbook site URI

### DIFF
--- a/lib/berkshelf/errors.rb
+++ b/lib/berkshelf/errors.rb
@@ -222,7 +222,7 @@ module Berkshelf
     set_status_code(123)
 
     def initialize(uri, message)
-      @uri     = uri
+      @api_uri = uri
       @message = message
     end
 

--- a/spec/unit/berkshelf/errors_spec.rb
+++ b/spec/unit/berkshelf/errors_spec.rb
@@ -3,3 +3,18 @@ require 'spec_helper'
 describe Berkshelf::BerkshelfError do
   skip
 end
+
+describe Berkshelf::CommunitySiteError do
+  let(:api_uri) { 'https://infra.as.code' }
+  let(:message) { 'Cookbook name' }
+
+  subject { described_class.new(api_uri, message) }
+
+  it "includes the supplied uri in the error message" do
+    expect(subject.message).to include api_uri
+  end
+
+  it "includes the supplied message in the error message" do
+    expect(subject.message).to include message
+  end
+end


### PR DESCRIPTION
During today's brief moment of [Supermarket partial outage](http://status.chef.io/incidents/tkvw761v4ckk), I noticed the error message didn't show the remote cookbook site appropriately:
```
E, [2016-10-10T15:10:03.097968 #15130] ERROR -- : Actor crashed!
Berkshelf::CommunitySiteError: An unexpected error occurred retrieving 'chef_handler' (1.1.9) 
from the cookbook site at ''.
```
While debugging to see if it was a change on our end instead of a Supermarket outage I ended up correcting the error output. 

Here's what the output looks like after my change:
```
E, [2016-10-10T15:16:30.065167 #15468] ERROR -- : Actor crashed!
Berkshelf::CommunitySiteError: An unexpected error occurred retrieving 'chef_handler' (1.1.9) 
from the cookbook site at 'https://supermarket.chef.io:443/api/v1'.
```
Along with this change I also added 2 specs that assert the different parts of the error output. I can remove them if desired - specs for errors in general are skipped, if that's the chosen path for this project I can adjust my PR accordingly 😎 