### PR TITLE
Add chef_repo source

### DIFF
--- a/features/commands/install.feature
+++ b/features/commands/install.feature
@@ -634,3 +634,24 @@ Feature: berks install
     """
     Resolving cookbook dependencies...
     """
+
+  Scenario: when using a chef_repo source
+    Given I use a fixture named "complex-cookbook-path"
+    And a file named "Berksfile" with:
+      """
+      source chef_repo: '.'
+
+      cookbook 'jenkins-config'
+      """
+    When I successfully run `berks install`
+    Then the output should contain:
+      """
+      Installing jenkins (2.0.1) from
+      """
+    And the output should contain:
+      """
+      Installing jenkins-config (0.1.0) from
+      """
+    And the cookbook store should have the cookbooks:
+      | jenkins        | 2.0.1 |
+      | jenkins-config | 0.1.0 |

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -198,7 +198,7 @@ module Berkshelf
     #
     # @return [Array<Source>]
     def source(api_url, **options)
-      source = Source.new(api_url, **options)
+      source = Source.new(self, api_url, **options)
       @sources[source.uri.to_s] = source
     end
     expose :source

--- a/lib/berkshelf/chef_repo_universe.rb
+++ b/lib/berkshelf/chef_repo_universe.rb
@@ -14,7 +14,7 @@ module Berkshelf
 
     def universe
       Dir.entries(cookbooks_path).sort.each_with_object([]) do |entry, cookbooks|
-        next if entry[0] == '.' # Skip hidden folders.
+        next if entry[0] == "." # Skip hidden folders.
         entry_path = "#{cookbooks_path}/#{entry}"
         next unless File.directory?(entry_path) # Skip non-dirs.
         cookbook = begin
@@ -25,9 +25,9 @@ module Berkshelf
         cookbooks << Berkshelf::APIClient::RemoteCookbook.new(
           cookbook.cookbook_name,
           cookbook.version,
-          location_type: 'file_store',
+          location_type: "file_store",
           location_path: entry_path,
-          dependencies: cookbook.metadata.dependencies,
+          dependencies: cookbook.metadata.dependencies
         )
       end
     end

--- a/lib/berkshelf/chef_repo_universe.rb
+++ b/lib/berkshelf/chef_repo_universe.rb
@@ -1,0 +1,45 @@
+require "berkshelf/api_client/remote_cookbook"
+require "ridley/chef/cookbook"
+
+module Berkshelf
+  # Shim to look like a Berkshelf::APIClient but for a chef repo folder.
+  #
+  # @since 6.1
+  class ChefRepoUniverse
+    def initialize(uri, **options)
+      @uri = uri
+      @path = options[:path]
+      @options = options
+    end
+
+    def universe
+      Dir.entries(cookbooks_path).sort.each_with_object([]) do |entry, cookbooks|
+        next if entry[0] == '.' # Skip hidden folders.
+        entry_path = "#{cookbooks_path}/#{entry}"
+        next unless File.directory?(entry_path) # Skip non-dirs.
+        cookbook = begin
+          Ridley::Chef::Cookbook.from_path(entry_path)
+        rescue IOError
+          next # It wasn't a cookbook.
+        end
+        cookbooks << Berkshelf::APIClient::RemoteCookbook.new(
+          cookbook.cookbook_name,
+          cookbook.version,
+          location_type: 'file_store',
+          location_path: entry_path,
+          dependencies: cookbook.metadata.dependencies,
+        )
+      end
+    end
+
+    private
+
+    def cookbooks_path
+      if File.exist?("#{@path}/cookbooks")
+        "#{@path}/cookbooks"
+      else
+        @path
+      end
+    end
+  end
+end

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -262,7 +262,7 @@ module Berkshelf
       banner: "URL"
     desc "search NAME", "Search the remote source for cookbooks matching the partial name"
     def search(name)
-      source = Source.new(options[:source])
+      source = Source.new(nil, options[:source])
       cookbooks = source.search(name)
       Berkshelf.formatter.search(cookbooks)
     end

--- a/lib/berkshelf/formatters/human.rb
+++ b/lib/berkshelf/formatters/human.rb
@@ -19,7 +19,9 @@ module Berkshelf
     def install(source, cookbook)
       message = "Installing #{cookbook.name} (#{cookbook.version})"
 
-      unless source.default?
+      if source.type == :chef_repo
+        message << " from #{cookbook.location_path}"
+      elsif !source.default?
         message << " from #{source}"
         message << " ([#{cookbook.location_type}] #{cookbook.location_path})"
       end

