### PR TITLE
Add support for ssh_agent_signing

### DIFF
--- a/lib/berkshelf/ridley_compat.rb
+++ b/lib/berkshelf/ridley_compat.rb
@@ -15,6 +15,7 @@ module Berkshelf
       chef_opts[:headers]              = opts[:headers] if opts[:headers]
       chef_opts[:client_name]          = opts[:client_name] if opts[:client_name]
       chef_opts[:signing_key_filename] = opts[:client_key] if opts[:client_key]
+      chef_opts[:ssh_agent_signing]    = Chef::Config[:ssh_agent_signing] if Chef::Config[:ssh_agent_signing]
       chef_opts[:verify_api_cert]      = opts[:ssl][:verify] || opts[:ssl][:verify].nil?
       chef_opts[:ssl_verify_mode]      = chef_opts[:verify_api_cert] ? :verify_peer : :verify_none
       chef_opts[:ssl_ca_path]          = opts[:ssl][:ca_path] if opts[:ssl][:ca_path]


### PR DESCRIPTION
Enable support for ssh agent support for user keys with [ssh_agent_signing](https://github.com/chef/chef/blob/master/RELEASE_NOTES.md#ssh-agent-support-for-user-keys). 

### Description
This allows users to encrypt their chef key and make it available to berkshelf with an ssh-agent. This capability was added to the rest of the chef tools back in [14.2](https://github.com/chef/chef/blob/master/RELEASE_NOTES.md#whats-new-in-142). I'm not sure this is the proper place to add this option but it works.

### Issues Resolved
This resolves #1862 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)