### PR TITLE
Handles relative URLs in community_rest.

### DIFF
--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -171,6 +171,8 @@ module Berkshelf
     #
     # @return [Tempfile]
     def stream(target)
+      target = relative_to_absolute_url(target)
+
       local = Tempfile.new("community-rest-stream")
       local.binmode
       Retryable.retryable(tries: retries, on: Berkshelf::APIClientError, sleep: retry_interval) do
@@ -178,6 +180,14 @@ module Berkshelf
       end
     ensure
       local.close(false) unless local.nil?
+    end
+
+    def relative_to_absolute_url(target)
+      if !URI.parse(target).absolute?
+        target = "#{api_uri.chomp("/api/v1")}#{target}"  
+      else 
+        target
+      end
     end
   end
 end


### PR DESCRIPTION
This lil ditty does something similar to what I did in #1799 , but inside of community_rest.rb, where it is not super stoked on relative URLs, as well.