### PR TITLE
[SHACK-295] Missing require for ChefDK 2.x patch release

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require "rspec"
 require "cleanroom/rspec"
 require "webmock/rspec"
 require "rspec/its"
+require "berkshelf"
 
 Dir["spec/support/**/*.rb"].each { |f| require File.expand_path(f) }
 
@@ -62,8 +63,6 @@ def capture(stream)
 
   result
 end
-
-require "berkshelf"
 
 module Berkshelf
   class GitLocation


### PR DESCRIPTION
This needs to be earlier in the order for the `chef verify` tests to pass

Signed-off-by: tyler-ball <tball@chef.io>