### PR TITLE
fix to generate metadata.json only in the vendored cookbook

### DIFF
--- a/features/commands/vendor.feature
+++ b/features/commands/vendor.feature
@@ -150,3 +150,5 @@ Feature: Vendoring cookbooks to a directory
     Then the directory "vendor/bacon" should contain version "1.0.0" of the "bacon" cookbook
     And a file named "vendor/bacon/metadata.json" should exist
     And a file named "vendor/bacon/metadata.rb" should exist
+    And a file named "bacon/metadata.rb" should exist
+    And a file named "bacon/metadata.json" should not exist

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -636,10 +636,6 @@ module Berkshelf
         cached_cookbooks.each do |cookbook|
           Berkshelf.formatter.vendor(cookbook, destination)
 
-          # compile the metadata early before we do the file list
-          cookbook.compile_metadata
-          cookbook.reload
-
           cookbook_destination = File.join(scratch, cookbook.cookbook_name)
           FileUtils.mkdir_p(cookbook_destination)
 
@@ -666,6 +662,8 @@ module Berkshelf
             FileUtils.mkdir_p( File.join(cookbook_destination, File.dirname(rpath)) )
             FileUtils.cp( File.join(cookbook.path.to_s, rpath), File.join(cookbook_destination, rpath) )
           end
+
+          cookbook.compile_metadata(cookbook_destination)
         end
 
         # Don't vendor the raw metadata (metadata.rb). The raw metadata is

--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -162,7 +162,7 @@ module Berkshelf
       true
     end
 
-    def compile_metadata
+    def compile_metadata(path = self.path)
       json_file = "#{path}/metadata.json"
       rb_file = "#{path}/metadata.rb"
       return nil if File.exist?(json_file)


### PR DESCRIPTION
I thought the path argument to the `compile_metadata()` method was useless when I ported the method over from ridley, but it turns out it uses that here in order to construct the metadata only in the destination vendored directory, so I started to create litter in the root of the cookbook.  There were no tests, so no indication that broke.  There is now a test that will fail properly.