### PR TITLE
Berks package  corrupt archive fixed with using relative path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - run: git config --global user.name "Berkshelf"
     - run: |
          if [ "$RUNNER_OS" == "Linux" ]; then
-           sudo apt-get install graphviz libarchive-dev
+           sudo apt-get update && sudo apt-get install graphviz libarchive-dev
          elif [ "$RUNNER_OS" == "Windows" ]; then
            choco install graphviz
          elif [ "$RUNNER_OS" == "macOS" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        ruby: [2.6, 2.7, 3.0 ]
+        ruby: [2.7, 3.0, 3.1]
     steps:
     - run: git config --global user.email "ci@berkshelf.com"
     - run: git config --global user.name "Berkshelf"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
         os: [ubuntu, macos, windows]
         ruby: [2.7, 3.0, 3.1]
     steps:
-    - run: git config --global user.email "ci@berkshelf.com"
-    - run: git config --global user.name "Berkshelf"
     - run: |
          if [ "$RUNNER_OS" == "Linux" ]; then
            sudo apt-get update && sudo apt-get install graphviz libarchive-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
+## [8.0.1](https://github.com/chef/berkshelf/releases/tag/v8.0.1) (2022-05-19)
+- Updated the gem specifications to point to the forked repo.
 
-## [8.0.0](https://github.com/berkshelf/berkshelf/tree/8.0.0) (2022-05-29)
+## [8.0.0](https://github.com/chef/berkshelf/releases/tag/v8.0.0) (2022-04-29)
 - Added support for Ruby 3.1 and ended support for Ruby 2.6
 - Refer fork in Chef instead of repo in RiotGames
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [8.0.0](https://github.com/berkshelf/berkshelf/tree/8.0.0) (2022-05-29)
+- Added support for Ruby 3.1 and ended support for Ruby 2.6
+- Refer fork in Chef instead of repo in RiotGames
+
 ## [7.2.2](https://github.com/berkshelf/berkshelf/tree/7.2.2) (2021-06-16)
 
 - Fix Ruby 3.0 support with Berkshelf::APIClient::ChefServerConnection

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -25,8 +25,13 @@ Gem::Specification.new do |s|
   s.name                      = "berkshelf"
   s.require_paths             = ["lib"]
   s.version                   = Berkshelf::VERSION
-  s.required_ruby_version     = ">= 2.4.0"
+  s.required_ruby_version     = ">= 2.7.0"
   s.required_rubygems_version = ">= 2.0.0"
+  s.metadata                  = {
+    "bug_tracker_uri" => "https://github.com/chef/berkshelf/issues",
+    "source_code_uri" => "https://github.com/chef/berkshelf",
+    "changelog_uri"   => "https://github.com/chef/berkshelf/blob/main/CHANGELOG.md"
+  }
 
   s.add_dependency "mixlib-shellout",      ">= 2.0", "< 4.0"
   s.add_dependency "cleanroom",            "~> 1.0"

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.metadata                  = {
     "bug_tracker_uri" => "https://github.com/chef/berkshelf/issues",
     "source_code_uri" => "https://github.com/chef/berkshelf",
-    "changelog_uri"   => "https://github.com/chef/berkshelf/blob/main/CHANGELOG.md"
+    "changelog_uri"   => "https://github.com/chef/berkshelf/blob/main/CHANGELOG.md",
   }
 
   s.add_dependency "mixlib-shellout",      ">= 2.0", "< 4.0"

--- a/features/commands/install.feature
+++ b/features/commands/install.feature
@@ -60,7 +60,7 @@ Feature: berks install
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
       cookbook 'berkshelf-cookbook-fixture',
-        github: 'RiotGames/berkshelf-cookbook-fixture',
+        github: 'chef/berkshelf-cookbook-fixture',
         branch: 'deps'
       """
     And the cookbook store contains a cookbook "berkshelf" "1.0.0" with dependencies:
@@ -188,36 +188,36 @@ Feature: berks install
   Scenario: installing a demand from a Git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 1.0.0 | a97b9447cbd41a5fe58eee2026e48ccb503bd3bc |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at master)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at master)
       """
 
   Scenario: installing a demand from a Git location that has already been installed
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git"
       """
     And the cookbook store has the git cookbooks:
       | berkshelf-cookbook-fixture | 1.0.0 | a97b9447cbd41a5fe58eee2026e48ccb503bd3bc |
     When I successfully run `berks install`
     Then the output should contain:
       """
-      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at master)
       """
 
   Scenario: installing a Berksfile that contains a Git location with a rel
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
       cookbook 'berkshelf-cookbook-fixture',
-        github: 'RiotGames/berkshelf-cookbook-fixture',
+        github: 'chef/berkshelf-cookbook-fixture',
         branch: 'rel',
         rel:    'cookbooks/berkshelf-cookbook-fixture'
       """
@@ -226,16 +226,16 @@ Feature: berks install
       | berkshelf-cookbook-fixture | 1.0.0 | 93f5768b7d14df45e10d16c8bf6fe98ba3ff809a |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at rel/cookbooks/berkshelf-cookbook-fixture)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at rel/cookbooks/berkshelf-cookbook-fixture)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at rel/cookbooks/berkshelf-cookbook-fixture)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at rel/cookbooks/berkshelf-cookbook-fixture)
       """
 
   Scenario: installing a Berksfile that contains a Git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
       cookbook 'berkshelf-cookbook-fixture',
-        git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git',
+        git: 'https://github.com/chef/berkshelf-cookbook-fixture.git',
         tag: 'v0.2.0'
       """
     When I successfully run `berks install`
