### PR TITLE
fix for including hashie versions before the logger appeared

### DIFF
--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -1,8 +1,12 @@
 # XXX: work around logger spam from hashie
 # https://github.com/intridea/hashie/issues/394
-require "hashie"
-require "hashie/logger"
-Hashie.logger = Logger.new(nil)
+begin
+  require "hashie"
+  require "hashie/logger"
+  Hashie.logger = Logger.new(nil)
+rescue LoadError
+  # intentionally left blank
+end
 
 require "buff/extensions"
 require "cleanroom"


### PR DESCRIPTION
before the logger we didn't have the logger spam so we don't
need the workaround.

closes #1671 
Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>