### PR TITLE
remove buff-extensions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/chef/chef
-  revision: 51c59ecb887e9122aa849d8153b9984df74b2b09
+  revision: 8e9ea543502781d4e0f71a9d577f639c256171b1
   branch: master
   specs:
-    chef (14.0.146)
+    chef (14.0.149)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.0.146)
+      chef-config (= 14.0.149)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -33,7 +33,7 @@ GIT
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef-config (14.0.146)
+    chef-config (14.0.149)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -44,7 +44,6 @@ PATH
   remote: .
   specs:
     berkshelf (7.0.0.alpha.0)
-      buff-extensions (~> 2.0)
       chef (>= 13.6.52)
       chef-config
       cleanroom (~> 1.0)
@@ -77,7 +76,6 @@ GEM
       thor (~> 0.19)
     ast (2.4.0)
     backports (3.11.1)
-    buff-extensions (2.0.0)
     builder (3.2.3)
     chef-zero (14.0.1)
       ffi-yajl (~> 2.2)

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.4.0"
   s.required_rubygems_version = ">= 2.0.0"
 
-  s.add_dependency "buff-extensions",      "~> 2.0"
   s.add_dependency "mixlib-shellout",      "~> 2.0"
   s.add_dependency "cleanroom",            "~> 1.0"
   s.add_dependency "minitar",              ">= 0.6"

--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -9,7 +9,6 @@ rescue LoadError
   # intentionally left blank
 end
 
-require "buff/extensions"
 require "cleanroom"
 require "digest/md5"
 require "forwardable"
@@ -151,21 +150,22 @@ module Berkshelf
                                  end
       ssl_options[:cert_store] = ssl_policy.store if ssl_policy.store
 
-      ridley_options               = options.slice(:ssl)
+      ridley_options = {}
+      ridley_options[:ssl]         = options[:ssl] if options.key?(:ssl)
       ridley_options[:server_url]  = options[:server_url] || Berkshelf.config.chef.chef_server_url
       ridley_options[:client_name] = options[:client_name] || Berkshelf.config.chef.node_name
       ridley_options[:client_key]  = options[:client_key] || Berkshelf.config.chef.client_key
       ridley_options[:ssl]         = ssl_options
 
-      unless ridley_options[:server_url].present?
+      if !ridley_options[:server_url] || ridley_options[:server_url] =~ /^\s*$/
         raise ChefConnectionError, "Missing required attribute in your Berkshelf configuration: chef.server_url"
       end
 
-      unless ridley_options[:client_name].present?
+      if !ridley_options[:client_name] || ridley_options[:client_name] =~ /^\s*$/
         raise ChefConnectionError, "Missing required attribute in your Berkshelf configuration: chef.node_name"
       end
 
-      unless ridley_options[:client_key].present?
+      if !ridley_options[:client_key] || ridley_options[:client_key] =~ /^\s*$/
         raise ChefConnectionError, "Missing required attribute in your Berkshelf configuration: chef.client_key"
       end
 

--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -88,14 +88,14 @@ module Berkshelf
 
     def pretty_print
       [].tap do |a|
