### PR TITLE
fix reading the json config file

### DIFF
--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -40,23 +40,12 @@ module Berkshelf
         @instance = nil
       end
 
-      # @return [String, nil]
-      #   the contents of the file
-      def file
-        File.read(path) if File.exist?(path)
-      end
-
       # Instantiate and return or just return the currently instantiated Berkshelf
       # configuration
       #
       # @return [Config]
       def instance
-        @instance ||=
-          if file
-            from_json file
-          else
-            new
-          end
+        @instance ||= new(path)
         coerce_ssl
       end
 
@@ -77,18 +66,6 @@ module Berkshelf
         ssl[:client_cert] = OpenSSL::X509::Certificate.new(File.read(ssl[:client_cert])) if ssl[:client_cert] && ssl[:client_cert].is_a?(String)
         ssl[:client_key] = OpenSSL::PKey::RSA.new(File.read(ssl[:client_key])) if ssl[:client_key] && ssl[:client_key].is_a?(String)
         @instance
-      end
-
-      def from_file(path)
-        new(path)
-      end
-
-      def from_json(json)
-        new.from_json(json)
-      end
-
-      def from_hash(hash)
-        new.from_hash(hash)
       end
     end
 

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -67,6 +67,10 @@ module Berkshelf
         ssl[:client_key] = OpenSSL::PKey::RSA.new(File.read(ssl[:client_key])) if ssl[:client_key] && ssl[:client_key].is_a?(String)
         @instance
       end
+
+      def from_file(path)
+        new(path)
+      end
     end
 
     attr_accessor :path

--- a/spec/unit/berkshelf/config_spec.rb
+++ b/spec/unit/berkshelf/config_spec.rb
@@ -1,16 +1,6 @@
 require "spec_helper"
 
 describe Berkshelf::Config do
-  describe "::file" do
-    context "when the file does not exist" do
-      before { allow(File).to receive(:exist?).and_return(false) }
-
-      it "is nil" do
-        expect(Berkshelf::Config.file).to be_nil
-      end
-    end
-  end
-
   describe "::instance" do
     it "should be a Berkshelf::Config" do
       expect(Berkshelf::Config.instance).to be_an_instance_of(Berkshelf::Config)
@@ -74,10 +64,6 @@ describe Berkshelf::Config do
       expect(Berkshelf::Config.path).to be_a(String)
     end
 
-    before do
-      allow(File).to receive(:exist?).and_return(false)
-    end
-
     after do
       Berkshelf::Config.instance_variable_set(:@path, nil)
     end
@@ -90,6 +76,16 @@ describe Berkshelf::Config do
 
       it "points to a location within it" do
         expect(Berkshelf::Config.path).to match(%r{/tmp/config.json})
+      end
+    end
+
+    it "reads json from a path" do
+      Tempfile.open(["berkstest", ".json"]) do |t|
+        t.write JSON.generate({ "ssl" => { "verify" => false } })
+        t.close
+        expect(Berkshelf::Config).to receive(:local_location).at_least(:once).and_return(t.path)
+        Berkshelf::Config.reload
+        expect( Berkshelf::Config.instance[:ssl][:verify] ).to be false
       end
     end
   end


### PR DESCRIPTION
just delegating to mixlib-config's from_file API in the constructor
makes all this a lot simpler to understand

closes #1764 
closes #1765 
