### PR TITLE
Ruby 2.7: double-splat to expand optional args

### DIFF
--- a/lib/berkshelf/community_rest.rb
+++ b/lib/berkshelf/community_rest.rb
@@ -75,7 +75,7 @@ module Berkshelf
       @retries = options.delete(:retries)
       @retry_interval = options.delete(:retry_interval)
 
-      @connection = Berkshelf::RidleyCompatJSON.new(options)
+      @connection = Berkshelf::RidleyCompatJSON.new(**options)
     end
 
     # Download and extract target cookbook archive to the local file system,

--- a/lib/berkshelf/core_ext/file_utils.rb
+++ b/lib/berkshelf/core_ext/file_utils.rb
@@ -14,10 +14,10 @@ module FileUtils
     # symlink on Linux
     # @see {FileUtils::mv}
     def mv(src, dest, options = {})
-      old_mv(src, dest, options)
+      old_mv(src, dest, **options)
     rescue Errno::EACCES, Errno::ENOENT
       options.delete(:force) if options.key?(:force)
-      FileUtils.cp_r(src, dest, options)
+      FileUtils.cp_r(src, dest, **options)
       FileUtils.rm_rf(src)
     end
   end

--- a/spec/unit/berkshelf/core_ext/file_utils_spec.rb
+++ b/spec/unit/berkshelf/core_ext/file_utils_spec.rb
@@ -7,12 +7,12 @@ describe FileUtils do
     let(:options) { {} }
 
     it "uses mv by default" do
-      expect(FileUtils).to receive(:old_mv).with(src, dest, options)
+      expect(FileUtils).to receive(:old_mv).with(src, dest, **options)
       FileUtils.mv(src, dest, options)
     end
 
     it "replaces mv with cp_r and rm_rf" do
-      expect(FileUtils).to receive(:cp_r).with(src, dest, options)
+      expect(FileUtils).to receive(:cp_r).with(src, dest, **options)
       expect(FileUtils).to receive(:rm_rf).with(src)
 
       FileUtils.mv(src, dest, options)


### PR DESCRIPTION
Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
Uses double-splat operator to expand optional arguments to functions.  This prevents ruby 2.7 warnings in the form `warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`


### Check List

- ~[ ] New functionality includes tests~
- [x] All tests pass
- ~[ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)~