### PR TITLE
Allow configuring default branch for git cookbook resolution

### DIFF
--- a/features/commands/install.feature
+++ b/features/commands/install.feature
@@ -200,6 +200,29 @@ Feature: berks install
       Using berkshelf-cookbook-fixture (1.0.0) from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
       """
 
+  Scenario: installing a demand from a Git location with git default_branch set in config.json
+    Given I have a Berksfile pointing at the local Berkshelf API with:
+      """
+      cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git"
+      """
+    And I have a Berkshelf config file containing:
+      """
+      {
+        "git": {
+          "default_branch": "branch1"
+        }
+      }
+      """
+    When I successfully run `berks install`
+    Then the cookbook store should have the git cookbooks:
+      | berkshelf-cookbook-fixture | 1.0.0 | 919afa0c402089df23ebdf36637f12271b8a96b4 |
+    And the output should contain:
+      """
+      Fetching 'berkshelf-cookbook-fixture' from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at branch1)
+      Fetching cookbook index from http://127.0.0.1:26310...
+      Using berkshelf-cookbook-fixture (1.0.0) from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at branch1)
+      """
+
   Scenario: installing a demand from a Git location that has already been installed
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """

--- a/lib/berkshelf/config.rb
+++ b/lib/berkshelf/config.rb
@@ -147,6 +147,9 @@ module Berkshelf
           default :gitlab, []
           # :git, :ssh, or :https
           default :github_protocol, :https
+          config_context :git do
+            default :default_branch, 'master' # for backwards compatibility
+          end
         end
       end
     end

--- a/lib/berkshelf/locations/git.rb
+++ b/lib/berkshelf/locations/git.rb
@@ -19,8 +19,11 @@ module Berkshelf
       @revision = options[:revision]
       @rel      = options[:rel]
 
+      config = Berkshelf.config.git.default_branch
+      puts "default_branch: #{config.inspect}"
+
       # The revision to parse
-      @rev_parse = options[:ref] || options[:branch] || options[:tag] || "master"
+      @rev_parse = options[:ref] || options[:branch] || options[:tag] || Berkshelf.config.git.default_branch
     end
 
     # @see BaseLoation#installed?


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

### Description
Recently there has been a mass movement to retire use of the
word `master` in git repositories.  While not everyone has
updated their repos, continuing to hard-code `master` as the
default branch can complicate dependency resolution.

Allow overriding the default branch for use in environments
where most or all git repos have been updated to use a different
default branch.

Continue falling back to default of `master` (when this config
value is not specified) for backwards compatibility.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)

Co-authored-by: Chris Usick <christopher.usick@gmail.com>
