### PR TITLE
Fix config parsing from json file

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -53,7 +53,7 @@ module Berkshelf
       def instance
         @instance ||=
           if file
-            from_json file
+            new path
           else
             new
           end


### PR DESCRIPTION
Following 7.0.0 release and commit 523366f438e the `instance` method is trying to create config using `Mixlib::Config.from_json` method and passing a json string.

Use the initialize method instead of the from_json one.

Fix #1764 & #1765