### PR TITLE
Add a format option to berkz viz that outputs a dotfile

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -694,12 +694,21 @@ module Berkshelf
     #
     # @return [String] path
     #   the path where the image was written
-    def viz(outfile = nil)
+    def viz(outfile = nil, format = 'png')
       outfile = File.join(Dir.pwd, outfile || 'graph.png')
 
       validate_lockfile_present!
       validate_lockfile_trusted!
-      Visualizer.from_lockfile(lockfile).to_png(outfile)
+      vizualiser = Visualizer.from_lockfile(lockfile)
+
+      case format
+      when 'dot'
+        vizualiser.to_dot_file(outfile)
+      when 'png'
+        vizualiser.to_png(outfile)
+      else
+        raise ConfigurationError, "Vizualiser format #{format} not recognised."
+      end
     end
 
     # Get the lockfile corresponding to this Berksfile. This is necessary because

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -421,10 +421,16 @@ EOF
       desc: 'The name of the output file',
       aliases: '-o',
       banner: 'NAME'
+    method_option :outfile_format,
+      type: :string,
+      default: 'png',
+      desc: 'The format of the output file, either png or dot.',
+      aliases: '-f',
+      banner: 'FORMAT'
     desc "viz", "Visualize the dependency graph"
     def viz
       berksfile = Berksfile.from_options(options)
-      path = berksfile.viz(options[:outfile])
+      path = berksfile.viz(options[:outfile], options[:outfile_format])
 
       Berkshelf.ui.info(path)
     end

--- a/lib/berkshelf/visualizer.rb
+++ b/lib/berkshelf/visualizer.rb
@@ -76,6 +76,11 @@ module Berkshelf
       out
     end
 
+    def to_dot_file(outfile = 'graph.dot')
+      File.open(outfile, 'w') { |f| f.write(to_dot) }
+      File.expand_path(outfile)
+    end
+
     # Save the graph visually as a PNG.
     #
     # @param [String] outfile

--- a/spec/unit/berkshelf/visualizer_spec.rb
+++ b/spec/unit/berkshelf/visualizer_spec.rb
@@ -31,6 +31,15 @@ module Berkshelf
       end
 
       context 'when the graphviz command succeeds', :graphviz do
+        it 'builds a dot from a Lockfile' do
+          outfile = tmp_path.join('test-graph.dot').to_s
+          lockfile = Lockfile.from_file(fixtures_path.join('lockfiles/default.lock').to_s)
+
+          Visualizer.from_lockfile(lockfile).to_dot_file(outfile)
+
+          expect(File.exists?(outfile)).to be true
+        end
+
         it 'builds a png from a Lockfile' do
           outfile = tmp_path.join('test-graph.png').to_s
           lockfile = Lockfile.from_file(fixtures_path.join('lockfiles/default.lock').to_s)


### PR DESCRIPTION
This adds a `--format (png|dot)` option to `berks viz`.

* `--format dot` writes an unrendered graphviz dotfile.
* `--format png` matches the existing behaviour, and is the default.

I've found this useful for filtering common dependencies from large dependency graphs (100+ cookbooks), as the graph becomes hard to read at that point.