@@ -247,76 +247,76 @@ Feature: berks install
   Scenario: installing a Berksfile that contains a Git location with a tag
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       """
 
   Scenario: installing a Berksfile that contains a Git location with a ref
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", ref: "70a527e17d91f01f031204562460ad1c17f972ee"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", ref: "70a527e17d91f01f031204562460ad1c17f972ee"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at 70a527e)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at 70a527e)
       """
 
   Scenario: installing a Berksfile that contains a Git location with an abbreviated ref
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", ref: "70a527e"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", ref: "70a527e"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at 70a527e)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at 70a527e)
       """
 
   Scenario: installing a Berksfile that contains a GitHub location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", github: "RiotGames/berkshelf-cookbook-fixture", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", github: "chef/berkshelf-cookbook-fixture", tag: "v0.2.0"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       """
 
   Scenario: installing a Berksfile that contains a GitHub location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", github: "RiotGames/berkshelf-cookbook-fixture", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", github: "chef/berkshelf-cookbook-fixture", tag: "v0.2.0"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       """
 
   Scenario: running install when current project is a cookbook and the 'metadata' is specified
@@ -445,12 +445,12 @@ Feature: berks install
   Scenario: when a Git demand points to a branch that does not satisfy the version constraint
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", "1.0.0", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", "1.0.0", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
       """
     When I run `berks install`
     Then the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       The cookbook downloaded for berkshelf-cookbook-fixture (= 1.0.0) did not satisfy the constraint.
       """
     And the exit status should be "CookbookValidationFailure"
@@ -458,16 +458,16 @@ Feature: berks install
   Scenario: when a Git demand is defined and a cookbook of the same name and version is already in the cookbook store
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v1.0.0"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", tag: "v1.0.0"
       """
     And the cookbook store has the cookbooks:
       | berkshelf-cookbook-fixture | 1.0.0 |
     When I successfully run `berks install`
     Then the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v1.0.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v1.0.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v1.0.0)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at v1.0.0)
       """
 
   Scenario: with a git error during download

--- a/features/commands/package.feature
+++ b/features/commands/package.feature
@@ -15,3 +15,20 @@ Feature: berks package
       """
       Cookbook(s) packaged to
       """
+    And the archive "my-cookbooks.tar.gz" should contain:
+      """
+      cookbooks
+      cookbooks/fake
+      cookbooks/fake/attributes
+      cookbooks/fake/attributes/default.rb
+      cookbooks/fake/files
+      cookbooks/fake/files/default
+      cookbooks/fake/files/default/file.h
+      cookbooks/fake/metadata.json
+      cookbooks/fake/metadata.rb
+      cookbooks/fake/recipes
+      cookbooks/fake/recipes/default.rb
+      cookbooks/fake/templates
+      cookbooks/fake/templates/default
+      cookbooks/fake/templates/default/template.erb
+      """

--- a/features/commands/update.feature
+++ b/features/commands/update.feature
@@ -96,13 +96,13 @@ Feature: berks update
   Scenario: With a git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/chef/berkshelf-cookbook-fixture'
       """
     And I write to "Berksfile.lock" with:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture
+          git: https://github.com/chef/berkshelf-cookbook-fixture
           revision: 70a527e17d91f01f031204562460ad1c17f972ee
 
       GRAPH
@@ -114,7 +114,7 @@ Feature: berks update
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture
+          git: https://github.com/chef/berkshelf-cookbook-fixture
           revision: a97b9447cbd41a5fe58eee2026e48ccb503bd3bc
 
       GRAPH

--- a/features/json_formatter.feature
+++ b/features/json_formatter.feature
@@ -110,7 +110,7 @@ Feature: --format json
           {
             "name": "example_cookbook",
             "version": "0.5.0",
-            "uploaded_to": "http://localhost:26310"
+            "uploaded_to": "http://127.0.0.1:26310"
           }
         ],
         "errors": [],

--- a/features/lockfile.feature
+++ b/features/lockfile.feature
@@ -169,14 +169,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git', ref: '919afa0c4'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/chef/berkshelf-cookbook-fixture.git', ref: '919afa0c4'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: 919afa0c402089df23ebdf36637f12271b8a96b4
           ref: 919afa0
 
@@ -187,14 +187,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a git location and a branch
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git', branch: 'master'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/chef/berkshelf-cookbook-fixture.git', branch: 'master'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: a97b9447cbd41a5fe58eee2026e48ccb503bd3bc
           branch: master
 
@@ -205,14 +205,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a git location and a tag
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git', tag: 'v0.2.0'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/chef/berkshelf-cookbook-fixture.git', tag: 'v0.2.0'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: 70a527e17d91f01f031204562460ad1c17f972ee
           tag: v0.2.0
 
@@ -223,14 +223,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a GitHub location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', github: 'RiotGames/berkshelf-cookbook-fixture', ref: '919afa0c4'
+      cookbook 'berkshelf-cookbook-fixture', github: 'chef/berkshelf-cookbook-fixture', ref: '919afa0c4'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: 919afa0c402089df23ebdf36637f12271b8a96b4
           ref: 919afa0
 
@@ -241,14 +241,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock when a git location with :rel
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', github: 'RiotGames/berkshelf-cookbook-fixture', branch: 'rel', rel: 'cookbooks/berkshelf-cookbook-fixture'
+      cookbook 'berkshelf-cookbook-fixture', github: 'chef/berkshelf-cookbook-fixture', branch: 'rel', rel: 'cookbooks/berkshelf-cookbook-fixture'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: 93f5768b7d14df45e10d16c8bf6fe98ba3ff809a
           branch: rel
           rel: cookbooks/berkshelf-cookbook-fixture

--- a/features/step_definitions/utility_steps.rb
+++ b/features/step_definitions/utility_steps.rb
@@ -2,6 +2,13 @@ Given /^skip\s+"([^\"]+)"$/ do |msg|
   skip
 end
 