-        a.push "        Name: #{cookbook_name}" unless name.blank?
-        a.push "     Version: #{version}" unless version.blank?
-        a.push " Description: #{metadata.description}" unless metadata.description.blank?
-        a.push "      Author: #{metadata.maintainer}" unless metadata.maintainer.blank?
-        a.push "       Email: #{metadata.maintainer_email}" unless metadata.maintainer_email.blank?
-        a.push "     License: #{metadata.license}" unless metadata.license.blank?
-        a.push "   Platforms: #{pretty_map(metadata.platforms, 14)}" unless metadata.platforms.blank?
-        a.push "Dependencies: #{pretty_map(dependencies, 14)}" unless dependencies.blank?
+        a.push "        Name: #{cookbook_name}" if name && name =~ /\S/
+        a.push "     Version: #{version}" if version && version =~ /\S/
+        a.push " Description: #{metadata.description}" if metadata.description && metadata.description =~ /\S/
+        a.push "      Author: #{metadata.maintainer}" if metadata.maintainer && metadata.maintainer =~ /\S/
+        a.push "       Email: #{metadata.maintainer_email}" if metadata.maintainer_email && metadata.maintainer_email =~ /\S/
+        a.push "     License: #{metadata.license}" if metadata.license && metadata.license =~ /\S/
+        a.push "   Platforms: #{pretty_map(metadata.platforms, 14)}" if metadata.platforms && !metadata.platforms.empty?
+        a.push "Dependencies: #{pretty_map(dependencies, 14)}" if dependencies && !dependencies.empty?
       end.join("\n")
     end
 
@@ -111,14 +111,14 @@ module Berkshelf
     # @return [Hash]
     def pretty_hash
       {}.tap do |h|
-        h[:name]          = cookbook_name unless cookbook_name.blank?
-        h[:version]       = version unless version.blank?
-        h[:description]   = description unless description.blank?
-        h[:author]        = maintainer unless maintainer.blank?
-        h[:email]         = maintainer_email unless maintainer_email.blank?
-        h[:license]       = license unless license.blank?
-        h[:platforms]     = platforms.to_hash unless platforms.blank?
-        h[:dependencies]  = dependencies.to_hash unless dependencies.blank?
+        h[:name]          = cookbook_name if cookbook_name && cookbook_name =~ /\S/
+        h[:version]       = version if version && version =~ /\S/
+        h[:description]   = description if description && description =~ /\S/
+        h[:author]        = maintainer if maintainer && maintainer =~ /\S/
+        h[:email]         = maintainer_email if maintainer_email && maintainer_email =~ /\S/
+        h[:license]       = license if license && license =~ /\S/
+        h[:platforms]     = platforms.to_hash if platforms && !platforms.empty?
+        h[:dependencies]  = dependencies.to_hash if dependencies && !dependencies.empty?
       end
     end
 

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -192,8 +192,7 @@ module Berkshelf
 
       options[:freeze]    = !options[:no_freeze]
       options[:validate]  = false if options[:skip_syntax_check]
-
-      berksfile.upload(names, options.symbolize_keys)
+      berksfile.upload(names, options.each_with_object({}) { |(k, v), m| m[k.to_sym] = v })
     end
 
     method_option :envfile,
@@ -217,7 +216,7 @@ module Berkshelf
       end
 
       lockfile     = Lockfile.from_file(options[:lockfile])
-      lock_options = Hash[options].symbolize_keys
+      lock_options = Hash[options].each_with_object({}) { |(k, v), m| m[k.to_sym] = v }
 
       lockfile.apply(environment_name, lock_options)
     end

--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -69,7 +69,7 @@ module Berkshelf
     #   how often we should pause between retries
     def initialize(uri = V1_API, options = {})
       options = options.dup
-      options         = options.reverse_merge(retries: 5, retry_interval: 0.5, ssl: Berkshelf::Config.instance.ssl)
+      options         = { retries: 5, retry_interval: 0.5, ssl: Berkshelf::Config.instance.ssl }.merge(options)
       @api_uri        = uri
       options[:server_url] = uri
       @retries        = options.delete(:retries)

--- a/lib/berkshelf/uploader.rb
+++ b/lib/berkshelf/uploader.rb
@@ -13,7 +13,7 @@ module Berkshelf
     def initialize(berksfile, *args)
       @berksfile = berksfile
       @lockfile  = berksfile.lockfile
