### PR TITLE
Minor refactor on the default artifactory options and support artifactory_api_key in knife.rb

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -65,8 +65,7 @@ module Berkshelf
       when :opscode, :supermarket
         options = {}
         if source.type == :artifactory
-          api_key = source.options[:api_key] || ENV['ARTIFACTORY_API_KEY']
-          options[:headers] = {'X-Jfrog-Art-Api' => api_key}
+          options[:headers] = {'X-Jfrog-Art-Api' => source.options[:api_key]}
         end
         CommunityREST.new(remote_cookbook.location_path, options).download(name, version)
       when :chef_server

--- a/spec/unit/berkshelf/source_spec.rb
+++ b/spec/unit/berkshelf/source_spec.rb
@@ -141,6 +141,12 @@ module Berkshelf
         let(:arguments) { [{artifactory: 'https://example.com/api/chef/chef-virtual'}, {key: 'value'}] }
         its([:key]) { is_expected.to eq 'value' }
       end
+
+      context "with an artifactory source and the API key in the Chef config" do
+        let(:arguments) { [{artifactory: 'https://example.com/api/chef/chef-virtual'}] }
+        before { config.chef.artifactory_api_key = 'secret' }
+        its([:api_key]) { is_expected.to eq 'secret' }
+      end
     end
 
     describe "#==" do


### PR DESCRIPTION
Also fixes setting client_name and client_key when using `source chef_server: 'https://whatever'` if you're doing funky stuff with multiple Chef Servers.