### PR TITLE
Fix Hashie::Logger load

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,16 @@ def windows?
 end
 
 Spork.prefork do
+  # XXX: work around logger spam from hashie
+  # https://github.com/intridea/hashie/issues/394
+  require "hashie"
+  begin
+    require "hashie/logger"
+    Hashie.logger = Logger.new(nil)
+  rescue LoadError
+    nil
+  end
+
   require "aruba/cucumber"
   require "aruba/in_process"
   require "aruba/spawn_process"

--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -1,8 +1,12 @@
 # XXX: work around logger spam from hashie
 # https://github.com/intridea/hashie/issues/394
 require "hashie"
-require "hashie/logger"
-Hashie.logger = Logger.new(nil)
+begin
+  require "hashie/logger"
+  Hashie.logger = Logger.new(nil)
+rescue LoadError
+  nil
+end
 
 require "buff/extensions"
 require "cleanroom"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,16 @@ end
 BERKS_SPEC_DATA = File.expand_path("../data", __FILE__)
 
 Spork.prefork do
+  # XXX: work around logger spam from hashie
+  # https://github.com/intridea/hashie/issues/394
+  require "hashie"
+  begin
+    require "hashie/logger"
+    Hashie.logger = Logger.new(nil)
+  rescue LoadError
+    nil
+  end
+
   require "rspec"
   require "cleanroom/rspec"
   require "webmock/rspec"


### PR DESCRIPTION
For use when Hashie is < 3.5.0 and does not yet have a logger.

* Rescue load error when silencing Hashie::Logger in case it does not exist
* Add Hashie::Logger silencing to rspec and cucumber