### PR TITLE
Fix more ruby3 splatargs issues

### DIFF
--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -156,7 +156,7 @@ module Berkshelf
         options[:group] += @active_group
       end
 
-      add_dependency(name, constraint, options)
+      add_dependency(name, constraint, **options)
     end
     expose :cookbook
 


### PR DESCRIPTION
For some reason this isn't a runtime error but it has only
been exposed by recent changes to rspec

This is actively causing test failures on https://github.com/chef/chef on every PR right now