### PR TITLE
Fix up Dir.glob for windows

### DIFF
--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -104,9 +104,12 @@ module Berkshelf
       if File.cookbook?(extracted)
         extracted
       else
-        Dir.glob(File.join(extracted, "*")).find do |dir|
-          File.cookbook?(dir)
+        dir = Dir.chdir(extracted) do
+          Dir.glob("*").find do |dir|
+            File.cookbook?(dir)
+          end
         end
+        File.join(extracted, dir) if dir
       end
     ensure
       archive.unlink unless archive.nil?

--- a/lib/berkshelf/cookbook_store.rb
+++ b/lib/berkshelf/cookbook_store.rb
@@ -48,7 +48,9 @@ module Berkshelf
 
     # Destroy the contents of the initialized storage path.
     def clean!
-      FileUtils.rm_rf(Dir.glob(File.join(storage_path, "*")))
+      Dir.chdir(storage_path) do
+        FileUtils.rm_rf(Dir.glob("*"))
+      end
     end
 
     # Import a cookbook found on the local filesystem into this instance of the cookbook store.

--- a/lib/berkshelf/ssl_policies.rb
+++ b/lib/berkshelf/ssl_policies.rb
@@ -31,9 +31,11 @@ module Berkshelf
     end
 
     def set_custom_certs
-      ::Dir.glob("#{trusted_certs_dir}/" "{*.crt,*.pem}").each do |cert|
-        cert = OpenSSL::X509::Certificate.new(IO.read(cert))
-        add_trusted_cert(cert)
+      Dir.chdir(trusted_certs_dir) do
+        ::Dir.glob("{*.crt,*.pem}").each do |cert|
+          cert = OpenSSL::X509::Certificate.new(IO.read(cert))
+          add_trusted_cert(cert)
+        end
       end
     end
   end

--- a/lib/berkshelf/validator.rb
+++ b/lib/berkshelf/validator.rb
@@ -24,9 +24,12 @@ module Berkshelf
         Array(cookbooks).each do |cookbook|
           path = cookbook.path.to_s
 
-          files = Dir.glob(File.join(path, "**", "*.rb")).select do |f|
-            parent = Pathname.new(path).dirname.to_s
-            f.gsub(parent, "") =~ /[[:space:]]/
+          files = Dir.chdir(path) do
+            Dir.glob(File.join("**", "*.rb")).select do |f|
+              f = File.join(path, f)
+              parent = Pathname.new(path).dirname.to_s
+              f.gsub(parent, "") =~ /[[:space:]]/
+            end
           end
 
           raise InvalidCookbookFiles.new(cookbook, files) unless files.empty?

--- a/spec/unit/berkshelf/community_rest_spec.rb
+++ b/spec/unit/berkshelf/community_rest_spec.rb
@@ -93,6 +93,7 @@ describe Berkshelf::CommunityREST do
         .and_return("/foo/nginx")
         .once
       expect(archive).to receive(:unlink).once
+      expect(Dir).to receive(:chdir).with("/foo/nginx")
 
       subject.download("bacon", "1.0.0")
     end

--- a/spec/unit/berkshelf/ssl_policies_spec.rb
+++ b/spec/unit/berkshelf/ssl_policies_spec.rb
@@ -78,6 +78,7 @@ describe Berkshelf::SSLPolicy do
         before do
           allow(chef_config).to receive_messages(trusted_certs_dir: self_signed_crt_path_windows_backslashes)
           allow(File).to receive(:exist?).with(self_signed_crt_path_windows_forwardslashes).and_return(true)
+          allow(Dir).to receive(:chdir).with(self_signed_crt_path_windows_forwardslashes)
         end
 
         it "replaces the backslashes in trusted_certs_dir from Berkshelf config with forwardslashes" do

--- a/spec/unit/berkshelf/validator_spec.rb
+++ b/spec/unit/berkshelf/validator_spec.rb
@@ -4,6 +4,10 @@ describe Berkshelf::Validator do
   describe "#validate_files" do
     let(:cookbook) { double("cookbook", cookbook_name: "cookbook", path: "path") }
 
+    before do
+      allow(Dir).to receive(:chdir) { |&block| block.call }
+    end
+
     it "raises an error when the cookbook has spaces in the files" do
       allow(Dir).to receive(:glob).and_return(["/there are/spaces/in this/recipes/default.rb"])
       expect do


### PR DESCRIPTION
Dir.glob does not work on windows if a symlinked directory is in the pattern. This is most likely the issue being seen in https://github.com/test-kitchen/test-kitchen/issues/1238

This patch takes the approach of changing to the directory before doing any globbing.
