### PR TITLE
Bump mixlib-archive for Ruby 3.0 fix 

### DIFF
--- a/.github/workflows/testberks.yml
+++ b/.github/workflows/testberks.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron:  '21 3 * * *'
 
 jobs:
   test:
@@ -17,6 +19,7 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         ruby: [2.6, 2.7, 3.0, head ]
+        what: [spec, features]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
     - run: git config --global user.email "ci@berkshelf.com"
@@ -38,7 +41,7 @@ jobs:
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
-    - run: bundle exec rake
+    - run: bundle exec rake ${{ matrix.what }}
   style:
     runs-on: ubuntu-latest
     steps:

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency "solve",                "~> 4.0"
   s.add_dependency "thor",                 ">= 0.20"
   s.add_dependency "octokit",              "~> 4.0"
-  s.add_dependency "mixlib-archive",       ">= 0.4", "< 2.0"
+  s.add_dependency "mixlib-archive",       ">= 1.1.4", "< 2.0" # needed for ruby 3.0 / Dir.chdir removal
   s.add_dependency "concurrent-ruby",      "~> 1.0"
   s.add_dependency "chef",                 ">= 15.7.32" # needed for --skip-syntax-check
   s.add_dependency "chef-config"

--- a/features/step_definitions/utility_steps.rb
+++ b/features/step_definitions/utility_steps.rb
@@ -9,3 +9,9 @@ Then /the output from \`(.+)\` should be the same as \`(.+)\`/ do |actual, expec
   expected_output = last_command_started.stdout
   expect(actual_output).to eql(expected_output)
 end
+
+When(/^I run `(.*?)`(?: for up to ([\d.]+) seconds)? printing output$/) do |cmd, secs|
+  cmd = sanitize_text(cmd)
+  cmd = run_command(cmd, :fail_on_error => true, :exit_timeout => secs && secs.to_f)
+  puts cmd.output
+end

--- a/features/step_definitions/utility_steps.rb
+++ b/features/step_definitions/utility_steps.rb
@@ -12,6 +12,6 @@ end
 
 When(/^I run `(.*?)`(?: for up to ([\d.]+) seconds)? printing output$/) do |cmd, secs|
   cmd = sanitize_text(cmd)
-  cmd = run_command(cmd, :fail_on_error => true, :exit_timeout => secs && secs.to_f)
+  cmd = run_command(cmd, fail_on_error: true, exit_timeout: secs && secs.to_f)
   puts cmd.output
 end


### PR DESCRIPTION
This should get berkshelf green for ruby-3.0

Also breaks out specs+cukes into different runs so its easier to see
what is exploding across tests

Adds a utility helper for getting debug output from berkshelf commands
run inside of cukes