### PR TITLE
Remove the use of Dir.chdir in the code

### DIFF
--- a/lib/berkshelf/cookbook_store.rb
+++ b/lib/berkshelf/cookbook_store.rb
@@ -49,9 +49,7 @@ module Berkshelf
 
     # Destroy the contents of the initialized storage path.
     def clean!
-      Dir.chdir(storage_path) do
-        FileUtils.rm_rf(Dir.glob("*"))
-      end
+      FileUtils.rm_rf(Dir.glob("#{storage_path}/*"))
     end
 
     # Import a cookbook found on the local filesystem into this instance of the cookbook store.

--- a/lib/berkshelf/mixin/git.rb
+++ b/lib/berkshelf/mixin/git.rb
@@ -13,12 +13,12 @@ module Berkshelf
       #
       # @raise [String]
       #   the +$stdout+ from the command
-      def git(command, error = true)
+      def git(command, error = true, **kwargs)
         unless Berkshelf.which("git") || Berkshelf.which("git.exe") || Berkshelf.which("git.bat")
           raise GitNotInstalled.new
         end
 
-        response = shell_out(%{git #{command}})
+        response = shell_out(%{git #{command}}, **kwargs)
 
         if response.error?
           raise GitCommandError.new(command, cache_path, response.stderr)

--- a/lib/berkshelf/packager.rb
+++ b/lib/berkshelf/packager.rb
@@ -40,10 +40,8 @@ module Berkshelf
     # @return [String]
     #   path to the generated archive
     def run(source)
-      Dir.chdir(source.to_s) do |dir|
-        tgz = Zlib::GzipWriter.new(File.open(out_file, "wb"))
-        Archive::Tar::Minitar.pack(Dir.glob("*"), tgz)
-      end
+      tgz = Zlib::GzipWriter.new(File.open(out_file, "wb"))
+      Archive::Tar::Minitar.pack(Dir.glob("#{source.to_s}/*"), tgz)
 
       out_file
     rescue SystemCallError => ex

--- a/lib/berkshelf/packager.rb
+++ b/lib/berkshelf/packager.rb
@@ -41,7 +41,7 @@ module Berkshelf
     #   path to the generated archive
     def run(source)
       tgz = Zlib::GzipWriter.new(File.open(out_file, "wb"))
-      Archive::Tar::Minitar.pack(Dir.glob("#{source.to_s}/*"), tgz)
+      Archive::Tar::Minitar.pack(Dir.glob("#{source}/*"), tgz)
 
       out_file
     rescue SystemCallError => ex

--- a/lib/berkshelf/shell_out.rb
+++ b/lib/berkshelf/shell_out.rb
@@ -8,8 +8,9 @@ module Berkshelf
       cmd
     end
 
-    def shell_out!(*args)
-      cmd = shell_out(*args)
+    def shell_out!(*args, **options)
+      cmd = Mixlib::ShellOut.new(*args, **options)
+      cmd.run_command
       cmd.error!
       cmd
     end

--- a/lib/berkshelf/ssl_policies.rb
+++ b/lib/berkshelf/ssl_policies.rb
@@ -29,11 +29,9 @@ module Berkshelf
     end
 
     def set_custom_certs
-      Dir.chdir(trusted_certs_dir) do
-        ::Dir.glob("{*.crt,*.pem}").each do |cert|
-          cert = OpenSSL::X509::Certificate.new(IO.read(cert))
-          add_trusted_cert(cert)
-        end
+      ::Dir.glob("#{trusted_certs_dir}/{*.crt,*.pem}").each do |cert|
+        cert = OpenSSL::X509::Certificate.new(IO.read(cert))
+        add_trusted_cert(cert)
       end
     end
   end

--- a/lib/berkshelf/validator.rb
+++ b/lib/berkshelf/validator.rb
@@ -22,15 +22,9 @@ module Berkshelf
       #  the Cookbook(s) to validate
       def validate_files(cookbooks)
         Array(cookbooks).each do |cookbook|
-          path = cookbook.path.to_s
+          base, name = Pathname.new(cookbook.path.to_s).split
 
-          files = Dir.chdir(path) do
-            Dir.glob(File.join("**", "*.rb")).select do |f|
-              f = File.join(path, f)
-              parent = Pathname.new(path).dirname.to_s
-              f.gsub(parent, "") =~ /[[:space:]]/
-            end
-          end
+          files = Dir.glob("#{name}/**/*.rb", base: base.to_s).select { |f| f =~ /[[:space:]]/ }
 
           raise InvalidCookbookFiles.new(cookbook, files) unless files.empty?
         end

--- a/spec/unit/berkshelf/locations/git_spec.rb
+++ b/spec/unit/berkshelf/locations/git_spec.rb
@@ -104,11 +104,10 @@ module Berkshelf
 
       context "when the repository is cached" do
         it "pulls a new version" do
-          allow(Dir).to receive(:chdir) { |args, &b| b.call } # Force eval the chdir block
-
+          cache_path = subject.send(:cache_path)
           allow(subject).to receive(:cached?).and_return(true)
           expect(subject).to receive(:git).with(
-            'fetch --force --tags https://repo.com "refs/heads/*:refs/heads/*"'
+            'fetch --force --tags https://repo.com "refs/heads/*:refs/heads/*"', cwd: cache_path.to_s
           )
           subject.install
         end
@@ -116,8 +115,6 @@ module Berkshelf
 
       context "when the revision is not cached" do
         it "clones the repository" do
-          allow(Dir).to receive(:chdir) { |args, &b| b.call } # Force eval the chdir block
-
           cache_path = subject.send(:cache_path)
           allow(subject).to receive(:cached?).and_return(false)
           expect(subject).to receive(:git).with(

--- a/spec/unit/berkshelf/ssl_policies_spec.rb
+++ b/spec/unit/berkshelf/ssl_policies_spec.rb
@@ -73,7 +73,6 @@ describe Berkshelf::SSLPolicy do
         before do
           allow(chef_config).to receive_messages(trusted_certs_dir: self_signed_crt_path_windows_backslashes)
           allow(File).to receive(:exist?).with(self_signed_crt_path_windows_forwardslashes).and_return(true)
-          allow(Dir).to receive(:chdir).with(self_signed_crt_path_windows_forwardslashes)
         end
 
         it "replaces the backslashes in trusted_certs_dir from Berkshelf config with forwardslashes" do

--- a/spec/unit/berkshelf/validator_spec.rb
+++ b/spec/unit/berkshelf/validator_spec.rb
@@ -4,10 +4,6 @@ describe Berkshelf::Validator do
   describe "#validate_files" do
     let(:cookbook) { double("cookbook", cookbook_name: "cookbook", path: "path") }
 
-    before do
-      allow(Dir).to receive(:chdir) { |&block| block.call }
-    end
-
     it "raises an error when the cookbook has spaces in the files" do
       allow(Dir).to receive(:glob).and_return(["/there are/spaces/in this/recipes/default.rb"])
       expect do
@@ -17,15 +13,6 @@ describe Berkshelf::Validator do
 
     it "does not raise an error when the cookbook is valid" do
       allow(Dir).to receive(:glob).and_return(["/there-are/no-spaces/in-this/recipes/default.rb"])
-      expect do
-        subject.validate_files(cookbook)
-      end.to_not raise_error
-    end
-
-    it "does not raise an exception with spaces in the path" do
-      allow(Dir).to receive(:glob).and_return(["/there are/spaces/in this/recipes/default.rb"])
-      allow_any_instance_of(Pathname).to receive(:dirname).and_return("/there are/spaces/in this")
-
       expect do
         subject.validate_files(cookbook)
       end.to_not raise_error


### PR DESCRIPTION
The use of Dir.chdir is bad because it is global state and is not
threadsafe.  In ruby-3.0 Dir.chdir use from another thread from
within a Dir.chdir is now a hard error.  It was unclear exactly
which Dir.chdir was problematic, so they were all removed.

This may also clean up some issues with test-kitchen where Berkshelf
may be run in threads and not be threadsafe.

(Test-kitchen should still fork off berkshelf and stop using it in
threads)