--- a/lib/berkshelf/installer.rb
+++ b/lib/berkshelf/installer.rb
@@ -17,7 +17,7 @@ module Berkshelf
       berksfile.sources.collect do |source|
         Thread.new do
           begin
-            Berkshelf.formatter.msg("Fetching cookbook index from #{source.uri}...")
+            Berkshelf.formatter.msg("Fetching cookbook index from #{source}...")
             source.build_universe
           rescue Berkshelf::APIClientError => ex
             Berkshelf.formatter.warn "Error retrieving universe from source: #{source}"

--- a/lib/berkshelf/source.rb
+++ b/lib/berkshelf/source.rb
@@ -41,7 +41,7 @@ module Berkshelf
       when :chef_repo
         @options[:path] = uri_string
         # If given a relative path, expand it against the Berksfile's folder.
-        @options[:path] = File.expand_path(@options[:path], File.dirname(berksfile.filepath))
+        @options[:path] = File.expand_path(@options[:path], File.dirname(berksfile ? berksfile.filepath : Dir.pwd))
         # Lie because this won't actually parse as a URI.
         @uri_string = "file://#{@options[:path]}"
       end

--- a/lib/berkshelf/source.rb
+++ b/lib/berkshelf/source.rb
@@ -1,4 +1,5 @@
 require "berkshelf/api-client"
+require "berkshelf/chef_repo_universe"
 require "berkshelf/ssl_policies"
 require "openssl"
 
@@ -10,8 +11,9 @@ module Berkshelf
     attr_accessor :uri_string
     attr_accessor :options
 
+    # @param [Berkshelf::Berksfile] berksfile
     # @param [String, Berkshelf::SourceURI] source
-    def initialize(source, **options)
+    def initialize(berksfile, source, **options)
       @options = { timeout: api_timeout, open_timeout: [(api_timeout / 10), 3].max, ssl: {} }
       @options.update(options)
       case source
@@ -36,6 +38,12 @@ module Berkshelf
         @options[:client_key] ||= Berkshelf::Config.instance.chef.client_key
       when :artifactory
         @options[:api_key] ||= Berkshelf::Config.instance.chef.artifactory_api_key || ENV["ARTIFACTORY_API_KEY"]
+      when :chef_repo
+        @options[:path] = uri_string
+        # If given a relative path, expand it against the Berksfile's folder.
+        @options[:path] = File.expand_path(@options[:path], File.dirname(berksfile.filepath))
+        # Lie because this won't actually parse as a URI.
+        @uri_string = "file://#{@options[:path]}"
       end
       # Set some default SSL options.
       Berkshelf::Config.instance.ssl.each do |key, value|
@@ -58,6 +66,8 @@ module Berkshelf
                         client_options = options.dup
                         api_key = client_options.delete(:api_key)
                         APIClient.new(uri, headers: { "X-Jfrog-Art-Api" => api_key }, **client_options)
+                      when :chef_repo
+                        ChefRepoUniverse.new(uri_string, **options)
                       else
                         APIClient.new(uri, **options)
                       end
@@ -133,8 +143,11 @@ module Berkshelf
     end
 
     def to_s
-      if type == :supermarket
-        "#{uri}"
+      case type
+      when :supermarket
+        uri.to_s
+      when :chef_repo
+        options[:path]
       else
         "#{type}: #{uri}"
       end

--- a/lib/berkshelf/source_uri.rb
+++ b/lib/berkshelf/source_uri.rb
@@ -22,7 +22,7 @@ module Berkshelf
       end
     end
 
-    VALID_SCHEMES = %w{http https}.freeze
+    VALID_SCHEMES = %w{http https file}.freeze
 
     # @raise [Berkshelf::InvalidSourceURI]
     def validate

--- a/spec/fixtures/complex-cookbook-path/cookbooks/app/metadata.rb
+++ b/spec/fixtures/complex-cookbook-path/cookbooks/app/metadata.rb
@@ -1,0 +1,2 @@
+name "app"
+version "1.2.3"

--- a/spec/fixtures/complex-cookbook-path/cookbooks/jenkins-config/metadata.rb
+++ b/spec/fixtures/complex-cookbook-path/cookbooks/jenkins-config/metadata.rb
@@ -1,0 +1,4 @@
+name "jenkins-config"
+version "0.1.0"
+
+depends "jenkins", "~> 2.0"

--- a/spec/fixtures/complex-cookbook-path/cookbooks/jenkins/metadata.rb
+++ b/spec/fixtures/complex-cookbook-path/cookbooks/jenkins/metadata.rb
@@ -1,0 +1,2 @@
+name "jenkins"
+version "2.0.1"

