### PR TITLE
Adds the possibility to show all outdated dependencies with berks outdated

### DIFF
--- a/features/commands/outdated.feature
+++ b/features/commands/outdated.feature
@@ -75,6 +75,55 @@ Feature: berks outdated
         * bacon (1.0.0 => 1.5.8)
       """
 
+  Scenario: the dependency has a version constraint and there are new items that don't satisfy it
+    Given the Chef Server has cookbooks:
+      | bacon | 1.1.0 |
+      | bacon | 1.5.8 |
+    And the cookbook store has the cookbooks:
+      | bacon | 1.1.0 |
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'bacon', '~> 1.1.0'
+      """
+    And I write to "Berksfile.lock" with:
+      """
+      DEPENDENCIES
+        bacon (~> 1.1.0)
+
+      GRAPH
+        bacon (1.1.0)
+      """
+    When I successfully run `berks outdated`
+    Then the output should contain:
+      """
+      All cookbooks up to date!
+      """
+
+  Scenario: the dependency has a version constraint and there are new items that satisfy it and --all is given
+    Given the Chef Server has cookbooks:
+      | bacon | 1.1.0 |
+      | bacon | 1.5.8 |
+    And the cookbook store has the cookbooks:
+      | bacon | 1.1.0 |
+    And I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook 'bacon', '~> 1.1.0'
+      """
+    And I write to "Berksfile.lock" with:
+      """
+      DEPENDENCIES
+        bacon (~> 1.1.0)
+
+      GRAPH
+        bacon (1.1.0)
+      """
+    When I successfully run `berks outdated --all`
+    Then the output should contain:
+      """
+      The following cookbooks have newer versions:
+        * bacon (1.1.0 => 1.5.8)
+      """
+
   Scenario: When the lockfile is not present
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -468,6 +468,10 @@ module Berkshelf
     # List of all the cookbooks which have a newer version found at a source
     # that satisfies the constraints of your dependencies.
     #
+    # @param [Boolean] include_non_satisfying
+    #   include cookbooks that would not satisfy the given constraints in the
+    #   +Berksfile+. Defaults to false.
+    #
     # @return [Hash]
     #   a hash of cached cookbooks and their latest version grouped by their
     #   remote API source. The hash will be empty if there are no newer
@@ -483,7 +487,7 @@ module Berkshelf
     #       }
     #     }
     #   }
-    def outdated(*names)
+    def outdated(*names, include_non_satisfying: false)
       validate_lockfile_present!
       validate_lockfile_trusted!
       validate_dependencies_installed!
@@ -494,7 +498,7 @@ module Berkshelf
           cookbooks = source.versions(name)
 
           latest = cookbooks.select do |cookbook|
-            dependency.version_constraint.satisfies?(cookbook.version) &&
+            (include_non_satisfying || dependency.version_constraint.satisfies?(cookbook.version)) &&
               Semverse::Version.coerce(cookbook.version) > dependency.locked_version
           end.sort_by { |cookbook| cookbook.version }.last
 

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -235,10 +235,15 @@ module Berkshelf
       type: :array,
       desc: "Only cookbooks that are in these groups.",
       aliases: "-o"
+    method_option :all,
+      type: :boolean,
+      desc: "Include cookbooks that don't satisfy the version constraints.",
+      aliases: "-a",
+      default: false
     desc "outdated [COOKBOOKS]", "List dependencies that have new versions available that satisfy their constraints"
     def outdated(*names)
       berksfile = Berksfile.from_options(options)
-      outdated  = berksfile.outdated(*names)
+      outdated  = berksfile.outdated(*names, include_non_satisfying: options[:all])
       Berkshelf.formatter.outdated(outdated)
     end
 


### PR DESCRIPTION
This makes it possible to run `berks outdated --all` to get a list of outdated dependencies, including those that wouldn't satisfy the version constraints set in `Berksfile`.

This would make it easier to maintain repositories with conservative dependency locking.

https://github.com/berkshelf/berkshelf/issues/1678