### PR TITLE
Fixes berks verify path is broken

### DIFF
--- a/lib/berkshelf/cached_cookbook.rb
+++ b/lib/berkshelf/cached_cookbook.rb
@@ -151,7 +151,8 @@ module Berkshelf
     def validate
       raise IOError, "No Cookbook found at: #{path}" unless path.exist?
 
-      syntax_checker = Chef::Cookbook::SyntaxCheck.for_cookbook(cookbook_name, path)
+      syntax_checker = Chef::Cookbook::SyntaxCheck.new(path.to_path)
+
       unless syntax_checker.validate_ruby_files
         raise Berkshelf::Errors::CookbookSyntaxError, "Invalid ruby files in cookbook: #{cookbook_name} (#{version})."
       end


### PR DESCRIPTION

### Description
Method [SyntaxCheck.for_cookbook](https://github.com/chef/chef/blob/master/lib/chef/cookbook/syntax_check.rb#L89) expect the `cookbook_name` and `cookbook_path(either explicit or set by Chef::Config.cookbook_path)`but here it passes the exact cookbook dir.

if cookbook exact path is already known, instantiate object of `Chef::Cookbook::SyntaxCheck.new` directly.


### Issues Resolved

Fixes https://github.com/berkshelf/berkshelf/issues/1830
### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>