### PR TITLE
handle Windows backslashes in trusted_certs path

### DIFF
--- a/lib/berkshelf/ssl_policies.rb
+++ b/lib/berkshelf/ssl_policies.rb
@@ -22,7 +22,7 @@ module Berkshelf
     end
 
     def trusted_certs_dir
-      config_dir = Berkshelf.config.chef.trusted_certs_dir.to_s
+      config_dir = Berkshelf.config.chef.trusted_certs_dir.to_s.gsub('\\','/')
       if config_dir.empty? || !::File.exist?(config_dir)
         File.join(ENV["HOME"], ".chef", "trusted_certs")
       else

--- a/lib/berkshelf/ssl_policies.rb
+++ b/lib/berkshelf/ssl_policies.rb
@@ -22,7 +22,7 @@ module Berkshelf
     end
 
     def trusted_certs_dir
-      config_dir = Berkshelf.config.chef.trusted_certs_dir.to_s.gsub('\\','/')
+      config_dir = Berkshelf.config.chef.trusted_certs_dir.to_s.tr('\\', '/')
       if config_dir.empty? || !::File.exist?(config_dir)
         File.join(ENV["HOME"], ".chef", "trusted_certs")
       else

--- a/spec/unit/berkshelf/ssl_policies_spec.rb
+++ b/spec/unit/berkshelf/ssl_policies_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 describe Berkshelf::SSLPolicy do
   let(:self_signed_crt_path) { File.join(BERKS_SPEC_DATA, "trusted_certs") }
+  let(:self_signed_crt_path_windows_backslashes) { "C:/users/vagrant\\.chef\\trusted_certs" }
+  let(:self_signed_crt_path_windows_forwardslashes) { "C:/users/vagrant/.chef/trusted_certs" }
 
   let(:chef_config) do
     double(Ridley::Chef::Config,
@@ -61,12 +63,25 @@ describe Berkshelf::SSLPolicy do
         end
       end
 
-      context "config is seti but does not exist" do
+      context "config is set but does not exist" do
         before { allow(chef_config).to receive_messages(trusted_certs_dir: "/fake") }
 
         it "defaults to ~/.chef/trusted_certs" do
           expect(subject.trusted_certs_dir).to eq(
             File.join(ENV["HOME"], ".chef", "trusted_certs")
+          )
+        end
+      end
+
+      context 'config has Windows backslashes in trusted_certs_dir path' do
+        before do
+          allow(chef_config).to receive_messages(trusted_certs_dir: self_signed_crt_path_windows_backslashes)
+          allow(File).to receive(:exist?).with(self_signed_crt_path_windows_forwardslashes).and_return(true)
+        end
+
+        it 'replaces the backslashes in trusted_certs_dir from Berkshelf config with forwardslashes' do
+          expect(subject.trusted_certs_dir).to eq(
+            self_signed_crt_path_windows_forwardslashes
           )
         end
       end


### PR DESCRIPTION
This fixes #1688 

With this change `tr('\\', '/)` for the trusted_certs, we now return a string with any occurrences of backslashes replaced with forward slashes, if they exist, if none exist, we just return a copy of the original string.

Before:
```
[1] pry(#<Berkshelf::SSLPolicy>)> Berkshelf.config.chef
=> {"chef_server_url"=>"https://localhost:443",
 "validation_client_name"=>"chef-validator",
 "validation_key_path"=>"C:\\chef\\validation.pem",
 "client_key"=>"C:\\chef\\client.pem",
 "node_name"=>nil,
 "trusted_certs_dir"=>"C:/Users/vagrant\\.chef\\trusted_certs"}
[2] pry(#<Berkshelf::SSLPolicy>)> trusted_certs_dir
=> "C:/Users/vagrant\\.chef\\trusted_certs"
[3] pry(#<Berkshelf::SSLPolicy>)> ::Dir.glob("#{trusted_certs_dir}/" "{*.crt,*.p
em}")r.glob("#{trusted_certs_dir}/" "{*.crt,*.pem}")
=> []
[4] pry(#<Berkshelf::SSLPolicy>)>

C:\Users\vagrant\.chef>dir trusted_certs
 Volume in drive C is Windows 2012 R2
 Volume Serial Number is A099-33E6

 Directory of C:\Users\vagrant\.chef\trusted_certs

04/26/2017  01:02 PM    <DIR>          .
04/26/2017  01:02 PM    <DIR>          ..
04/26/2017  01:02 PM             1,568 amazon.crt
               1 File(s)          1,568 bytes
               2 Dir(s)  50,021,965,824 bytes free

C:\Users\vagrant\.chef>
```

After:
```
From: C:/opscode/chefdk/embedded/lib/ruby/gems/2.3.0/gems/berkshelf-5.6.4/lib/be
rkshelf/ssl_policies.rb @ line 34 Berkshelf::SSLPolicy#set_custom_certs:

    32: def set_custom_certs
    33:   require 'pry';binding.pry
 => 34:   ::Dir.glob("#{trusted_certs_dir}/" "{*.crt,*.pem}").each do |cert|
    35:     cert = OpenSSL::X509::Certificate.new(IO.read(cert))
    36:     puts cert.inspect
    37:     add_trusted_cert(cert)
    38:   end
    39: end
[1] pry(#<Berkshelf::SSLPolicy>)> trusted_certs_dir
=> "C:/Users/vagrant/.chef/trusted_certs"
[2] pry(#<Berkshelf::SSLPolicy>)> ::Dir.glob("#{trusted_certs_dir}/" "{*.crt,*.p
em}")=> ["C:/Users/vagrant/.chef/trusted_certs/amazon.crt"]
[3] pry(#<Berkshelf::SSLPolicy>)>
```