### PR TITLE
Pass along an artifactory_api_key attribute from a Chef config

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -110,6 +110,9 @@ module Berkshelf
     attribute "chef.trusted_certs_dir",
       type: String,
       default: Berkshelf.chef_config.trusted_certs_dir
+    attribute "chef.artifactory_api_key",
+      type: String,
+      default: Berkshelf.chef_config.artifactory_api_key
     attribute "cookbook.copyright",
       type: String,
       default: Berkshelf.chef_config.cookbook_copyright

--- a/spec/unit/berkshelf/config_spec.rb
+++ b/spec/unit/berkshelf/config_spec.rb
@@ -21,6 +21,52 @@ describe Berkshelf::Config do
         expect(Berkshelf::Config.instance.api.timeout).to eq("30")
       end
     end
+
+    context "a Chef config to read defaults from" do
+      let(:chef_config) do
+        double(
+          Ridley::Chef::Config,
+          chef_server_url: "https://chef.example.com",
+          validation_client_name: "validator",
+          validation_key: "validator.pem",
+          client_key: "client-key",
+          node_name: "fake-client",
+          trusted_certs_dir: "/tmp/fakecerts",
+          artifactory_api_key: "secret",
+          cookbook_copyright: "user",
+          cookbook_email: "user@example.com",
+          cookbook_license: "apachev2"
+        )
+      end
+
+      before do
+        allow(Berkshelf).to receive(:chef_config).and_return(chef_config)
+      end
+
+      {
+        chef_server_url: "https://chef.example.com",
+        validation_client_name: "validator",
+        validation_key_path: "validator.pem",
+        client_key: "client-key",
+        node_name: "fake-client",
+        trusted_certs_dir: "/tmp/fakecerts",
+        artifactory_api_key: "secret",
+      }.each do |attr, default|
+        it "should have a default chef.#{attr}" do
+          expect(Berkshelf::Config.instance.chef.send(attr)).to eq(default)
+        end
+      end
+
+      {
+        copyright: "user",
+        email: "user@example.com",
+        license: "apachev2",
+      }.each do |attr, default|
+        it "should have a default cookbook.#{attr}" do
+          expect(Berkshelf::Config.instance.cookbook.send(attr)).to eq(default)
+        end
+      end
+    end
   end
 
   describe "::path" do

--- a/spec/unit/berkshelf/downloader_spec.rb
+++ b/spec/unit/berkshelf/downloader_spec.rb
@@ -95,6 +95,7 @@ module Berkshelf
             chef_server_url: chef_server_url,
             validation_client_name: "validator",
             validation_key: "validator.pem",
+            artifactory_api_key: "secret",
             cookbook_copyright: "user",
             cookbook_email: "user@example.com",
             cookbook_license: "apachev2",

--- a/spec/unit/berkshelf/ssl_policies_spec.rb
+++ b/spec/unit/berkshelf/ssl_policies_spec.rb
@@ -12,6 +12,7 @@ describe Berkshelf::SSLPolicy do
       chef_server_url: "http://configured-chef-server/",
       validation_client_name: "validator",
       validation_key: "validator.pem",
+      artifactory_api_key: "secret",
       cookbook_copyright: "user",
       cookbook_email: "user@example.com",
       cookbook_license: "apachev2",

--- a/spec/unit/berkshelf/uploader_spec.rb
+++ b/spec/unit/berkshelf/uploader_spec.rb
@@ -57,6 +57,7 @@ module Berkshelf
           chef_server_url: "http://configured-chef-server/",
           validation_client_name: "validator",
           validation_key: "validator.pem",
+          artifactory_api_key: "secret",
           cookbook_copyright: "user",
           cookbook_email: "user@example.com",
           cookbook_license: "apachev2",


### PR DESCRIPTION
Without the attribute defined, an API key set in a user's Chef config gets
dropped on the floor instead of being passed on to the Source object.

Signed-off-by: Jonathan Hartman <j@p4nt5.com>