### PR TITLE
Fix directory structure of berkshelf package

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -595,10 +595,10 @@ module Berkshelf
       packager = Packager.new(path)
       packager.validate!
 
-      outdir = Dir.mktmpdir do |temp_dir|
-        Berkshelf.ui.mute { vendor(File.join(temp_dir, "cookbooks")) }
-        packager.run(temp_dir)
-      end
+      temp_dir = path.split('/')[-1][0...-7]
+      Berkshelf.ui.mute { vendor(File.join(temp_dir, "cookbooks")) }
+      outdir = packager.run(temp_dir)
+      FileUtils.rm_rf( temp_dir ) if File.exist?(temp_dir)
 
       Berkshelf.formatter.package(outdir)
       outdir


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

Fix directory structure of berkshelf package when `berks package` command executes.

### Description
<!--- Please describe what this change achieves -->

In present code 

`berks package cookbook.tar.gz` command creates a long weird directory structure depending on OS  

**Example** 

 - 1000/1000 769 2021-11-16 16:23 /tmp/d20211116-1057094-n6n53k/cookbooks/
 - var/folders/64/1khgsggn12j22p5p2gxsw93hrh6_1z/T/d20211128-9398-1viwnaw/cookbooks/

**After fix**

`berks package cookbook_java.tar.gz` command creates a directory structure like this
- cookbook_java/cookbooks/


### Issues Resolved
<!--- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

- https://github.com/chef/customer-bugs/issues/535

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)