### PR TITLE
Workaround issue which impacts running ChefSpec on Github Actions

### DIFF
--- a/lib/berkshelf/file_syncer.rb
+++ b/lib/berkshelf/file_syncer.rb
@@ -89,6 +89,9 @@ module Berkshelf
           destination = File.expand_path(destination)
           FileUtils.ln_sf(target, "#{destination}/#{relative_path}")
         when :file
+          # TODO: Workaround issue related to [1] which impacts running ChefSpec on Github Actions
+          # [1] https://github.com/docker/for-linux/issues/1015
+          FileUtils.touch(source_file)
           FileUtils.cp(source_file, "#{destination}/#{relative_path}")
         else
           type = File.ftype(source_file)


### PR DESCRIPTION
We started noticing issues in Sous Chefs with ChefSpec runs would fail when running on Github Actions. After some investigation (Thanks @bmhughes), it seems to be related to this upstream Docker issue [1].

This has been confirmed as a workaround but should be reverted once upstream has a proper fix.

[1] https://github.com/docker/for-linux/issues/1015

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Please describe what this change achieves -->

### Issues Resolved
<!--- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