--- a/spec/unit/berkshelf/chef_repo_universe_spec.rb
+++ b/spec/unit/berkshelf/chef_repo_universe_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+module Berkshelf
+  describe ChefRepoUniverse do
+    let(:fixture) { nil }
+    let(:fixture_path) { File.expand_path("../../../fixtures/#{fixture}", __FILE__) }
+    subject { described_class.new("file://#{fixture_path}", path: fixture_path).universe }
+
+    context 'with cookbooks in ./' do
+      let(:fixture) { 'cookbook-path' }
+
+      it "returns the correct universe" do
+        expect(subject.size).to eq 1
+        expect(subject[0].name).to eq 'jenkins-config'
+        expect(subject[0].version).to eq '0.1.0'
+        expect(subject[0].dependencies).to eq "jenkins" => "~> 2.0"
+      end
+    end
+
+    context 'with cookbooks in cookbooks/' do
+      let(:fixture) { 'complex-cookbook-path' }
+
+      it "returns the correct universe" do
+        expect(subject.size).to eq 3
+        expect(subject[0].name).to eq 'app'
+        expect(subject[0].version).to eq '1.2.3'
+        expect(subject[0].dependencies).to eq({})
+        expect(subject[1].name).to eq 'jenkins'
+        expect(subject[1].version).to eq '2.0.1'
+        expect(subject[1].dependencies).to eq({})
+        expect(subject[2].name).to eq 'jenkins-config'
+        expect(subject[2].version).to eq '0.1.0'
+        expect(subject[2].dependencies).to eq "jenkins" => "~> 2.0"
+      end
+    end
+  end
+end

--- a/spec/unit/berkshelf/chef_repo_universe_spec.rb
+++ b/spec/unit/berkshelf/chef_repo_universe_spec.rb
@@ -6,30 +6,30 @@ module Berkshelf
     let(:fixture_path) { File.expand_path("../../../fixtures/#{fixture}", __FILE__) }
     subject { described_class.new("file://#{fixture_path}", path: fixture_path).universe }
 
-    context 'with cookbooks in ./' do
-      let(:fixture) { 'cookbook-path' }
+    context "with cookbooks in ./" do
+      let(:fixture) { "cookbook-path" }
 
       it "returns the correct universe" do
         expect(subject.size).to eq 1
-        expect(subject[0].name).to eq 'jenkins-config'
-        expect(subject[0].version).to eq '0.1.0'
+        expect(subject[0].name).to eq "jenkins-config"
+        expect(subject[0].version).to eq "0.1.0"
         expect(subject[0].dependencies).to eq "jenkins" => "~> 2.0"
       end
     end
 
-    context 'with cookbooks in cookbooks/' do
-      let(:fixture) { 'complex-cookbook-path' }
+    context "with cookbooks in cookbooks/" do
+      let(:fixture) { "complex-cookbook-path" }
 
       it "returns the correct universe" do
         expect(subject.size).to eq 3
-        expect(subject[0].name).to eq 'app'
-        expect(subject[0].version).to eq '1.2.3'
+        expect(subject[0].name).to eq "app"
+        expect(subject[0].version).to eq "1.2.3"
         expect(subject[0].dependencies).to eq({})
-        expect(subject[1].name).to eq 'jenkins'
-        expect(subject[1].version).to eq '2.0.1'
+        expect(subject[1].name).to eq "jenkins"
+        expect(subject[1].version).to eq "2.0.1"
         expect(subject[1].dependencies).to eq({})
-        expect(subject[2].name).to eq 'jenkins-config'
-        expect(subject[2].version).to eq '0.1.0'
+        expect(subject[2].name).to eq "jenkins-config"
+        expect(subject[2].version).to eq "0.1.0"
         expect(subject[2].dependencies).to eq "jenkins" => "~> 2.0"
       end
     end

--- a/spec/unit/berkshelf/resolver/graph_spec.rb
+++ b/spec/unit/berkshelf/resolver/graph_spec.rb
@@ -1,10 +1,11 @@
 require "spec_helper"
 
 describe Berkshelf::Resolver::Graph, :not_supported_on_windows do
+  let(:berksfile) { double("Berksfile", filepath: "/test/Berksfile") }
   subject { described_class.new }
 
   describe "#populate" do
-    let(:sources) { Berkshelf::Source.new("http://localhost:26210") }
+    let(:sources) { Berkshelf::Source.new(berksfile, "http://localhost:26210") }
 
     before do
       berks_dependency("ruby", "1.0.0", dependencies: { "elixir" => ">= 0.1.0" })
