### PR TITLE
Remove spork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,23 +11,22 @@ group :guard do
   gem "guard"
   gem "guard-cucumber"
   gem "guard-rspec"
-  gem "guard-spork"
 
   require "rbconfig"
 
-  if RbConfig::CONFIG["target_os"] =~ /darwin/i
+  install_if -> { RbConfig::CONFIG["target_os"] =~ /darwin/i } do
     gem "growl", require: false
     gem "rb-fsevent", require: false
 
-    if `uname`.strip == "Darwin" && `sw_vers -productVersion`.strip >= "10.8"
+    install_if -> { `uname`.strip == "Darwin" && `sw_vers -productVersion`.strip >= "10.8" } do
       gem "terminal-notifier-guard", "~> 1.5.3", require: false
     end rescue Errno::ENOENT
-
-  elsif RbConfig::CONFIG["target_os"] =~ /linux/i
+  end
+  install_if -> {RbConfig::CONFIG["target_os"] =~ /linux/i } do
     gem "libnotify",  "~> 0.8.0", require: false
     gem "rb-inotify", require: false
-
-  elsif RbConfig::CONFIG["target_os"] =~ /mswin|mingw/i
+  end
+  install_if -> { RbConfig::CONFIG["target_os"] =~ /mswin|mingw/i } do
     gem "rb-notifu", ">= 0.0.4", require: false
     gem "wdm", require: false
     gem "win32console", require: false
@@ -46,7 +45,6 @@ group :development do
   gem "dep_selector",  ">= 1.0"
   gem "fuubar",        ">= 2.0"
   gem "rspec",         ">= 3.0"
-  gem "spork",         ">= 0.9"
   gem "test-kitchen",  ">= 1.2"
   gem "webmock",       ">= 1.11"
   gem "yard",          ">= 0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,11 +177,6 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    guard-spork (2.1.0)
-      childprocess (>= 0.2.3)
-      guard (~> 2.0)
-      guard-compat (~> 1.0)
-      spork (>= 0.8.4)
     hashdiff (0.3.2)
     hashie (3.5.1)
     hitimes (1.2.4)
@@ -198,6 +193,8 @@ GEM
     i18n (0.8.0)
     ice_nine (0.11.2)
     json (1.8.6)