+Then("the archive {string} should contain:") do |path, expected_contents|
+  actual_contents = Zlib::GzipReader.open(expand_path(path)) do |gz|
+    Archive::Tar::Minitar::Input.each_entry(gz).map(&:full_name).join("\n")
+  end
+  expect(actual_contents).to eql(expected_contents)
+end
+
 Then /the output from \`(.+)\` should be the same as \`(.+)\`/ do |actual, expected|
   run(actual)
   actual_output = last_command_started.stdout

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -118,7 +118,7 @@ module Berkshelf
     #   cookbook 'artifact', path: '/Users/reset/code/artifact'
     #
     # @example a cookbook dependency that will be retrieved from a Git server
-    #   cookbook 'artifact', git: 'https://github.com/RiotGames/artifact-cookbook.git'
+    #   cookbook 'artifact', git: 'https://github.com/chef/artifact-cookbook.git'
     #
     # @overload cookbook(name, version_constraint, options = {})
     #   @param [#to_s] name

--- a/lib/berkshelf/packager.rb
+++ b/lib/berkshelf/packager.rb
@@ -1,4 +1,5 @@
 require "archive/tar/minitar"
+require "find" unless defined?(Find)
 require "zlib" unless defined?(Zlib)
 
 module Berkshelf
@@ -40,8 +41,18 @@ module Berkshelf
     # @return [String]
     #   path to the generated archive
     def run(source)
-      tgz = Zlib::GzipWriter.new(File.open(out_file, "wb"))
-      Archive::Tar::Minitar.pack(Dir.glob("#{source}/*"), tgz)
+      begin
+        dest = Zlib::GzipWriter.open(out_file)
+        tar = RelativeTarWriter.new(dest, source)
+        Find.find(source) do |entry|
+          next if source == entry
+
+          Archive::Tar::Minitar.pack_file(entry, tar)
+        end
+      ensure
+        tar.close
+        dest.close
+      end
 
       out_file
     rescue SystemCallError => ex
@@ -67,5 +78,30 @@ module Berkshelf
 
     # @return [String]
     attr_reader :filename
+
+    # A private decorator for Archive::Tar::Minitar::Writer that
+    # turns absolute paths into relative ones.
+    class RelativeTarWriter < SimpleDelegator #:nodoc:
+      def initialize(io, base_path)
+        @base_path = Pathname.new(base_path)
+        super(Archive::Tar::Minitar::Writer.new(io))
+      end
+
+      %w{add_file add_file_simple mkdir}.each do |method|
+        class_eval <<~RUBY
+          def #{method}(name, *opts, &block)
+            super(relative_path(name), *opts, &block)
+          end
+        RUBY
+      end
+
+      private
+
+      attr_reader :base_path
+
+      def relative_path(path)
+        Pathname.new(path).relative_path_from(base_path).to_s
+      end
+    end
   end
 end

--- a/lib/berkshelf/packager.rb
+++ b/lib/berkshelf/packager.rb
@@ -81,7 +81,7 @@ module Berkshelf
 
     # A private decorator for Archive::Tar::Minitar::Writer that
     # turns absolute paths into relative ones.
-    class RelativeTarWriter < SimpleDelegator #:nodoc:
+    class RelativeTarWriter < SimpleDelegator # :nodoc:
       def initialize(io, base_path)
         @base_path = Pathname.new(base_path)
         super(Archive::Tar::Minitar::Writer.new(io))

--- a/lib/berkshelf/version.rb
+++ b/lib/berkshelf/version.rb
@@ -1,3 +1,3 @@
 module Berkshelf
-  VERSION = "7.2.2".freeze
+  VERSION = "8.0.0".freeze
 end

--- a/lib/berkshelf/version.rb
+++ b/lib/berkshelf/version.rb
@@ -1,3 +1,3 @@
 module Berkshelf
-  VERSION = "8.0.0".freeze
+  VERSION = "8.0.1".freeze
 end

--- a/spec/config/knife.rb
+++ b/spec/config/knife.rb
@@ -4,7 +4,7 @@ node_name                "berkshelf"
 client_key               File.expand_path("spec/config/berkshelf.pem")
 validation_client_name   "validator"
 validation_key           File.expand_path("spec/config/validator.pem")
-chef_server_url          "http://localhost:26310"
+chef_server_url          "http://127.0.0.1:26310"
 cache_type               "BasicFile"
 cache_options( path: "#{ENV["HOME"]}/.chef/checksums" )
 cookbook_path []

--- a/spec/support/git.rb
+++ b/spec/support/git.rb
@@ -5,7 +5,7 @@ module Berkshelf
       include Berkshelf::RSpec::PathHelpers
 
       def git_origin_for(repo, options = {})
-        "file://#{generate_fake_git_remote("git@github.com/RiotGames/#{repo}.git", options)}/.git"
+        "file://#{generate_fake_git_remote("git@github.com/chef/#{repo}.git", options)}/.git"
       end
 
       def generate_fake_git_remote(uri, options = {})


### PR DESCRIPTION
Decorate minitar's output writer to add files using paths relative
to the source directory.
 pulled in from - https://github.com/berkshelf/berkshelf/pull/1858/

### Description
<!--- Please describe what this change achieves -->

### Issues Resolved
Fixex: https://github.com/chef/customer-bugs/issues/535
StackOverflow discussion that's relevant -->

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)