### PR TITLE
bump gems and update thor pin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/chef/chef
-  revision: 39ff59de987a11efa8d4c9f803c79343b27c4b4a
+  revision: 45084f13cacc8de6c091ec464da0d24ea427019d
   branch: master
   specs:
-    chef (14.0.215)
+    chef (14.0.218)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.0.215)
+      chef-config (= 14.0.218)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -34,7 +34,7 @@ GIT
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef-config (14.0.215)
+    chef-config (14.0.218)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -56,7 +56,7 @@ PATH
       octokit (~> 4.0)
       retryable (~> 2.0)
       solve (~> 4.0)
-      thor (~> 0.19, < 0.19.2)
+      thor (>= 0.20)
 
 GEM
   remote: https://rubygems.org/
@@ -140,7 +140,7 @@ GEM
     hashdiff (0.3.7)
     hashie (3.5.7)
     highline (1.7.10)
-    http (3.2.1)
+    http (3.3.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 2.0)
@@ -157,7 +157,7 @@ GEM
     libyajl2 (1.2.0)
     minitar (0.6.1)
     minitest (5.11.3)
-    mixlib-archive (0.4.2)
+    mixlib-archive (0.4.4)
       mixlib-log
     mixlib-authentication (2.0.0)
     mixlib-cli (1.7.0)
@@ -254,7 +254,7 @@ GEM
       sfl
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    thor (0.19.1)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tomlrb (1.2.6)
     tzinfo (1.2.5)
@@ -264,7 +264,7 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.3.2)
     uuidtools (2.1.5)
-    webmock (3.3.0)
+    webmock (3.4.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "minitar",              ">= 0.6"
   s.add_dependency "retryable",            "~> 2.0"
   s.add_dependency "solve",                "~> 4.0"
-  s.add_dependency "thor",                 "~> 0.19", "< 0.19.2"
+  s.add_dependency "thor",                 ">= 0.20"
   s.add_dependency "octokit",              "~> 4.0"
   s.add_dependency "mixlib-archive",       "~> 0.4"
   s.add_dependency "concurrent-ruby",      "~> 1.0"


### PR DESCRIPTION
thor 0.20.x seems to fix the bug that caused us to overly pin on 0.19
versions.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>