### PR TITLE
Address hashie warning spam

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/tduffield/github-changelog-generator
-  revision: 8effcdd6988617b453669965fedc1280aa84bd7a
+  revision: c6245b58b91b863464ca88e02aa752a0658b5f30
   branch: adjust-tag-section-mapping
   specs:
     github_changelog_generator (1.14.2)
@@ -64,7 +64,7 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     archive (0.0.6)
       ffi (~> 1.9.3)
-    artifactory (2.5.1)
+    artifactory (2.6.0)
     aruba (0.14.2)
       childprocess (~> 0.5.6)
       contracts (~> 0.9)
@@ -94,12 +94,12 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.17.44)
+    chef-config (12.18.31)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
-    chef-zero (5.1.1)
+    chef-zero (5.3.0)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
       mixlib-log (~> 1.3)
@@ -165,7 +165,7 @@ GEM
       grape (>= 0.16.1)
       msgpack (>= 0.7.4)
     growl (1.0.3)
-    guard (2.14.0)
+    guard (2.14.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
       lumberjack (~> 1.0)
@@ -189,7 +189,7 @@ GEM
       guard-compat (~> 1.0)
       spork (>= 0.8.4)
     hashdiff (0.3.2)
-    hashie (3.4.6)
+    hashie (3.5.1)
     hitimes (1.2.4)
     http (2.1.0)
       addressable (~> 2.3)
@@ -201,7 +201,7 @@ GEM
     http-form_data (1.0.1)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (0.7.0)
+    i18n (0.8.0)
     ice_nine (0.11.2)
     json (1.8.6)
     libyajl2 (1.2.0)
@@ -218,7 +218,7 @@ GEM
     mixlib-authentication (1.4.1)
       mixlib-log
     mixlib-config (2.2.4)
-    mixlib-install (2.1.9)
+    mixlib-install (2.1.12)
       artifactory
       mixlib-shellout
       mixlib-versioning
@@ -227,7 +227,7 @@ GEM
     mixlib-shellout (2.2.7)
     mixlib-versioning (1.1.0)
     molinillo (0.5.5)
-    msgpack (1.0.2)
+    msgpack (1.0.3)
     multi_json (1.12.1)
     multi_test (0.1.2)
     multi_xml (0.6.0)
@@ -240,7 +240,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.0.1)
-    net-ssh-gateway (1.2.0)
+    net-ssh-gateway (1.3.0)
       net-ssh (>= 2.6.5)
     nio4r (2.0.0)
     notiffany (0.1.1)
@@ -259,7 +259,7 @@ GEM
     rainbow (2.2.1)
     rake (12.0.0)
     rb-fsevent (0.9.8)
-    rb-inotify (0.9.7)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     reel (0.6.1)
       celluloid (>= 0.15.1)

--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -1,3 +1,9 @@
+# XXX: work around logger spam from hashie
+# https://github.com/intridea/hashie/issues/394
+require "hashie"
+require "hashie/logger"
+Hashie.logger = Logger.new(nil)
+
 require "buff/extensions"
 require "cleanroom"
 require "digest/md5"


### PR DESCRIPTION
Bit of a hack.

Long term solution would probably be to remove buff-config/varia_model and the hashie dep in favor of Chef::Config and Chef::Mash objects.