### PR TITLE
Allow relative urls in location_path for downloader

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -68,7 +68,11 @@ module Berkshelf
         if source.type == :artifactory
           options[:headers] = { "X-Jfrog-Art-Api" => source.options[:api_key] }
         end
-        CommunityREST.new(remote_cookbook.location_path, options).download(name, version)
+
+        # Allow Berkshelf install to function if a relative url exists in location_path
+        path = URI.parse(remote_cookbook.location_path).absolute? ? remote_cookbook.location_path : "#{source.uri_string}#{remote_cookbook.location_path}"
+
+        CommunityREST.new(path, options).download(name, version)
       when :chef_server
         tmp_dir      = Dir.mktmpdir
         unpack_dir   = Pathname.new(tmp_dir) + "#{name}-#{version}"

--- a/spec/unit/berkshelf/downloader_spec.rb
+++ b/spec/unit/berkshelf/downloader_spec.rb
@@ -59,6 +59,31 @@ module Berkshelf
         subject.try_download(source, name, version)
       end
 
+      context "supports location paths" do
+        before(:each) do
+          allow(source).to receive(:type) { :supermarket }
+          allow(source).to receive(:options) { { ssl: {} } }
+          allow(source).to receive(:uri_string).and_return("http://localhost:8081/repository/chef-proxy")
+          allow(remote_cookbook).to receive(:location_type) { :opscode }
+        end
+
+        let(:rest) { double("community-rest") }
+
+        it "that are relative and prepends the source URI for the download" do
+          allow(remote_cookbook).to receive(:location_path) { "/api/v1" }
+          expect(CommunityREST).to receive(:new).with("http://localhost:8081/repository/chef-proxy/api/v1", { ssl: {} }) { rest }
+          expect(rest).to receive(:download).with(name, version)
+          subject.try_download(source, name, version)
+        end
+
+        it "that are absolute and uses the given absolute URI" do
+          allow(remote_cookbook).to receive(:location_path) { "http://localhost:8081/repository/chef-proxy/api/v1" }
+          expect(CommunityREST).to receive(:new).with("http://localhost:8081/repository/chef-proxy/api/v1", { ssl: {} }) { rest }
+          expect(rest).to receive(:download).with(name, version)
+          subject.try_download(source, name, version)
+        end
+      end
+
       context "with an artifactory source" do
         it "supports the 'opscode' location type" do
           allow(source).to receive(:type) { :artifactory }


### PR DESCRIPTION
Hi there!

I'm working on a chef plugin for Nexus Repository, and I ran into some fun!

When using berkshelf to install, it initially hits /universe to get the chef dependency graph. This graph includes a bunch of absolute URLs, which makes for fun times when proxying a repository. I wrote a utility that sets all those URLs to relative, which would in theory work with a tool, and it did for knife (I don't think it uses universe), but berkshelf was not so happy. The reason we prefer relative URLs for Nexus Repo is because once we get into building a group type functionality (grouping multiple repositories under one accessible URL), it makes life a lot easier.

What I did in this PR was check to see if the location_path was set to relative, and if it is, I take the source.uri_string and append the two together, as the source.uri_string SHOULD be the location for Nexus Repo, etc... if your berksfile is configured correctly.

I am probably opening a can of worms with this PR, so feel free to let me know if this is a poorly thought out change.

A few tests appear to be failing but I believe they are unrelated to this change.