### PR TITLE
CI fix:  remove '::' from module statements

### DIFF
--- a/lib/berkshelf/api_client/chef_server_connection.rb
+++ b/lib/berkshelf/api_client/chef_server_connection.rb
@@ -1,28 +1,30 @@
 require "berkshelf/ridley_compat"
 
-module Berkshelf::APIClient
-  require_relative "errors"
+module Berkshelf
+  module APIClient
+    require_relative "errors"
 
-  class ChefServerConnection
-    attr_reader :client
+    class ChefServerConnection
+      attr_reader :client
 
-    def initialize(*args)
-      @client = Berkshelf::RidleyCompat.new(*args)
-      @url = args[0][:server_url]
-    end
-
-    def universe
-      response = client.get("universe")
-
-      [].tap do |cookbooks|
-        response.each do |name, versions|
-          versions.each do |version, attributes|
-            attributes[:location_path] = @url
-            cookbooks << RemoteCookbook.new(name, version, attributes) end
-        end
+      def initialize(*args)
+        @client = Berkshelf::RidleyCompat.new(*args)
+        @url = args[0][:server_url]
       end
-    rescue Ridley::Errors::HTTPNotFound
-      raise ServiceNotFound, "service not found at: #{@url}"
+
+      def universe
+        response = client.get("universe")
+
+        [].tap do |cookbooks|
+          response.each do |name, versions|
+            versions.each do |version, attributes|
+              attributes[:location_path] = @url
+              cookbooks << RemoteCookbook.new(name, version, attributes) end
+          end
+        end
+      rescue Ridley::Errors::HTTPNotFound
+        raise ServiceNotFound, "service not found at: #{@url}"
+      end
     end
   end
 end

--- a/lib/berkshelf/api_client/connection.rb
+++ b/lib/berkshelf/api_client/connection.rb
@@ -1,53 +1,55 @@
 require "berkshelf/ridley_compat"
 
-module Berkshelf::APIClient
-  require_relative "errors"
+module Berkshelf
+  module APIClient
+    require_relative "errors"
 
-  class Connection
-    # @return [String]
-    attr_reader :url
+    class Connection
+      # @return [String]
+      attr_reader :url
 
-    # @return [Integer]
-    #   how many retries to attempt on HTTP requests
-    attr_reader :retries
+      # @return [Integer]
+      #   how many retries to attempt on HTTP requests
+      attr_reader :retries
 
-    # @return [Float]
-    #   time to wait between retries
-    attr_reader :retry_interval
+      # @return [Float]
+      #   time to wait between retries
+      attr_reader :retry_interval
 
-    # @param [String, Addressable::URI] url
-    #
-    # @option options [Integer] :open_timeout (3)
-    #   how long to wait (in seconds) for connection open to the API server
-    # @option options [Integer] :timeout (30)
-    #   how long to wait (in seconds) before getting a response from the API server
-    # @option options [Integer] :retries (3)
-    #   how many retries to perform before giving up
-    # @option options [Float] :retry_interval (0.5)
-    #   how long to wait (in seconds) between each retry
-    def initialize(url, options = {})
-      # it looks like Faraday mutates the URI argument it is given, when we ripped Faraday out of this
-      # API it stopped doing that.  this may or may not be a breaking change (it broke some fairly
-      # brittle berkshelf tests).  if it causes too much berkshelf chaos we could revert by uncommenting
-      # the next line.  as it is removing this behavior feels more like fixing a bug.
-      #@url = url.normalize! if url.is_a?(Addressable::URI)
-      options = { retries: 3, retry_interval: 0.5, open_timeout: 30, timeout: 30 }.merge(options)
-      options[:server_url] = url
+      # @param [String, Addressable::URI] url
+      #
+      # @option options [Integer] :open_timeout (3)
+      #   how long to wait (in seconds) for connection open to the API server
+      # @option options [Integer] :timeout (30)
+      #   how long to wait (in seconds) before getting a response from the API server
+      # @option options [Integer] :retries (3)
+      #   how many retries to perform before giving up
+      # @option options [Float] :retry_interval (0.5)
+      #   how long to wait (in seconds) between each retry
+      def initialize(url, options = {})
+        # it looks like Faraday mutates the URI argument it is given, when we ripped Faraday out of this
+        # API it stopped doing that.  this may or may not be a breaking change (it broke some fairly
+        # brittle berkshelf tests).  if it causes too much berkshelf chaos we could revert by uncommenting
+        # the next line.  as it is removing this behavior feels more like fixing a bug.
+        #@url = url.normalize! if url.is_a?(Addressable::URI)
+        options = { retries: 3, retry_interval: 0.5, open_timeout: 30, timeout: 30 }.merge(options)
+        options[:server_url] = url
 
-      @client = Berkshelf::RidleyCompatJSON.new(**options)
-    end
+        @client = Berkshelf::RidleyCompatJSON.new(**options)
+      end
 
