### PR TITLE
Artifactory support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development do
   gem "dep_selector",  ">= 1.0"
   gem "fuubar",        ">= 2.0"
   gem "rspec",         ">= 3.0"
+  gem "rspec-its",     ">= 1.2"
   gem "test-kitchen",  ">= 1.2"
   gem "webmock",       ">= 1.11"
   gem "yard",          ">= 0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,9 @@ GEM
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
@@ -368,6 +371,7 @@ DEPENDENCIES
   rb-inotify
   rb-notifu (>= 0.0.4)
   rspec (>= 3.0)
+  rspec-its (>= 1.2)
   terminal-notifier-guard (~> 1.5.3)
   test-kitchen (>= 1.2)
   wdm

--- a/features/artifactory.feature
+++ b/features/artifactory.feature
@@ -1,0 +1,70 @@
+Feature: Installing cookbooks from an Artifactory server
+  This integration test uses some environment variables to configure which
+  Artifactory server to talk to, as there is no ArtifactoryZero to test against.
+  If those aren't present, we skip the tests.
+
+  $TEST_BERKSHELF_ARTIFACTORY - URL to the Chef virtual repository.
+  $TEST_BERKSHELF_ARTIFACTORY_API_KEY - API key to use.
+
+  Scenario: when the cookbook exists
+    Given I have a Berksfile pointing at an authenticated Artifactory server with:
+      """
+      cookbook 'poise', '2.7.2'
+      """
+    When I successfully run `berks install`
+    Then the output should contain:
+      """
+      Installing poise (2.7.2)
+      """
+    And the cookbook store should have the cookbooks:
+      | poise | 2.7.2 |
+
+  Scenario: when the cookbook does not exist
+    Given I have a Berksfile pointing at an authenticated Artifactory server with:
+      """
+      cookbook '1234567890'
+      """
+    When I run `berks install`
+    Then the output should contain:
+      """
+      Unable to find a solution for demands: 1234567890 (>= 0.0.0)
+      """
+    And the exit status should be "NoSolutionError"
+
+  Scenario: when the cookbook exists, but the version does not
+    Given I have a Berksfile pointing at an authenticated Artifactory server with:
+      """
+      cookbook 'poise', '0.0.0'
+      """
+    When I run `berks install`
+    Then the output should contain:
+      """
+      Unable to find a solution for demands: poise (= 0.0.0)
+      """
+    And the exit status should be "NoSolutionError"
+
+  Scenario: when the API key is not present:
+    Given I have a Berksfile pointing at an Artifactory server with:
+      """
+      cookbook 'poise'
+      """
+    When I run `berks install`
+    Then the output should contain:
+      """
+      Unable to find a solution for demands: poise (>= 0.0.0)
+      """
+    And the exit status should be "NoSolutionError"
+
+  Scenario: when the API key is given in $ARTIFACTORY_API_KEY:
+    Given I have a Berksfile pointing at an Artifactory server with:
+      """
+      cookbook 'poise', '2.7.2'
+      """
+    And the environment variable ARTIFACTORY_API_KEY is $TEST_BERKSHELF_ARTIFACTORY_API_KEY
+    When I successfully run `berks install`
+    Then the output should contain:
+      """
+      Installing poise (2.7.2)
+      """
+    And the cookbook store should have the cookbooks:
+      | poise | 2.7.2 |

