### PR TITLE
Catch http exceptions from upload

### DIFF
--- a/lib/berkshelf/uploader.rb
+++ b/lib/berkshelf/uploader.rb
@@ -84,6 +84,8 @@ module Berkshelf
               end
 
               Berkshelf.formatter.skipping(cookbook, connection)
+            rescue Net::HTTPClientException => e
+              puts e.response.body
             end
           ensure
             if compiled_metadata


### PR DESCRIPTION
### Description

This changes resolves long stack traces on http errors when using chef-guard:

```
> /opt/chef/embedded/bin/berks upload foobar
E, [2019-12-05T08:31:28.836260 #1726] ERROR -- : Net::HTTPServerException: 412 "Precondition Failed"
E, [2019-12-05T08:31:28.837087 #1726] ERROR -- : /opt/chef/embedded/lib/ruby/2.6.0/net/http/response.rb:122:in `error!'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.4.45/lib/chef/http.rb:152:in `request'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.4.45/lib/chef/http.rb:123:in `put'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.4.45/lib/chef/cookbook_uploader.rb:103:in `block in upload_cookbooks'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.4.45/lib/chef/cookbook_uploader.rb:97:in `each'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.4.45/lib/chef/cookbook_uploader.rb:97:in `upload_cookbooks'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/uploader.rb:79:in `block (2 levels) in upload'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/uploader.rb:61:in `map'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/uploader.rb:61:in `block in upload'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/ridley_compat.rb:56:in `new_client'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf.rb:172:in `ridley_connection'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/uploader.rb:55:in `upload'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/uploader.rb:42:in `run'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/berksfile.rb:580:in `upload'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/cli.rb:195:in `upload'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/cli.rb:47:in `dispatch'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/lib/berkshelf/cli.rb:23:in `execute!'
/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/berkshelf-7.0.8/bin/berks:5:in `<top (required)>'
/opt/chef/embedded/bin/berks:23:in `load'
/opt/chef/embedded/bin/berks:23:in `<main>'
There was an error connecting to the Chef Server
```

Versus:
```
> /opt/chef/embedded/bin/berks upload foobar

=== Cookbook Compare errors found ===
The following file(s) are changed:
 - metadata.rb

Make sure all your changes are merged into the central
repositories before trying to upload the cookbook again.

HINT: Also double check your line endings (CRLF vs LF)!
=====================================
```

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)