-    # Retrieves the entire universe of known cookbooks from the API source
-    #
-    # @raise [APIClient::TimeoutError]
-    #
-    # @return [Array<APIClient::RemoteCookbook>]
-    def universe
-      response = @client.get("universe")
+      # Retrieves the entire universe of known cookbooks from the API source
+      #
+      # @raise [APIClient::TimeoutError]
+      #
+      # @return [Array<APIClient::RemoteCookbook>]
+      def universe
+        response = @client.get("universe")
 
-      [].tap do |cookbooks|
-        response.each do |name, versions|
-          versions.each { |version, attributes| cookbooks << RemoteCookbook.new(name, version, attributes) }
+        [].tap do |cookbooks|
+          response.each do |name, versions|
+            versions.each { |version, attributes| cookbooks << RemoteCookbook.new(name, version, attributes) }
+          end
         end
       end
     end

--- a/lib/berkshelf/api_client/remote_cookbook.rb
+++ b/lib/berkshelf/api_client/remote_cookbook.rb
@@ -1,54 +1,56 @@
 require "json"
 require "chef/mash"
 
-module Berkshelf::APIClient
-  # A representation of cookbook metadata indexed by a Berkshelf API Server. Returned
-  # by sending messages to a {Berkshelf::APIClient} and used to download cookbooks
-  # indexed by the Berkshelf API Server.
-  class RemoteCookbook
-    # @return [String]
-    attr_reader :name
-    # @return [String]
-    attr_reader :version
+module Berkshelf
+  module APIClient
+    # A representation of cookbook metadata indexed by a Berkshelf API Server. Returned
+    # by sending messages to a {Berkshelf::APIClient} and used to download cookbooks
+    # indexed by the Berkshelf API Server.
+    class RemoteCookbook
+      # @return [String]
+      attr_reader :name
+      # @return [String]
+      attr_reader :version
 
-    # @param [String] name
-    # @param [String] version
-    # @param [Hash] attributes
-    def initialize(name, version, attributes = {})
-      @name       = name
-      @version    = version
-      @attributes = ::Mash.new(attributes)
-    end
+      # @param [String] name
+      # @param [String] version
+      # @param [Hash] attributes
+      def initialize(name, version, attributes = {})
+        @name       = name
+        @version    = version
+        @attributes = ::Mash.new(attributes)
+      end
 
-    # @return [Hash]
-    def dependencies
-      @attributes[:dependencies]
-    end
+      # @return [Hash]
+      def dependencies
+        @attributes[:dependencies]
+      end
 
-    # @return [Hash]
-    def platforms
-      @attributes[:platforms]
-    end
+      # @return [Hash]
+      def platforms
+        @attributes[:platforms]
+      end
 
-    # @return [Symbol]
-    def location_type
-      @attributes[:location_type].to_sym
-    end
+      # @return [Symbol]
+      def location_type
+        @attributes[:location_type].to_sym
+      end
 
-    # @return [String]
-    def location_path
-      @attributes[:location_path]
-    end
+      # @return [String]
+      def location_path
+        @attributes[:location_path]
+      end
 
-    def to_hash
-      {
-        name: name,
-        version: version,
-      }
-    end
+      def to_hash
+        {
+          name: name,
+          version: version,
+        }
+      end
 
-    def to_json(options = {})
-      ::JSON.pretty_generate(to_hash, options)
+      def to_json(options = {})
+        ::JSON.pretty_generate(to_hash, options)
+      end
     end
   end
 end

--- a/spec/support/chef_server.rb
+++ b/spec/support/chef_server.rb
@@ -1,99 +1,101 @@
 require "chef_zero/server"
 require "json"
 
-module Berkshelf::RSpec
-  module ChefServer
-    PORT = 4000
+module Berkshelf
+  module RSpec
+    module ChefServer
+      PORT = 4000
 
-    class << self
-      attr_reader :server
+      class << self
+        attr_reader :server
 
-      def clear_request_log
-        @request_log = Array.new
-      end
-
-      def request_log
-        @request_log ||= Array.new
-      end
-
-      def server_url
-        @server && @server.url
-      end
-
-      def start(options = {})
-        return @server if @server
-
-        options = { port: PORT }.merge(options)
-        options[:generate_real_keys] = false
-
-        @server = ChefZero::Server.new(options)
-        @server.start_background
-        @server.on_response do |request, response|
-          request_log << [ request, response ]
+        def clear_request_log
+          @request_log = Array.new
         end
-        clear_request_log
 
-        @server
+        def request_log
+          @request_log ||= Array.new
+        end
+
+        def server_url
+          @server && @server.url
+        end
+
+        def start(options = {})
+          return @server if @server
+
+          options = { port: PORT }.merge(options)
+          options[:generate_real_keys] = false
+
+          @server = ChefZero::Server.new(options)
+          @server.start_background
+          @server.on_response do |request, response|
+            request_log << [ request, response ]
+          end
+          clear_request_log
+
+          @server
+        end
+
+        def stop
+          @server.stop if running?
+        end
+
+        def running?
+          @server && @server.running?
+        end
+
+        def reset!
+          @server && @server.clear_data
+        end
       end
 
