### PR TITLE
#1815 Fix gitlab using faraday.

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -1,6 +1,7 @@
 require "net/http"
 require "mixlib/archive"
 require "berkshelf/ssl_policies"
+require "faraday"
 
 module Berkshelf
   class Downloader


### PR DESCRIPTION
I am using berkshelf with gitlab.
But I got an error `NameError uninitialized constant Berkshelf::Downloader::Faraday` because gitlab can't use Faraday(#1815).
I solved by making it possible to load Faraday.