@@ -24,7 +25,7 @@ describe Berkshelf::Resolver::Graph, :not_supported_on_windows do
   end
 
   describe "#universe" do
-    let(:sources) { Berkshelf::Source.new("http://localhost:26210") }
+    let(:sources) { Berkshelf::Source.new(berksfile, "http://localhost:26210") }
 
     before do
       berks_dependency("ruby", "1.0.0")

--- a/spec/unit/berkshelf/source_spec.rb
+++ b/spec/unit/berkshelf/source_spec.rb
@@ -96,7 +96,7 @@ module Berkshelf
 
       context "with a chef_repo source" do
         let(:arguments) { [{ chef_repo: "." }] }
-        it { is_expected.to eq "file:///test" }
+        it { is_expected.to eq(windows? ? "file://C/test" : "file:///test") }
       end
     end
 
@@ -156,7 +156,7 @@ module Berkshelf
 
       context "with a chef_repo source" do
         let(:arguments) { [{ chef_repo: "." }] }
-        its([:path]) { is_expected.to eq "/test" }
+        its([:path]) { is_expected.to eq(windows? ? "C:/test" : "/test") }
       end
     end
 

--- a/spec/unit/berkshelf/source_spec.rb
+++ b/spec/unit/berkshelf/source_spec.rb
@@ -2,9 +2,10 @@ require "spec_helper"
 
 module Berkshelf
   describe Source do
+    let(:berksfile) { double("Berksfile", filepath: "/test/Berksfile") }
     let(:arguments) { [] }
     let(:config) { Config.new }
-    subject(:instance) { described_class.new(*arguments) }
+    subject(:instance) { described_class.new(berksfile, *arguments) }
     before do
       allow(Berkshelf::Config).to receive(:instance).and_return(config)
     end
@@ -92,6 +93,11 @@ module Berkshelf
         let(:arguments) { ["ftp://example.com"] }
         it { expect { subject }.to raise_error InvalidSourceURI }
       end
+
+      context "with a chef_repo source" do
+        let(:arguments) { [{ chef_repo: "." }] }
+        it { is_expected.to eq "file:///test" }
+      end
     end
 
     describe "#options" do
@@ -147,19 +153,24 @@ module Berkshelf
         before { config.chef.artifactory_api_key = "secret" }
         its([:api_key]) { is_expected.to eq "secret" }
       end
+
+      context "with a chef_repo source" do
+        let(:arguments) { [{ chef_repo: "." }] }
+        its([:path]) { is_expected.to eq "/test" }
+      end
     end
 
     describe "#==" do
       it "is the same if the uri matches" do
-        first = described_class.new("http://localhost:8080")
-        other = described_class.new("http://localhost:8080")
+        first = described_class.new(berksfile, "http://localhost:8080")
+        other = described_class.new(berksfile, "http://localhost:8080")
 
         expect(first).to eq(other)
       end
 
       it "is not the same if the uri is different" do
-        first = described_class.new("http://localhost:8089")
-        other = described_class.new("http://localhost:8080")
+        first = described_class.new(berksfile, "http://localhost:8089")
+        other = described_class.new(berksfile, "http://localhost:8080")
 
         expect(first).to_not eq(other)
       end
@@ -167,17 +178,17 @@ module Berkshelf
 
     describe ".default?" do
       it "returns true when the source is the default" do
-        instance = described_class.new(Berksfile::DEFAULT_API_URL)
+        instance = described_class.new(berksfile, Berksfile::DEFAULT_API_URL)
         expect(instance).to be_default
       end
 
       it "returns true when the scheme is different" do
-        instance = described_class.new("http://supermarket.chef.io")
+        instance = described_class.new(berksfile, "http://supermarket.chef.io")
         expect(instance).to be_default
       end
 
       it "returns false when the source is not the default" do
-        instance = described_class.new("http://localhost:8080")
+        instance = described_class.new(berksfile, "http://localhost:8080")
         expect(instance).to_not be_default
       end
     end
@@ -194,7 +205,7 @@ module Berkshelf
       end
 
       it "returns the latest version" do
-        instance = described_class.new(Berksfile::DEFAULT_API_URL)
+        instance = described_class.new(berksfile, Berksfile::DEFAULT_API_URL)
         expect(instance.search("cb1")).to eq [cookbooks[1]]
       end
     end


### PR DESCRIPTION
Adds a Berksfile source `:chef_repo`:

```ruby
source chef_repo: '.'
```

Bit of a hack but not too bad :)

Ping @tas50 because you asked for it.