### PR TITLE
Add a Chef::CookbookManifestVersions to RidleyCompat

### DIFF
--- a/lib/berkshelf/ridley_compat.rb
+++ b/lib/berkshelf/ridley_compat.rb
@@ -3,6 +3,7 @@ require "chef/http/simple_json"
 require "chef/http/simple"
 require "berkshelf/api_client/errors"
 require "chef/config"
+require "chef/cookbook_manifest"
 
 module Berkshelf
   module RidleyCompatAPI
@@ -20,6 +21,7 @@ module Berkshelf
       chef_opts[:ssl_ca_file]          = opts[:ssl][:ca_file] if opts[:ssl][:ca_file]
       chef_opts[:ssl_client_cert]      = opts[:ssl][:client_cert] if opts[:ssl][:client_cert]
       chef_opts[:ssl_client_key]       = opts[:ssl][:client_key] if opts[:ssl][:client_key]
+      chef_opts[:version_class]        = opts[:version_class] if opts[:version_class]
       # chef/http/ssl_policies.rb reads only from Chef::Config and not from the opts in the constructor
       Chef::Config[:verify_api_cert] = chef_opts[:verify_api_cert]
       Chef::Config[:ssl_verify_mode] = chef_opts[:ssl_verify_mode]
@@ -97,5 +99,11 @@ module Berkshelf
     use Chef::HTTP::ValidateContentLength
 
     include RidleyCompatAPI
+
+    def initialize(**opts)
+      opts[:version_class] = Chef::CookbookManifestVersions
+      super(**opts)
+    end
+
   end
 end

--- a/spec/unit/berkshelf/ridley_compat_spec.rb
+++ b/spec/unit/berkshelf/ridley_compat_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+require "chef/cookbook_manifest"
+
+describe Berkshelf::RidleyCompat do
+  let(:opts) { Hash.new }
+
+  subject { described_class.new(opts) }
+
+  context "default" do
+    it "has a cookbook version_class" do
+      expect(subject.options).to have_key(:version_class)
+      expect(subject.options[:version_class])
+        .to eq(Chef::CookbookManifestVersions)
+    end
+  end
+end


### PR DESCRIPTION
Add a version class to the RidleyCompat shim so that the underlying
ServerAPI can properly negotiate cookbook API versions when uploading
non-segmented cookbooks with V2 of the Chef Server cookbooks API.

Without this it requests API version 1 but uses the Chef::CookbookUploader to generate a non-segmented cookbook which requires API version 2:

```
[2018-08-03T19:53:30+00:00] TRACE: ---- HTTP Request Header Data: ----                                                                                                              
...
[2018-08-03T19:53:30+00:00] TRACE: X-Ops-Server-API-Version: 1                                                                                                                      
...
[2018-08-03T19:53:30+00:00] TRACE: ---- End HTTP Request Header Data ----
[2018-08-03T19:53:30+00:00] TRACE: ---- HTTP Status and Header Data: ----
[2018-08-03T19:53:30+00:00] TRACE: HTTP 1.1 400 Bad Request
[2018-08-03T19:53:30+00:00] TRACE: server: nginx
[2018-08-03T19:53:30+00:00] TRACE: date: Fri, 03 Aug 2018 19:53:30 GMT
[2018-08-03T19:53:30+00:00] TRACE: content-length: 51
[2018-08-03T19:53:30+00:00] TRACE: connection: close                                                                                                                               
[2018-08-03T19:53:30+00:00] TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"1","response_version":"1"}
[2018-08-03T19:53:30+00:00] TRACE: x-ops-api-info: flavor=cs;version=12.0.0;oc_erchef=12.17.61
...
[2018-08-03T19:53:30+00:00] TRACE: ---- HTTP Response Body ----
[2018-08-03T19:53:30+00:00] TRACE: {"error":["Invalid key all_files in request body"]}
[2018-08-03T19:53:30+00:00] TRACE: ---- End HTTP Response Body -----
```

With the version class the ServerAPI request API version 2.

```
[2018-08-03T19:55:09+00:00] TRACE: x-ops-server-api-version {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
```