### PR TITLE
Update insecure `git://` references with `https://`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Install the latest version of [Bundler](http://gembundler.com)
 
 Clone the project
 
-    $ git clone git://github.com/berkshelf/berkshelf.git
+    $ git clone https://github.com/berkshelf/berkshelf.git
 
 and run:
 

--- a/features/commands/install.feature
+++ b/features/commands/install.feature
@@ -188,29 +188,29 @@ Feature: berks install
   Scenario: installing a demand from a Git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 1.0.0 | a97b9447cbd41a5fe58eee2026e48ccb503bd3bc |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (1.0.0) from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
       """
 
   Scenario: installing a demand from a Git location that has already been installed
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git"
       """
     And the cookbook store has the git cookbooks:
       | berkshelf-cookbook-fixture | 1.0.0 | a97b9447cbd41a5fe58eee2026e48ccb503bd3bc |
     When I successfully run `berks install`
     Then the output should contain:
       """
-      Using berkshelf-cookbook-fixture (1.0.0) from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
       """
 
   Scenario: installing a Berksfile that contains a Git location with a rel
@@ -235,7 +235,7 @@ Feature: berks install
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
       cookbook 'berkshelf-cookbook-fixture',
-        git: 'git://github.com/RiotGames/berkshelf-cookbook-fixture.git',
+        git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git',
         tag: 'v0.2.0'
       """
     When I successfully run `berks install`
@@ -247,46 +247,46 @@ Feature: berks install
   Scenario: installing a Berksfile that contains a Git location with a tag
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
       """
 
   Scenario: installing a Berksfile that contains a Git location with a ref
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git", ref: "70a527e17d91f01f031204562460ad1c17f972ee"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", ref: "70a527e17d91f01f031204562460ad1c17f972ee"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
       """
 
   Scenario: installing a Berksfile that contains a Git location with an abbreviated ref
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git", ref: "70a527e"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", ref: "70a527e"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
       """
 
   Scenario: installing a Berksfile that contains a GitHub location
@@ -445,12 +445,12 @@ Feature: berks install
   Scenario: when a Git demand points to a branch that does not satisfy the version constraint
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", "1.0.0", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", "1.0.0", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
       """
     When I run `berks install`
     Then the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
       The cookbook downloaded for berkshelf-cookbook-fixture (= 1.0.0) did not satisfy the constraint.
       """
     And the exit status should be "CookbookValidationFailure"
@@ -458,23 +458,23 @@ Feature: berks install
   Scenario: when a Git demand is defined and a cookbook of the same name and version is already in the cookbook store
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "git://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v1.0.0"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v1.0.0"
       """
     And the cookbook store has the cookbooks:
       | berkshelf-cookbook-fixture | 1.0.0 |
     When I successfully run `berks install`
     Then the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v1.0.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v1.0.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (1.0.0) from git://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v1.0.0)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v1.0.0)
       """
 
   Scenario: with a git error during download
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
       cookbook 'berkshelf-cookbook-fixture', '1.0.0'
-      cookbook "doesntexist", git: "git://github.com/asdjhfkljashflkjashfakljsf"
+      cookbook "doesntexist", git: "https://github.com/asdjhfkljashflkjashfakljsf"
       """
     When I run `berks install`
     Then the exit status should be "GitError"

--- a/features/commands/update.feature
+++ b/features/commands/update.feature
@@ -96,13 +96,13 @@ Feature: berks update
   Scenario: With a git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'git://github.com/RiotGames/berkshelf-cookbook-fixture'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture'
       """
     And I write to "Berksfile.lock" with:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: git://github.com/RiotGames/berkshelf-cookbook-fixture
+          git: https://github.com/RiotGames/berkshelf-cookbook-fixture
           revision: 70a527e17d91f01f031204562460ad1c17f972ee
 
       GRAPH
@@ -114,7 +114,7 @@ Feature: berks update
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: git://github.com/RiotGames/berkshelf-cookbook-fixture
+          git: https://github.com/RiotGames/berkshelf-cookbook-fixture
           revision: a97b9447cbd41a5fe58eee2026e48ccb503bd3bc
 
       GRAPH

--- a/features/lockfile.feature
+++ b/features/lockfile.feature
@@ -169,14 +169,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'git://github.com/RiotGames/berkshelf-cookbook-fixture.git', ref: '919afa0c4'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git', ref: '919afa0c4'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: git://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
           revision: 919afa0c402089df23ebdf36637f12271b8a96b4
           ref: 919afa0
 
@@ -187,14 +187,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a git location and a branch
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'git://github.com/RiotGames/berkshelf-cookbook-fixture.git', branch: 'master'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git', branch: 'master'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: git://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
           revision: a97b9447cbd41a5fe58eee2026e48ccb503bd3bc
           branch: master
 
@@ -205,14 +205,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a git location and a tag
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'git://github.com/RiotGames/berkshelf-cookbook-fixture.git', tag: 'v0.2.0'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git', tag: 'v0.2.0'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: git://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
           revision: 70a527e17d91f01f031204562460ad1c17f972ee
           tag: v0.2.0
 

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -118,7 +118,7 @@ module Berkshelf
     #   cookbook 'artifact', path: '/Users/reset/code/artifact'
     #
     # @example a cookbook dependency that will be retrieved from a Git server
-    #   cookbook 'artifact', git: 'git://github.com/RiotGames/artifact-cookbook.git'
+    #   cookbook 'artifact', git: 'https://github.com/RiotGames/artifact-cookbook.git'
     #
     # @overload cookbook(name, version_constraint, options = {})
     #   @param [#to_s] name

--- a/lib/berkshelf/location.rb
+++ b/lib/berkshelf/location.rb
@@ -9,7 +9,7 @@ module Berkshelf
       # is returned.
       #
       # @example Create a git location
-      #   Location.init(dependency, git: 'git://github.com/berkshelf/berkshelf.git')
+      #   Location.init(dependency, git: 'https://github.com/berkshelf/berkshelf.git')
       #
       # @example Create a GitHub location
       #   Location.init(dependency, github: 'berkshelf/berkshelf')

--- a/lib/berkshelf/locations/github.rb
+++ b/lib/berkshelf/locations/github.rb
@@ -9,7 +9,7 @@ module Berkshelf
       when :https
         options[:git] = "https://#{HOST}/#{options.delete(:github)}.git"
       when :git
-        options[:git] = "git://#{HOST}/#{options.delete(:github)}.git"
+        options[:git] = "https://#{HOST}/#{options.delete(:github)}.git"
       else
         # if some bizarre value is provided, treat it as :https
         options[:git] = "https://#{HOST}/#{options.delete(:github)}.git"

--- a/spec/unit/berkshelf/dependency_spec.rb
+++ b/spec/unit/berkshelf/dependency_spec.rb
@@ -35,7 +35,7 @@ describe Berkshelf::Dependency do
       end
 
       context "given a location key :git" do
-        let(:url) { "git://url_to_git" }
+        let(:url) { "https://url_to_git" }
         let(:source) { described_class.new(berksfile, cookbook_name, git: url) }
 
         it "initializes a GitLocation for location" do

--- a/spec/unit/berkshelf/location_spec.rb
+++ b/spec/unit/berkshelf/location_spec.rb
@@ -11,7 +11,7 @@ module Berkshelf
       end
 
       it "finds a :git location by key" do
-        instance = described_class.init(dependency, git: "git://foo.com/meats/bacon.git")
+        instance = described_class.init(dependency, git: "https://foo.com/meats/bacon.git")
         expect(instance).to be_a(GitLocation)
       end
 


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

### Description
Github no longer supports the insecure `git:` protocol. All references are updated to `https:` according to this [blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git)

### Issues Resolved
Fixes - https://github.com/chef/chef-workstation/issues/2649

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)