--- a/features/step_definitions/berksfile_steps.rb
+++ b/features/step_definitions/berksfile_steps.rb
@@ -37,3 +37,18 @@ Given /^I have a Berksfile at "(.+)" pointing at the local Berkshelf API with:$/
       """
   }
 end
+
+Given /I have a Berksfile pointing at an( authenticated)? Artifactory server with:/ do |authenticated, content|
+  if ENV['TEST_BERKSHELF_ARTIFACTORY']
+    steps %Q{
+      Given a file named "Berksfile" with:
+        """
+        source artifactory: '#{ENV['TEST_BERKSHELF_ARTIFACTORY']}'#{authenticated ? ", api_key: '#{ENV['TEST_BERKSHELF_ARTIFACTORY_API_KEY']}'" : ''}
+
+        #{content}
+        """
+    }
+  else
+    skip_this_scenario
+  end
+end

--- a/features/step_definitions/environment_steps.rb
+++ b/features/step_definitions/environment_steps.rb
@@ -5,3 +5,7 @@ end
 Given /^the environment variable (.+) is "(.+)"$/ do |variable, value|
   set_environment_variable(variable, value)
 end
+
+Given /^the environment variable (.+) is \$TEST_BERKSHELF_ARTIFACTORY_API_KEY$/ do |variable|
+  set_environment_variable(variable, ENV['TEST_BERKSHELF_ARTIFACTORY_API_KEY'])
+end

--- a/features/step_definitions/filesystem_steps.rb
+++ b/features/step_definitions/filesystem_steps.rb
@@ -44,7 +44,7 @@ Then /^the cookbook store should have the cookbooks:$/ do |cookbooks|
   cookbooks.raw.each do |name, version|
     expect(cookbook_store.storage_path).to have_structure {
       directory "#{name}-#{version}" do
-        file "metadata.rb" do
+        file "metadata.{rb,json}" do
           contains version
         end
       end
@@ -56,7 +56,7 @@ Then /^the cookbook store should have the git cookbooks:$/ do |cookbooks|
   cookbooks.raw.each do |name, version, sha1|
     expect(cookbook_store.storage_path).to have_structure {
       directory "#{name}-#{sha1}" do
-        file "metadata.rb" do
+        file "metadata.{rb,json}" do
           contains version
         end
       end

--- a/features/step_definitions/json_steps.rb
+++ b/features/step_definitions/json_steps.rb
@@ -14,10 +14,16 @@ class Hash
   end
 end
 
+# Pending Ridley allowing newer Faraday and Celluloid.
+def clean_json_output(output)
+  output.gsub(/^.+warning: constant ::Fixnum is deprecated$/, '') \
+        .gsub(/^.*forwarding to private method Celluloid::PoolManager#url_prefix$/, '')
+end
+
 Then /^the output should contain JSON:$/ do |data|
   parsed = ERB.new(data).result
   target = JSON.pretty_generate(JSON.parse(parsed).sort_by_key)
-  actual = JSON.pretty_generate(JSON.parse(all_commands.map { |c| c.output }.join("\n")).sort_by_key)
+  actual = JSON.pretty_generate(JSON.parse(all_commands.map { |c| clean_json_output(c.output) }.join("\n")).sort_by_key)
 
   expect(actual).to eq(target)
 end

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -191,11 +191,15 @@ module Berkshelf
     # @param [String] api_url
     #   url for the api to add
     #
+    # @param [Hash] options
+    #   extra source options
+    #
     # @raise [InvalidSourceURI]
     #
     # @return [Array<Source>]
-    def source(api_url)
-      @sources[api_url] = Source.new(api_url)
+    def source(api_url, **options)
+      source = Source.new(api_url, **options)
+      @sources[source.uri.to_s] = source
     end
     expose :source
 

--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -115,6 +115,11 @@ module Berkshelf
     def find(name, version)
       response = get("cookbooks/#{name}/versions/#{self.class.uri_escape_version(version)}")
 
+      # Artifactory responds with a 200 and blank body for unknown cookbooks.
+      if response.status == 200 && response.body.to_s == ''
+        response.env.status = 404
+      end
+
       case response.status
       when (200..299)
         response.body
@@ -130,6 +135,11 @@ module Berkshelf
     # @return [String]
     def latest_version(name)
       response = get("cookbooks/#{name}")
+
+      # Artifactory responds with a 200 and blank body for unknown cookbooks.
+      if response.status == 200 && response.body.to_s == ''
+        response.env.status = 404
+      end
 
       case response.status
       when (200..299)

--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -63,7 +63,12 @@ module Berkshelf
 
       case remote_cookbook.location_type
       when :opscode, :supermarket
-        CommunityREST.new(remote_cookbook.location_path).download(name, version)
+        options = {}
+        if source.type == :artifactory
+          api_key = source.options[:api_key] || ENV['ARTIFACTORY_API_KEY']
+          options[:headers] = {'X-JFrog-Art-Api' => api_key}
+        end
+        CommunityREST.new(remote_cookbook.location_path, options).download(name, version)
       when :chef_server
         # @todo Dynamically get credentials for remote_cookbook.location_path
         ssl_options = { verify: Berkshelf::Config.instance.ssl.verify }

--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -71,14 +71,11 @@ module Berkshelf
         CommunityREST.new(remote_cookbook.location_path, options).download(name, version)
       when :chef_server
         # @todo Dynamically get credentials for remote_cookbook.location_path
-        ssl_options = { verify: Berkshelf::Config.instance.ssl.verify }
-        ssl_options[:cert_store] = ssl_policy.store if ssl_policy.store
-
         credentials = {
           server_url: remote_cookbook.location_path,
-          client_name: Berkshelf::Config.instance.chef.node_name,
-          client_key: Berkshelf::Config.instance.chef.client_key,
-          ssl: ssl_options,
+          client_name: source.options[:client_name] || Berkshelf::Config.instance.chef.node_name,
+          client_key: source.options[:client_key] || Berkshelf::Config.instance.chef.client_key,
+          ssl: source.options[:ssl],
         }
         # @todo  Something scary going on here - getting an instance of Kitchen::Logger from test-kitchen
         # https://github.com/opscode/test-kitchen/blob/master/lib/kitchen.rb#L99

--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -66,7 +66,7 @@ module Berkshelf
         options = {}
         if source.type == :artifactory
           api_key = source.options[:api_key] || ENV['ARTIFACTORY_API_KEY']
-          options[:headers] = {'X-JFrog-Art-Api' => api_key}
+          options[:headers] = {'X-Jfrog-Art-Api' => api_key}
         end
         CommunityREST.new(remote_cookbook.location_path, options).download(name, version)
       when :chef_server

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ BERKS_SPEC_DATA = File.expand_path("../data", __FILE__)
 require "rspec"
 require "cleanroom/rspec"
 require "webmock/rspec"
+require "rspec/its"
 require "berkshelf/api/rspec" unless windows?
 
 Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }

--- a/spec/support/matchers/file_system_matchers.rb
+++ b/spec/support/matchers/file_system_matchers.rb
@@ -23,11 +23,12 @@ module Berkshelf
         end
 
         def matches?(root)
-          unless root.join(@name).exist?
+          path = Pathname.glob(root.join(@name)).first
+          unless path.exist?
             throw :failure, root.join(@name)
           end
 
-          contents = File.read(root.join(@name))
+          contents = File.read(path)
 
           @contents.each do |string|
             unless contents.include?(string)

--- a/spec/unit/berkshelf/downloader_spec.rb
+++ b/spec/unit/berkshelf/downloader_spec.rb
@@ -133,6 +133,44 @@ module Berkshelf
           expect(Ridley).to receive(:open).with(credentials) { ridley_client }
           subject.try_download(source, name, version)
         end
+
+        context "with a source option for client_name" do
+          before do
+            allow(source).to receive(:options) { {client_name: "other-client", read_timeout: 30, open_timeout: 3, ssl: {verify: true, cert_store: cert_store}} }
+          end
+          it "uses the override" do
+            credentials = {
+              server_url: chef_server_url,
+              client_name: "other-client",
+              client_key: chef_config.client_key,
+              ssl: {
+                verify: berkshelf_config.ssl.verify,
+                cert_store: cert_store,
+              },
+            }
+            expect(Ridley).to receive(:open).with(credentials) { ridley_client }
+            subject.try_download(source, name, version)
+          end
+        end
+
+        context "with a source option for client_key" do
+          before do
+            allow(source).to receive(:options) { {client_key: "other-key", read_timeout: 30, open_timeout: 3, ssl: {verify: true, cert_store: cert_store}} }
+          end
+          it "uses the override" do
+            credentials = {
+              server_url: chef_server_url,
+              client_name: chef_config.node_name,
+              client_key: "other-key",
+              ssl: {
+                verify: berkshelf_config.ssl.verify,
+                cert_store: cert_store,
+              },
+            }
+            expect(Ridley).to receive(:open).with(credentials) { ridley_client }
+            subject.try_download(source, name, version)
+          end
+        end
       end
 
       it "supports the 'file_store' location type" do

--- a/spec/unit/berkshelf/downloader_spec.rb
+++ b/spec/unit/berkshelf/downloader_spec.rb
@@ -38,21 +38,47 @@ module Berkshelf
       let(:version) { "1.0.0" }
 
       it "supports the 'opscode' location type" do
+        allow(source).to receive(:type) { :supermarket }
         allow(remote_cookbook).to receive(:location_type) { :opscode }
         allow(remote_cookbook).to receive(:location_path) { "http://api.opscode.com" }
         rest = double("community-rest")
-        expect(CommunityREST).to receive(:new).with("http://api.opscode.com") { rest }
+        expect(CommunityREST).to receive(:new).with("http://api.opscode.com", {}) { rest }
         expect(rest).to receive(:download).with(name, version)
         subject.try_download(source, name, version)
       end
 
       it "supports the 'supermarket' location type" do
+        allow(source).to receive(:type) { :supermarket }
         allow(remote_cookbook).to receive(:location_type) { :supermarket }
         allow(remote_cookbook).to receive(:location_path) { "http://api.supermarket.com" }
         rest = double("community-rest")
-        expect(CommunityREST).to receive(:new).with("http://api.supermarket.com") { rest }
+        expect(CommunityREST).to receive(:new).with("http://api.supermarket.com", {}) { rest }
         expect(rest).to receive(:download).with(name, version)
         subject.try_download(source, name, version)
+      end
+
+      context "with an artifactory source" do
+        it "supports the 'opscode' location type" do
+          allow(source).to receive(:type) { :artifactory }
+          allow(source).to receive(:options) { {api_key: 'secret'} }
+          allow(remote_cookbook).to receive(:location_type) { :opscode }
+          allow(remote_cookbook).to receive(:location_path) { "http://artifactory/" }
+          rest = double("community-rest")
+          expect(CommunityREST).to receive(:new).with("http://artifactory/", {headers: {'X-Jfrog-Art-Api' => 'secret'}}) { rest }
+          expect(rest).to receive(:download).with(name, version)
+          subject.try_download(source, name, version)
+        end
+
+        it "supports the 'supermarket' location type" do
+          allow(source).to receive(:type) { :artifactory }
+          allow(source).to receive(:options) { {api_key: 'secret'} }
+          allow(remote_cookbook).to receive(:location_type) { :supermarket }
+          allow(remote_cookbook).to receive(:location_path) { "http://artifactory/" }
+          rest = double("community-rest")
+          expect(CommunityREST).to receive(:new).with("http://artifactory/", {headers: {'X-Jfrog-Art-Api' => 'secret'}}) { rest }
+          expect(rest).to receive(:download).with(name, version)
+          subject.try_download(source, name, version)
+        end
       end
 
       describe "chef_server location type" do
@@ -91,6 +117,7 @@ module Berkshelf
           allow(subject).to receive(:ssl_policy).and_return(ssl_policy)
           allow(remote_cookbook).to receive(:location_type) { :chef_server }
           allow(remote_cookbook).to receive(:location_path) { chef_server_url }
+          allow(source).to receive(:options) { {read_timeout: 30, open_timeout: 3, ssl: {verify: true, cert_store: cert_store}} }
         end
 
         it "uses the berkshelf config and provides a custom cert_store" do


### PR DESCRIPTION
The banner feature is support Artifactory's new pseudo-Supermarket mode:

```ruby
source artifactory: 'https://myserver/api/chef/chef-virtual'
```

It also majorly refactors how sources work, allowing for per-source options like:

```ruby
source :chef_server, client_key: '/path'
source 'https://mysupermarket', ssl: {verify: false}
source supermarket: 'https://mysupermarket', ssl: {client_cert: '/path'}
```