### PR TITLE
Revert vendoring metadata.rb file

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -629,6 +629,8 @@ module Berkshelf
       Dir.mktmpdir('vendor') do |scratch|
         chefignore       = nil
         cached_cookbooks = install
+        raw_metadata_files = []
+
         return nil if cached_cookbooks.empty?
 
         cached_cookbooks.each do |cookbook|
@@ -646,6 +648,8 @@ module Berkshelf
           unless cookbook.compiled_metadata?
             cookbook.compile_metadata(cookbook_destination)
           end
+
+          raw_metadata_files << File::join(cookbook.cookbook_name, 'metadata.rb')
 
           FileUtils.cp_r(files, cookbook_destination)
         end
@@ -665,7 +669,7 @@ module Berkshelf
         #
         #   * https://tickets.opscode.com/browse/CHEF-4811
         #   * https://tickets.opscode.com/browse/CHEF-4810
-        FileSyncer.sync(scratch, destination, exclude: EXCLUDED_VCS_FILES_WHEN_VENDORING, delete: @delete)
+        FileSyncer.sync(scratch, destination, exclude: raw_metadata_files + EXCLUDED_VCS_FILES_WHEN_VENDORING, delete: @delete)
       end
 
       destination

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -650,6 +650,21 @@ module Berkshelf
           FileUtils.cp_r(files, cookbook_destination)
         end
 
+        # Don't vendor the raw metadata (metadata.rb). The raw metadata is
+        # unecessary for the client, and this is required until compiled metadata
+        # (metadata.json) takes precedence over raw metadata in the Chef-Client.
+        #
+        # We can change back to including the raw metadata in the future after
+        # this has been fixed or just remove these comments. There is no
+        # circumstance that I can currently think of where raw metadata should
+        # ever be read by the client.
+        #
+        # - Jamie
+        #
+        # See the following tickets for more information:
+        #
+        #   * https://tickets.opscode.com/browse/CHEF-4811
+        #   * https://tickets.opscode.com/browse/CHEF-4810
         FileSyncer.sync(scratch, destination, exclude: EXCLUDED_VCS_FILES_WHEN_VENDORING, delete: @delete)
       end
 

--- a/spec/unit/berkshelf/berksfile_spec.rb
+++ b/spec/unit/berkshelf/berksfile_spec.rb
@@ -387,9 +387,10 @@ describe Berkshelf::Berksfile do
   describe '#vendor' do
     let(:cached_cookbook)    { double(Berkshelf::CachedCookbook, cookbook_name: 'my_cookbook', path: '/my_cookbook/path', compiled_metadata?: true) }
     let(:installer)          { double(Berkshelf::Installer, run: [cached_cookbook]) }
+    let(:raw_metadata_files) { [File::join(cached_cookbook.cookbook_name, 'metadata.rb')] }
 
     let(:destination) { '/a/destination/path' }
-    let(:options)    { { :exclude => Berkshelf::Berksfile::EXCLUDED_VCS_FILES_WHEN_VENDORING, delete: nil } }
+    let(:options)    { { :exclude => raw_metadata_files + Berkshelf::Berksfile::EXCLUDED_VCS_FILES_WHEN_VENDORING, delete: nil } }
 
     before do
       allow(Berkshelf::Installer).to receive(:new).and_return(installer)
@@ -401,9 +402,9 @@ describe Berkshelf::Berksfile do
       subject.vendor(destination)
     end
 
-    it 'includes the top-level metadata.rb file' do
+    it 'excludes the top-level metadata.rb file' do
       expect(options[:exclude].any? { |exclude| File.fnmatch?(exclude, 'my_cookbook/recipes/metadata.rb', File::FNM_DOTMATCH) }).to be(false)
-      expect(options[:exclude].any? { |exclude| File.fnmatch?(exclude, 'my_cookbook/metadata.rb', File::FNM_DOTMATCH) }).to be(false)
+      expect(options[:exclude].any? { |exclude| File.fnmatch?(exclude, 'my_cookbook/metadata.rb', File::FNM_DOTMATCH) }).to be(true)
     end
   end
 


### PR DESCRIPTION
chef-zero and chef-client still don't handle metadata.rb-vs-metadata.json correctly everywhere yet.