### PR TITLE
Replace Thread.exclusive with Mutex.new

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -80,7 +80,8 @@ module Berkshelf
         Celluloid.logger = nil unless ENV["DEBUG_CELLULOID"]
         Ridley.open(credentials) { |r| r.cookbook.download(name, version) }
       when :github
-        Thread.exclusive { require 'octokit' unless defined?(Octokit) }
+        mutex_for_require = Mutex.new
+        mutex_for_require.synchronize { require 'octokit' unless defined?(Octokit) }
 
         tmp_dir      = Dir.mktmpdir
         archive_path = File.join(tmp_dir, "#{name}-#{version}.tar.gz")
@@ -124,7 +125,8 @@ module Berkshelf
 
         File.join(unpack_dir, cookbook_directory)
       when :uri
-        Thread.exclusive { require 'open-uri' unless defined?(OpenURI) }
+        mutex_for_require = Mutex.new
+        mutex_for_require.synchronize { require 'open-uri' unless defined?(OpenURI) }
 
         tmp_dir      = Dir.mktmpdir
         archive_path = Pathname.new(tmp_dir) + "#{name}-#{version}.tar.gz"


### PR DESCRIPTION
This fixes #1653

I don't know enough about Ruby threading to know whether this produces the proper threading behaviour, but I have confirmed that running Berkshelf with this fix does eliminate the unwanted warnings from Ruby 2.3 about Thread.exclusive being deprecated.