### PR TITLE
[SHACK-295] Kitchen generator conflicts on 'chefignore'

### DIFF
--- a/spec/unit/berkshelf/cookbook_generator_spec.rb
+++ b/spec/unit/berkshelf/cookbook_generator_spec.rb
@@ -11,6 +11,9 @@ describe Berkshelf::CookbookGenerator do
 
   context "with default options" do
     before do
+      if defined?(Kitchen::Generator::Init)
+        expect(Kitchen::Generator::Init).to receive(:new).with(any_args()).and_return(kitchen_generator)
+      end
       capture(:stdout) do
         Berkshelf::CookbookGenerator.new([target, name],
           license:          license,
@@ -76,6 +79,9 @@ describe Berkshelf::CookbookGenerator do
   context "given a 'maintainer_email' option" do
     before do
       capture(:stdout) do
+        if defined?(Kitchen::Generator::Init)
+          expect(Kitchen::Generator::Init).to receive(:new).with(any_args()).and_return(kitchen_generator)
+        end
         Berkshelf::CookbookGenerator.new([target, name], maintainer_email: "jamie@vialstudios.com").invoke_all
       end
     end

--- a/spec/unit/berkshelf/init_generator_spec.rb
+++ b/spec/unit/berkshelf/init_generator_spec.rb
@@ -6,6 +6,9 @@ describe Berkshelf::InitGenerator do
   let(:kitchen_generator) { double("kitchen-generator", invoke_all: nil) }
 
   before do
+    if defined?(Kitchen::Generator::Init)
+      allow(Kitchen::Generator::Init).to receive(:new).with(any_args()).and_return(kitchen_generator)
+    end
     FileUtils.mkdir_p(target)
     File.open(File.join(target, "metadata.rb"), "w") do |f|
       f.write("name 'some_cookbook'")


### PR DESCRIPTION
When the Kitchen generator runs it tries to create a 'chefignore' file
that is different from what Berkshelf creates. Because Berkshelf invokes
the kitchen generator by default (if the libraries are present) this
causes the 'chef verify berkshelf --unit' command to fail.

It ends up hanging indefinitely because the 'chefignore' that TK and
Berkshelf create are different, so it prompts the user to resolve this
conflict. This stdin prompt in the automated pipeline causes the tests
to hang forever until they are killed.

This is a partial revert of https://github.com/berkshelf/berkshelf/pull/1702

Signed-off-by: tyler-ball <tball@chef.io>