### PR TITLE
Update cookbook upload order

### DIFF
--- a/lib/berkshelf/uploader.rb
+++ b/lib/berkshelf/uploader.rb
@@ -85,15 +85,15 @@ module Berkshelf
       end
     end
 
-      # Filter cookbooks based off the list of dependencies in the Berksfile.
-      #
-      # This method is secretly recursive. It iterates over each dependency in
-      # the Berksfile (using {Berksfile#dependencies} to account for filters)
-      # and retrieves that cookbook, it's dependencies, and the recusive
-      # dependencies, but iteratively.
-      #
-      # @return [Array<CachedCookbook>]
-      #
+    # Filter cookbooks based off the list of dependencies in the Berksfile.
+    #
+    # This method is secretly recursive. It iterates over each dependency in
+    # the Berksfile (using {Berksfile#dependencies} to account for filters)
+    # and retrieves that cookbook, it's dependencies, and the recusive
+    # dependencies, but iteratively.
+    #
+    # @return [Array<CachedCookbook>]
+    #
     def filtered_cookbooks
       # Create a copy of the dependencies. We need to make a copy, or else
       # we would be adding dependencies directly to the Berksfile object, and

--- a/spec/fixtures/cookbook-path-uploader/apt-2.3.6/metadata.rb
+++ b/spec/fixtures/cookbook-path-uploader/apt-2.3.6/metadata.rb
@@ -1,0 +1,2 @@
+name "apt"
+version "2.3.6"

--- a/spec/fixtures/cookbook-path-uploader/build-essential-1.4.2/metadata.rb
+++ b/spec/fixtures/cookbook-path-uploader/build-essential-1.4.2/metadata.rb
@@ -1,0 +1,2 @@
+name "build-essential"
+version "1.4.2"

--- a/spec/fixtures/cookbook-path-uploader/jenkins-2.0.3/metadata.rb
+++ b/spec/fixtures/cookbook-path-uploader/jenkins-2.0.3/metadata.rb
@@ -1,0 +1,5 @@
+name "jenkins"
+version "2.0.3"
+depends "apt", "~> 2.0"
+depends "runit", "~> 1.5"
+depends "yum", "~> 3.0"

--- a/spec/fixtures/cookbook-path-uploader/jenkins-config-0.1.0/metadata.rb
+++ b/spec/fixtures/cookbook-path-uploader/jenkins-config-0.1.0/metadata.rb
@@ -1,0 +1,4 @@
+name "jenkins-config"
+version "0.1.0"
+depends "jenkins", "~> 2.0"
+depends "yum", "~> 3.0"

--- a/spec/fixtures/cookbook-path-uploader/runit-1.5.8/metadata.rb
+++ b/spec/fixtures/cookbook-path-uploader/runit-1.5.8/metadata.rb
@@ -1,0 +1,5 @@
+name "runit"
+version "1.5.8"
+depends "build-essential"
+depends "yum", "~> 3.0"
+depends "yum-epel"

--- a/spec/fixtures/cookbook-path-uploader/yum-3.0.6/metadata.rb
+++ b/spec/fixtures/cookbook-path-uploader/yum-3.0.6/metadata.rb
@@ -1,0 +1,2 @@
+name "yum"
+version "3.0.6"

--- a/spec/fixtures/cookbook-path-uploader/yum-epel-0.2.0/metadata.rb
+++ b/spec/fixtures/cookbook-path-uploader/yum-epel-0.2.0/metadata.rb
@@ -1,0 +1,3 @@
+name "yum-epel"
+version "0.2.0"
+depends "yum", "~> 3.0"

--- a/spec/unit/berkshelf/downloader_spec.rb
+++ b/spec/unit/berkshelf/downloader_spec.rb
@@ -99,10 +99,7 @@ module Berkshelf
             cookbook_copyright: "user",
             cookbook_email: "user@example.com",
             cookbook_license: "apachev2",
-            trusted_certs_dir: self_signed_crt_path,
-            knife: {
-              chef_guard: false,
-            }
+            trusted_certs_dir: self_signed_crt_path
           )
         end
 

--- a/spec/unit/berkshelf/ssl_policies_spec.rb
+++ b/spec/unit/berkshelf/ssl_policies_spec.rb
@@ -16,10 +16,7 @@ describe Berkshelf::SSLPolicy do
       cookbook_copyright: "user",
       cookbook_email: "user@example.com",
       cookbook_license: "apachev2",
-      trusted_certs_dir: self_signed_crt_path,
-      knife: {
-        chef_guard: false,
-      }
+      trusted_certs_dir: self_signed_crt_path
     )
   end
 


### PR DESCRIPTION
Following the conversation on Slack a couple of days ago, this PR amends the order cookbooks are uploaded in in order to remove the `knife[:chef_guard]` option and adds unit tests for #filtered_cookbooks and #lookup_dependencies.

Hope this suffices, please let me know if there's anything I can fix/make better.

Stephen