### PR TITLE
bump berkshelf-api-client dep to 4.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    berkshelf-api-client (4.0.0)
+    berkshelf-api-client (4.0.1)
       chef (>= 12.0)
     buff-config (2.0.0)
       buff-extensions (~> 2.0)
@@ -331,7 +331,7 @@ GEM
     solve (3.1.0)
       molinillo (>= 0.5)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.68.0)
+    specinfra (2.68.1)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet


### PR DESCRIPTION
picks up an artifactory fix in berkshelf-api-client