### PR TITLE
This resolves the issue where e.messsage actually contains 'X509_STOR…

### DIFF
--- a/lib/berkshelf/ssl_policies.rb
+++ b/lib/berkshelf/ssl_policies.rb
@@ -16,7 +16,7 @@ module Berkshelf
     def add_trusted_cert(cert)
       @store.add_cert(cert)
     rescue OpenSSL::X509::StoreError => e
-      raise e unless e.message == "cert already in hash table"
+      raise e unless e.message.match(/cert already in hash table/)
     end
 
     def trusted_certs_dir


### PR DESCRIPTION
This resolves an issue where "berks install" fails due to a cert is already being in the hash table. The error is being inadvertently raised because the message string does not match exactly what is stored in e.message.

<!--- Provide a short summary of your changes in the Title above -->
Instead if using `e.message == "cert already in hash table"` we can use a regular expression instead like this: `e.message.match(/cert already in hash table/)`

<!--- Please describe what this change achieves -->


<!--- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)