### PR TITLE
Bump minitar to >= 0.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       cleanroom (~> 1.0)
       faraday (~> 0.9)
       httpclient (~> 2.7)
-      minitar (~> 0.5, >= 0.5.4)
+      minitar (~> 0.6, >= 0.6.1)
       mixlib-archive (~> 0.4)
       octokit (~> 4.0)
       retryable (~> 2.0)
@@ -202,7 +202,7 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.11)
     method_source (0.8.2)
-    minitar (0.5.4)
+    minitar (0.6.1)
     minitest (5.10.1)
     mixlib-archive (0.4.1)
       mixlib-log

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "cleanroom",            "~> 1.0"
   s.add_dependency "faraday",              "~> 0.9"
   s.add_dependency "httpclient",           "~> 2.7"
-  s.add_dependency "minitar",              "~> 0.5", ">= 0.5.4"
+  s.add_dependency "minitar",              "~> 0.6", ">= 0.6.1"
   s.add_dependency "retryable",            "~> 2.0"
   s.add_dependency "ridley",               "~> 5.0"
   s.add_dependency "solve",                "> 2.0", "< 4.0"


### PR DESCRIPTION
minitar 0.6.0 fixes [CVE-2016-10173](https://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2016-10173)