### PR TITLE
Switch off open-uri for community site downloads

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -63,7 +63,7 @@ module Berkshelf
 
       case remote_cookbook.location_type
       when :opscode, :supermarket
-        options = {}
+        options = { ssl: source.options[:ssl] }
         if source.type == :artifactory
           options[:headers] = { "X-Jfrog-Art-Api" => source.options[:api_key] }
         end

--- a/lib/berkshelf/streaming_file_adapter.rb
+++ b/lib/berkshelf/streaming_file_adapter.rb
@@ -1,0 +1,22 @@
+require "faraday/adapter/net_http"
+
+module Berkshelf
+  class StreamingFileAdapter < Faraday::Adapter::NetHttp
+    def call(env)
+      env[:streaming_file] = env[:request_headers].delete(:streaming_file) if env[:request_headers] && env[:request_headers][:streaming_file]
+      super
+    end
+
+    def perform_request(http, env)
+      if env[:streaming_file]
+        http.request(create_request(env)) do |response|
+          response.read_body do |chunk|
+            env[:streaming_file].write(chunk) if response.code == "200"
+          end
+        end
+      else
+        super
+      end
+    end
+  end
+end

--- a/spec/unit/berkshelf/downloader_spec.rb
+++ b/spec/unit/berkshelf/downloader_spec.rb
@@ -39,20 +39,22 @@ module Berkshelf
 
       it "supports the 'opscode' location type" do
         allow(source).to receive(:type) { :supermarket }
+        allow(source).to receive(:options) { { ssl: {} } }
         allow(remote_cookbook).to receive(:location_type) { :opscode }
         allow(remote_cookbook).to receive(:location_path) { "http://api.opscode.com" }
         rest = double("community-rest")
-        expect(CommunityREST).to receive(:new).with("http://api.opscode.com", {}) { rest }
+        expect(CommunityREST).to receive(:new).with("http://api.opscode.com", { ssl: {} }) { rest }
         expect(rest).to receive(:download).with(name, version)
         subject.try_download(source, name, version)
       end
 
       it "supports the 'supermarket' location type" do
         allow(source).to receive(:type) { :supermarket }
+        allow(source).to receive(:options) { { ssl: {} } }
         allow(remote_cookbook).to receive(:location_type) { :supermarket }
         allow(remote_cookbook).to receive(:location_path) { "http://api.supermarket.com" }
         rest = double("community-rest")
-        expect(CommunityREST).to receive(:new).with("http://api.supermarket.com", {}) { rest }
+        expect(CommunityREST).to receive(:new).with("http://api.supermarket.com", { ssl: {} }) { rest }
         expect(rest).to receive(:download).with(name, version)
         subject.try_download(source, name, version)
       end
@@ -60,22 +62,22 @@ module Berkshelf
       context "with an artifactory source" do
         it "supports the 'opscode' location type" do
           allow(source).to receive(:type) { :artifactory }
-          allow(source).to receive(:options) { { api_key: "secret" } }
+          allow(source).to receive(:options) { { api_key: "secret", ssl: {} } }
           allow(remote_cookbook).to receive(:location_type) { :opscode }
           allow(remote_cookbook).to receive(:location_path) { "http://artifactory/" }
           rest = double("community-rest")
-          expect(CommunityREST).to receive(:new).with("http://artifactory/", { headers: { "X-Jfrog-Art-Api" => "secret" } }) { rest }
+          expect(CommunityREST).to receive(:new).with("http://artifactory/", { ssl: {}, headers: { "X-Jfrog-Art-Api" => "secret" } }) { rest }
           expect(rest).to receive(:download).with(name, version)
           subject.try_download(source, name, version)
         end
 
         it "supports the 'supermarket' location type" do
           allow(source).to receive(:type) { :artifactory }
-          allow(source).to receive(:options) { { api_key: "secret" } }
+          allow(source).to receive(:options) { { api_key: "secret", ssl: {} } }
           allow(remote_cookbook).to receive(:location_type) { :supermarket }
           allow(remote_cookbook).to receive(:location_path) { "http://artifactory/" }
           rest = double("community-rest")
-          expect(CommunityREST).to receive(:new).with("http://artifactory/", { headers: { "X-Jfrog-Art-Api" => "secret" } }) { rest }
+          expect(CommunityREST).to receive(:new).with("http://artifactory/", { ssl: {}, headers: { "X-Jfrog-Art-Api" => "secret" } }) { rest }
           expect(rest).to receive(:download).with(name, version)
           subject.try_download(source, name, version)
         end


### PR DESCRIPTION
This means we get actual streaming as well as using the source-level TLS configurations.