-      def stop
-        @server.stop if running?
+      def chef_server
+        ChefServer.server
       end
 
-      def running?
-        @server && @server.running?
+      def chef_client(name, hash = {})
+        load_data(:clients, name, hash)
       end
 
-      def reset!
-        @server && @server.clear_data
+      def chef_cookbook(name, hash = {})
+        chef_server.load_data({ "cookbooks" => { name => hash } })
       end
-    end
 
-    def chef_server
-      ChefServer.server
-    end
-
-    def chef_client(name, hash = {})
-      load_data(:clients, name, hash)
-    end
-
-    def chef_cookbook(name, hash = {})
-      chef_server.load_data({ "cookbooks" => { name => hash } })
-    end
-
-    def chef_cookbooks
-      chef_server.data_store.list(%w{organizations chef cookbooks}).inject({}) do |hash, name|
-        hash[name] = chef_server.data_store.list(["organizations", "chef", "cookbooks", name])
-        hash
+      def chef_cookbooks
+        chef_server.data_store.list(%w{organizations chef cookbooks}).inject({}) do |hash, name|
+          hash[name] = chef_server.data_store.list(["organizations", "chef", "cookbooks", name])
+          hash
+        end
       end
-    end
 
-    def chef_data_bag(name, hash = {})
-      chef_server.load_data({ "data" => { name => hash } })
-    end
+      def chef_data_bag(name, hash = {})
+        chef_server.load_data({ "data" => { name => hash } })
+      end
 
-    def chef_environment(name, hash = {})
-      load_data(:environments, name, hash)
-    end
+      def chef_environment(name, hash = {})
+        load_data(:environments, name, hash)
+      end
 
-    def chef_environment_locks(name)
-      JSON.parse(chef_server.data_store.get(["organizations", "chef", "environments", name]))["cookbook_versions"]
-    rescue ChefZero::DataStore::DataNotFoundError
-      {}
-    end
+      def chef_environment_locks(name)
+        JSON.parse(chef_server.data_store.get(["organizations", "chef", "environments", name]))["cookbook_versions"]
+      rescue ChefZero::DataStore::DataNotFoundError
+        {}
+      end
 
-    def chef_node(name, hash = {})
-      load_data(:nodes, name, hash)
-    end
+      def chef_node(name, hash = {})
+        load_data(:nodes, name, hash)
+      end
 
-    def chef_role(name, hash = {})
-      load_data(:roles, name, hash)
-    end
+      def chef_role(name, hash = {})
+        load_data(:roles, name, hash)
+      end
 
-    private
+      private
 
-    def load_data(key, name, hash)
-      chef_server.load_data({ key.to_s => { name => JSON.generate(hash) } })
+      def load_data(key, name, hash)
+        chef_server.load_data({ key.to_s => { name => JSON.generate(hash) } })
+      end
     end
   end
 end


### PR DESCRIPTION
Seeing piles of this only on sles-11 and el-6:

```
An error occurred while loading ./spec/unit/berkshelf/berksfile_spec.rb.
Failure/Error: module Berkshelf::RSpec

NameError:
  uninitialized constant Berkshelf
# ./spec/support/chef_server.rb:4:in `<top (required)>'
# ./spec/spec_helper.rb:12:in `require'
# ./spec/spec_helper.rb:12:in `block in <top (required)>'
# ./spec/spec_helper.rb:12:in `each'
# ./spec/spec_helper.rb:12:in `<top (required)>'
# ./spec/unit/berkshelf/berksfile_spec.rb:1:in `require'
# ./spec/unit/berkshelf/berksfile_spec.rb:1:in `<top (required)>'

An error occurred while loading ./spec/unit/berkshelf/berkshelf/api_client/connection_spec.rb.
Failure/Error: module Berkshelf::RSpec

NameError:
  uninitialized constant Berkshelf
# ./spec/support/chef_server.rb:4:in `<top (required)>'
# ./spec/spec_helper.rb:12:in `require'
# ./spec/spec_helper.rb:12:in `block in <top (required)>'
# ./spec/spec_helper.rb:12:in `each'
# ./spec/spec_helper.rb:12:in `<top (required)>'
# ./spec/unit/berkshelf/berkshelf/api_client/connection_spec.rb:1:in `require'
# ./spec/unit/berkshelf/berkshelf/api_client/connection_spec.rb:1:in `<top (required)>'

An error occurred while loading ./spec/unit/berkshelf/berkshelf/api_client/remote_cookbook_spec.rb.
Failure/Error: module Berkshelf::RSpec
```