+    libnotify (0.8.4)
+      ffi (>= 1.0.11)
     libyajl2 (1.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -255,6 +252,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
+    rb-notifu (0.0.4)
     reel (0.6.1)
       celluloid (>= 0.15.1)
       celluloid-io (>= 0.15.0)
@@ -306,7 +304,7 @@ GEM
     solve (3.1.0)
       molinillo (>= 0.5)
       semverse (>= 1.1, < 3.0)
-    spork (0.9.2)
+    terminal-notifier-guard (1.5.3)
     test-kitchen (1.15.0)
       mixlib-install (>= 1.2, < 3.0)
       mixlib-shellout (>= 1.2, < 3.0)
@@ -335,6 +333,7 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    wdm (0.1.1)
     webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -342,6 +341,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    win32console (1.3.2)
     yard (0.9.8)
 
 PLATFORMS
@@ -361,15 +361,19 @@ DEPENDENCIES
   guard
   guard-cucumber
   guard-rspec
-  guard-spork
   http (>= 0.9.8)
+  libnotify (~> 0.8.0)
   rake (>= 10.1)
   rb-fsevent
+  rb-inotify
+  rb-notifu (>= 0.0.4)
   rspec (>= 3.0)
-  spork (>= 0.9)
+  terminal-notifier-guard (~> 1.5.3)
   test-kitchen (>= 1.2)
+  wdm
   webmock (>= 1.11)
+  win32console
   yard (>= 0.8)
 
 BUNDLED WITH
-   1.14.2
+   1.14.3

--- a/Guardfile
+++ b/Guardfile
@@ -1,20 +1,15 @@
-guard "spork" do
-  watch("Gemfile")
-  watch("spec/spec_helper.rb")  { :rspec }
-  watch(%r{^features/support/}) { :cucumber }
-end
-
-rspec_cli = "--color --drb --format Fuubar"
-rspec_cli += " --tag ~@api_client --tag ~@not_supported_on_windows" if RUBY_PLATFORM =~ /mswin|mingw|windows/
-guard "rspec", cli: rspec_cli, all_on_start: false, all_after_pass: false do
+rspec_cmd = "rspec"
+rspec_cmd += " --color --format Fuubar"
+rspec_cmd += " --tag ~@api_client --tag ~@not_supported_on_windows" if RUBY_PLATFORM =~ /mswin|mingw|windows/
+guard "rspec", cmd: rspec_cmd, all_on_start: false, all_after_pass: false do
   watch(%r{^spec/unit/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})          { |m| "spec/unit/#{m[1]}_spec.rb" }
   watch("spec/spec_helper.rb")       { "spec" }
 end
 
-cucumber_cli = "--drb --format pretty --tags ~@no_run --tags ~@wip"
-cucumber_cli += " --tags ~@spawn --tags ~@api_server" if RUBY_PLATFORM =~ /mswin|mingw|windows/
-guard "cucumber", cli: cucumber_cli, all_on_start: false, all_after_pass: false do
+cucumber_args = "--format pretty --tags ~@no_run --tags ~@wip"
+cucumber_args += " --tags ~@spawn --tags ~@api_server" if RUBY_PLATFORM =~ /mswin|mingw|windows/
+guard "cucumber", cmd_additional_args: cucumber_args, all_on_start: false, all_after_pass: false do
   watch(%r{^features/.+\.feature$})
   watch(%r{^features/support/.+$})                      { "features" }
   watch(%r{^features/step_definitions/(.+)_steps\.rb$}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || "features" }

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,82 +1,76 @@
-require "spork"
-
 def windows?
   !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
 end
 
-Spork.prefork do
-  require "aruba/cucumber"
-  require "aruba/in_process"
-  require "aruba/spawn_process"
-  require "cucumber/rspec/doubles"
-  require "berkshelf/api/rspec" unless windows?
-  require "berkshelf/api/cucumber" unless windows?
+require "aruba/cucumber"
+require "aruba/in_process"
+require "aruba/spawn_process"
+require "cucumber/rspec/doubles"
+require "berkshelf/api/rspec" unless windows?
+require "berkshelf/api/cucumber" unless windows?
 
-  Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
+Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
 
-  World(Berkshelf::RSpec::PathHelpers)
-  World(Berkshelf::RSpec::Kitchen)
+World(Berkshelf::RSpec::PathHelpers)
+World(Berkshelf::RSpec::Kitchen)
 
-  CHEF_SERVER_PORT = 26310
-  BERKS_API_PORT   = 26210
+CHEF_SERVER_PORT = 26310
+BERKS_API_PORT   = 26210
 
-  at_exit do
-    Berkshelf::RSpec::ChefServer.stop
-    Berkshelf::API::RSpec::Server.stop unless windows?
-  end
+at_exit do
+  Berkshelf::RSpec::ChefServer.stop
+  Berkshelf::API::RSpec::Server.stop unless windows?
+end
 
-  Before do
+Before do
 
-    # Legacy ENV variables until we can move over to all InProcess
-    Berkshelf.instance_variable_set(:@berkshelf_path, nil)
-    ENV["BERKSHELF_PATH"] = berkshelf_path.to_s
-    ENV["BERKSHELF_CONFIG"] = Berkshelf.config.path.to_s
-    ENV["BERKSHELF_CHEF_CONFIG"] = chef_config_path.to_s
+  # Legacy ENV variables until we can move over to all InProcess
+  Berkshelf.instance_variable_set(:@berkshelf_path, nil)
+  ENV["BERKSHELF_PATH"] = berkshelf_path.to_s
+  ENV["BERKSHELF_CONFIG"] = Berkshelf.config.path.to_s
+  ENV["BERKSHELF_CHEF_CONFIG"] = chef_config_path.to_s
 
-    aruba.config.command_launcher = :in_process
-    aruba.config.main_class = Berkshelf::Cli::Runner
-    @dirs = ["spec/tmp/aruba"] # set aruba's temporary directory
+  aruba.config.command_launcher = :in_process
+  aruba.config.main_class = Berkshelf::Cli::Runner
+  @dirs = ["spec/tmp/aruba"] # set aruba's temporary directory
 
-    stub_kitchen!
-    clean_tmp_path
-    Berkshelf.initialize_filesystem
-    Berkshelf::CookbookStore.instance.initialize_filesystem
-    reload_configs
-    Berkshelf::CachedCookbook.instance_variable_set(:@loaded_cookbooks, nil)
+  stub_kitchen!
+  clean_tmp_path
+  Berkshelf.initialize_filesystem
+  Berkshelf::CookbookStore.instance.initialize_filesystem
+  reload_configs
+  Berkshelf::CachedCookbook.instance_variable_set(:@loaded_cookbooks, nil)
 
-    endpoints = [
-      {
-        type: "chef_server",
-        options: {
-          url: "http://localhost:#{CHEF_SERVER_PORT}",
-          client_name: "reset",
-          client_key: File.expand_path("spec/config/berkshelf.pem"),
-        },
+  endpoints = [
+    {
+      type: "chef_server",
+      options: {
+        url: "http://localhost:#{CHEF_SERVER_PORT}",
+        client_name: "reset",
+        client_key: File.expand_path("spec/config/berkshelf.pem"),
       },
-    ]
+    },
+  ]
 
-    Berkshelf::RSpec::ChefServer.start(port: CHEF_SERVER_PORT)
-    Berkshelf::API::RSpec::Server.start(port: BERKS_API_PORT, endpoints: endpoints) unless windows?
+  Berkshelf::RSpec::ChefServer.start(port: CHEF_SERVER_PORT)
+  Berkshelf::API::RSpec::Server.start(port: BERKS_API_PORT, endpoints: endpoints) unless windows?
 
-    aruba.config.io_wait_timeout = Cucumber::JRUBY ? 7 : 5
-    @aruba_timeout_seconds = Cucumber::JRUBY ? 35 : 15
-  end
-
-  Before("@spawn") do
-    aruba.config.command_launcher = :spawn
-
-    Berkshelf.instance_variable_set(:@berkshelf_path, nil)
-    set_environment_variable("BERKSHELF_PATH", berkshelf_path.to_s)
-    set_environment_variable("BERKSHELF_CONFIG", Berkshelf.config.path.to_s)
-    set_environment_variable("BERKSHELF_CHEF_CONFIG", chef_config_path.to_s)
-  end
-
-  Before("@slow_process") do
-    aruba.config.io_wait_timeout = Cucumber::JRUBY ? 70 : 30
-    @aruba_timeout_seconds = Cucumber::JRUBY ? 140 : 60
-  end
+  aruba.config.io_wait_timeout = Cucumber::JRUBY ? 7 : 5
+  @aruba_timeout_seconds = Cucumber::JRUBY ? 35 : 15
 end
 
-Spork.each_run do
-  require "berkshelf/cli"
+Before("@spawn") do
+  aruba.config.command_launcher = :spawn
+
+  Berkshelf.instance_variable_set(:@berkshelf_path, nil)
+  set_environment_variable("BERKSHELF_PATH", berkshelf_path.to_s)
+  set_environment_variable("BERKSHELF_CONFIG", Berkshelf.config.path.to_s)
+  set_environment_variable("BERKSHELF_CHEF_CONFIG", chef_config_path.to_s)
 end
+
+Before("@slow_process") do
+  aruba.config.io_wait_timeout = Cucumber::JRUBY ? 70 : 30
+  @aruba_timeout_seconds = Cucumber::JRUBY ? 140 : 60
+end
+
+require "berkshelf/cli"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,89 +1,83 @@
-require "spork"
-
 def windows?
   !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
 end
 
 BERKS_SPEC_DATA = File.expand_path("../data", __FILE__)
 
-Spork.prefork do
-  require "rspec"
-  require "cleanroom/rspec"
-  require "webmock/rspec"
-  require "berkshelf/api/rspec" unless windows?
+require "rspec"
+require "cleanroom/rspec"
+require "webmock/rspec"
+require "berkshelf/api/rspec" unless windows?
 
-  Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
+Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
 
-  RSpec.configure do |config|
-    config.include Berkshelf::RSpec::FileSystemMatchers
-    config.include Berkshelf::RSpec::ChefAPI
-    config.include Berkshelf::RSpec::ChefServer
-    config.include Berkshelf::RSpec::Git
-    config.include Berkshelf::RSpec::PathHelpers
-    config.include Berkshelf::API::RSpec unless windows?
+RSpec.configure do |config|
+  config.include Berkshelf::RSpec::FileSystemMatchers
+  config.include Berkshelf::RSpec::ChefAPI
+  config.include Berkshelf::RSpec::ChefServer
+  config.include Berkshelf::RSpec::Git
+  config.include Berkshelf::RSpec::PathHelpers
+  config.include Berkshelf::API::RSpec unless windows?
 
-    config.expect_with :rspec do |c|
-      c.syntax = :expect
-    end
-
-    config.mock_with :rspec
-    config.filter_run focus: true
-    config.filter_run_excluding not_supported_on_windows: windows?
-    config.run_all_when_everything_filtered = true
-
-    config.before(:each) do
-      Berkshelf.logger = Berkshelf::Logger.new(nil)
-      Berkshelf.set_format(:null)
-      Berkshelf.ui.mute!
-    end
-
-    config.before(:suite) do
-      WebMock.disable_net_connect!(allow_localhost: true, net_http_connect_on_start: true)
-      Berkshelf::RSpec::ChefServer.start
-      Berkshelf::API::RSpec::Server.start unless windows?
-    end
-
-    config.before(:all) do
-      ENV["BERKSHELF_PATH"] = berkshelf_path.to_s
-    end
-
-    config.before(:each) do
-      Berkshelf::API::RSpec::Server.clear_cache unless windows?
-      clean_tmp_path
-      Berkshelf.initialize_filesystem
-      Berkshelf::CookbookStore.instance.initialize_filesystem
-      reload_configs
-    end
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
   end
 
-  def capture(stream)
-    begin
-      stream = stream.to_s
-      eval "$#{stream} = StringIO.new"
-      yield
-      result = eval("$#{stream}").string
-    ensure
-      eval("$#{stream} = #{stream.upcase}")
-    end
+  config.mock_with :rspec
+  config.filter_run focus: true
+  config.filter_run_excluding not_supported_on_windows: windows?
+  config.run_all_when_everything_filtered = true
 
-    result
+  config.before(:each) do
+    Berkshelf.logger = Berkshelf::Logger.new(nil)
+    Berkshelf.set_format(:null)
+    Berkshelf.ui.mute!
+  end
+
+  config.before(:suite) do
+    WebMock.disable_net_connect!(allow_localhost: true, net_http_connect_on_start: true)
+    Berkshelf::RSpec::ChefServer.start
+    Berkshelf::API::RSpec::Server.start unless windows?
+  end
+
+  config.before(:all) do
+    ENV["BERKSHELF_PATH"] = berkshelf_path.to_s
+  end
+
+  config.before(:each) do
+    Berkshelf::API::RSpec::Server.clear_cache unless windows?
+    clean_tmp_path
+    Berkshelf.initialize_filesystem
+    Berkshelf::CookbookStore.instance.initialize_filesystem
+    reload_configs
   end
 end
 
-Spork.each_run do
-  require "berkshelf"
+def capture(stream)
+  begin
+    stream = stream.to_s
+    eval "$#{stream} = StringIO.new"
+    yield
+    result = eval("$#{stream}").string
+  ensure
+    eval("$#{stream} = #{stream.upcase}")
+  end
 
-  module Berkshelf
-    class GitLocation
-      include Berkshelf::RSpec::Git
+  result
+end
 
-      alias :real_clone :clone
-      def clone
-        fake_remote = generate_fake_git_remote(uri, tags: @branch ? [@branch] : [])
-        tmp_clone = File.join(self.class.tmpdir, uri.gsub(/[\/:]/, "-"))
-        @uri = "file://#{fake_remote}"
-        real_clone
-      end
+require "berkshelf"
+
+module Berkshelf
+  class GitLocation
+    include Berkshelf::RSpec::Git
+
+    alias :real_clone :clone
+    def clone
+      fake_remote = generate_fake_git_remote(uri, tags: @branch ? [@branch] : [])
+      tmp_clone = File.join(self.class.tmpdir, uri.gsub(/[\/:]/, "-"))
+      @uri = "file://#{fake_remote}"
+      real_clone
     end
   end
 end


### PR DESCRIPTION
Spork is no longer maintained and cucumber >= 1.3.0 dropped support for it

Also change Gemfile to use install_if for platform-specific gems, keeping
Gemfile.lock consistent.