### PR TITLE
Fix chefignores being ignored in berkshelf 7.0.0

### DIFF
--- a/features/commands/vendor.feature
+++ b/features/commands/vendor.feature
@@ -107,3 +107,30 @@ Feature: Vendoring cookbooks to a directory
     When I successfully run `berks vendor path/to/cukebooks`
     Then the directory "path/to/cukebooks/fake" should contain version "1.0.0" of the "fake" cookbook
 
+  Scenario: vendoring a cookbook with chefignores
+    Given a cookbook named "bacon"
+    And the cookbook "bacon" has the file "metadata.rb" with:
+      """
+      name 'bacon'
+      version '1.0.0'
+      """
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'bacon', path: './bacon'
+      """
+    And the cookbook "bacon" has the file "chefignore" with:
+      """
+      *.turd
+      """
+    And the cookbook "bacon" has the file "foo.turd" with:
+      """
+      poop
+      """
+    And the cookbook "bacon" has the file "recipes/foo.turd" with:
+      """
+      poop
+      """
+    When I successfully run `berks vendor vendor`
+    Then the directory "vendor/bacon" should contain version "1.0.0" of the "bacon" cookbook
+    And a file named "vendor/bacon/foo.turd" should not exist
+    And a file named "vendor/bacon/recipes/foo.turd" should not exist


### PR DESCRIPTION
As a bonus this addresses the long-standing #1317.   It looks like berkshelf was only ever comparing chefignores against the root directory in a cookbook and then recursively copying entire directories, so it was always impossible to chefignore anything in a subdirectory.  This fixes that to be compatible with the way that chef applies chefignores and filters every file against the chefignore file.

Conceivably people have been bug dependent upon this behavior, although the inconsistency between chef-client and berkshelf should now be resolved -- so this being a breaking change is entirely intended in that case.

closes #1317