### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/berkshelf.rb
+++ b/lib/berkshelf.rb
@@ -23,7 +23,7 @@ JSON.create_id = nil
 
 require_relative "berkshelf/core_ext"
 require_relative "berkshelf/thor_ext"
-require "berkshelf/chef_config_compat"
+require_relative "berkshelf/chef_config_compat"
 
 module Berkshelf
   Encoding.default_external = Encoding::UTF_8

--- a/lib/berkshelf/api_client/chef_server_connection.rb
+++ b/lib/berkshelf/api_client/chef_server_connection.rb
@@ -1,4 +1,4 @@
-require "berkshelf/ridley_compat"
+require_relative "../ridley_compat"
 
 module Berkshelf
   module APIClient

--- a/lib/berkshelf/api_client/connection.rb
+++ b/lib/berkshelf/api_client/connection.rb
@@ -1,4 +1,4 @@
-require "berkshelf/ridley_compat"
+require_relative "../ridley_compat"
 
 module Berkshelf
   module APIClient

--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -1,6 +1,6 @@
 require "chef/cookbook/cookbook_version_loader"
 require "chef/cookbook/syntax_check"
-require "berkshelf/errors"
+require_relative "errors"
 require "chef/json_compat"
 
 module Berkshelf

--- a/lib/berkshelf/chef_repo_universe.rb
+++ b/lib/berkshelf/chef_repo_universe.rb
@@ -1,5 +1,5 @@
-require "berkshelf/api_client/remote_cookbook"
-require "berkshelf/cached_cookbook"
+require_relative "api_client/remote_cookbook"
+require_relative "cached_cookbook"
 
 module Berkshelf
   # Shim to look like a Berkshelf::APIClient but for a chef repo folder.

--- a/lib/berkshelf/cli.rb
+++ b/lib/berkshelf/cli.rb
@@ -1,4 +1,4 @@
-require "berkshelf"
+require_relative "../berkshelf"
 require_relative "config"
 require_relative "commands/shelf"
 

--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -1,6 +1,6 @@
 require "net/http"
 require "mixlib/archive"
-require "berkshelf/ssl_policies"
+require_relative "ssl_policies"
 require "faraday"
 
 module Berkshelf

--- a/lib/berkshelf/installer.rb
+++ b/lib/berkshelf/installer.rb
@@ -1,4 +1,4 @@
-require "berkshelf/api-client"
+require_relative "api-client"
 require "concurrent/executors"
 require "concurrent/future"
 

--- a/lib/berkshelf/mixin/git.rb
+++ b/lib/berkshelf/mixin/git.rb
@@ -1,4 +1,4 @@
-require "berkshelf/shell_out"
+require_relative "../shell_out"
 
 module Berkshelf
   module Mixin

--- a/lib/berkshelf/ridley_compat.rb
+++ b/lib/berkshelf/ridley_compat.rb
@@ -1,7 +1,7 @@
 require "chef/server_api"
 require "chef/http/simple_json"
 require "chef/http/simple"
-require "berkshelf/api_client/errors"
+require_relative "api_client/errors"
 require "chef/config"
 require "chef/cookbook_manifest"
 

--- a/lib/berkshelf/source.rb
+++ b/lib/berkshelf/source.rb
@@ -1,6 +1,6 @@
-require "berkshelf/api-client"
-require "berkshelf/chef_repo_universe"
-require "berkshelf/ssl_policies"
+require_relative "api-client"
+require_relative "chef_repo_universe"
+require_relative "ssl_policies"
 require "openssl"
 
 module Berkshelf

--- a/lib/berkshelf/thor.rb
+++ b/lib/berkshelf/thor.rb
@@ -1,1 +1,1 @@
-require "berkshelf/cli"
+require_relative "cli"

--- a/lib/berkshelf/visualizer.rb
+++ b/lib/berkshelf/visualizer.rb
@@ -1,6 +1,6 @@
 require "set"
 require "tempfile"
-require "berkshelf/shell_out"
+require_relative "shell_out"
 
 module Berkshelf
   class Visualizer


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>