-      opts       = args.last.respond_to?(:to_hash) ? args.pop.to_hash.symbolize_keys : {}
+      opts       = args.last.respond_to?(:to_hash) ? args.pop.to_hash.each_with_object({}) { |(k, v), m| m[k.to_sym] = v } : {}
 
       @options = {
         force:          false,

--- a/spec/support/chef_server.rb
+++ b/spec/support/chef_server.rb
@@ -23,7 +23,7 @@ module Berkshelf::RSpec
       def start(options = {})
         return @server if @server
 
-        options = options.reverse_merge(port: PORT)
+        options = { port: PORT }.merge(options)
         options[:generate_real_keys] = false
 
         @server = ChefZero::Server.new(options)

--- a/spec/support/matchers/file_system_matchers.rb
+++ b/spec/support/matchers/file_system_matchers.rb
@@ -59,9 +59,7 @@ module Berkshelf
         end
 
         def file(name, &block)
-          silence_warnings do
-            @tree[name] = FileMatcher.new(location(name), &block)
-          end
+          @tree[name] = FileMatcher.new(location(name), &block)
         end
 
         def no_file(name)

--- a/spec/unit/berkshelf/cached_cookbook_spec.rb
+++ b/spec/unit/berkshelf/cached_cookbook_spec.rb
@@ -82,7 +82,7 @@ describe Berkshelf::CachedCookbook do
   end
 
   describe "#pretty_hash" do
-    shared_examples "a pretty_hash cookbook attribute" do |attribute, key|
+    shared_examples "a pretty_hash string cookbook attribute" do |attribute, key|
       it "is not present when the `#{attribute}` attribute is nil" do
         allow(subject).to receive(attribute.to_sym).and_return(nil)
         expect(subject.pretty_hash).to_not have_key((key || attribute).to_sym)
@@ -92,9 +92,11 @@ describe Berkshelf::CachedCookbook do
         allow(subject).to receive(attribute.to_sym).and_return("")
         expect(subject.pretty_hash).to_not have_key((key || attribute).to_sym)
       end
+    end
 
-      it "is not present when the `#{attribute}` attribute is an empty array" do
-        allow(subject).to receive(attribute.to_sym).and_return([])
+    shared_examples "a pretty_hash hash cookbook attribute" do |attribute, key|
+      it "is not present when the `#{attribute}` attribute is nil" do
+        allow(subject).to receive(attribute.to_sym).and_return(nil)
         expect(subject.pretty_hash).to_not have_key((key || attribute).to_sym)
       end
 
@@ -109,13 +111,13 @@ describe Berkshelf::CachedCookbook do
       end
     end
 
-    it_behaves_like "a pretty_hash cookbook attribute", "cookbook_name", "name"
-    it_behaves_like "a pretty_hash cookbook attribute", "version"
-    it_behaves_like "a pretty_hash cookbook attribute", "description"
-    it_behaves_like "a pretty_hash cookbook attribute", "maintainer", "author"
-    it_behaves_like "a pretty_hash cookbook attribute", "maintainer_email", "email"
-    it_behaves_like "a pretty_hash cookbook attribute", "license"
-    it_behaves_like "a pretty_hash cookbook attribute", "platforms"
-    it_behaves_like "a pretty_hash cookbook attribute", "dependencies"
+    it_behaves_like "a pretty_hash string cookbook attribute", "cookbook_name", "name"
+    it_behaves_like "a pretty_hash string cookbook attribute", "version"
+    it_behaves_like "a pretty_hash string cookbook attribute", "description"
+    it_behaves_like "a pretty_hash string cookbook attribute", "maintainer", "author"
+    it_behaves_like "a pretty_hash string cookbook attribute", "maintainer_email", "email"
+    it_behaves_like "a pretty_hash string cookbook attribute", "license"
+    it_behaves_like "a pretty_hash hash cookbook attribute", "platforms"
+    it_behaves_like "a pretty_hash hash cookbook attribute", "dependencies"
   end
 end


### PR DESCRIPTION
This should completely end the parade of APIs that have been getting added to new ruby versions and colliding with same-named-but-differently-implemented APIs monkeypatched in via buff-extensions
