### PR TITLE
Allow for retryable 3.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       mixlib-config (>= 2.2.5)
       mixlib-shellout (>= 2.0, < 4.0)
       octokit (~> 4.0)
-      retryable (~> 2.0)
+      retryable (>= 2.0, < 4.0)
       solve (~> 4.0)
       thor (>= 0.20)
 
@@ -204,7 +204,7 @@ GEM
     rainbow (3.0.0)
     rake (12.3.2)
     retriable (2.1.0)
-    retryable (2.0.4)
+    retryable (3.0.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,8 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "25"
+    - ruby_version: 24-x64
+    - ruby_version: 25-x64
 
 clone_folder: c:\projects\berkshelf
 clone_depth: 1

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-shellout",      ">= 2.0", "< 4.0"
   s.add_dependency "cleanroom",            "~> 1.0"
   s.add_dependency "minitar",              ">= 0.6"
-  s.add_dependency "retryable",            "~> 2.0"
+  s.add_dependency "retryable",            ">= 2.0", "< 4.0"
   s.add_dependency "solve",                "~> 4.0"
   s.add_dependency "thor",                 ">= 0.20"
   s.add_dependency "octokit",              "~> 4.0"


### PR DESCRIPTION
They did the major version bump to remove Ruby 1.8 support.

Signed-off-by: Tim Smith <tsmith@chef.io>