### PR TITLE
update to work with minitar 1.x

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "mixlib-shellout",      ">= 2.0", "< 4.0"
   s.add_dependency "cleanroom",            "~> 1.0"
-  s.add_dependency "minitar",              ">= 0.6"
+  s.add_dependency "minitar",              "~> 1.0"
   s.add_dependency "retryable",            ">= 2.0", "< 4.0"
   s.add_dependency "solve",                "~> 4.0"
   s.add_dependency "thor",                 ">= 0.20"

--- a/lib/berkshelf/packager.rb
+++ b/lib/berkshelf/packager.rb
@@ -1,4 +1,4 @@
-require "archive/tar/minitar"
+require "minitar"
 require "zlib" unless defined?(Zlib)
 
 module Berkshelf
@@ -41,7 +41,7 @@ module Berkshelf
     #   path to the generated archive
     def run(source)
       tgz = Zlib::GzipWriter.new(File.open(out_file, "wb"))
-      Archive::Tar::Minitar.pack(Dir.glob("#{source}/*"), tgz)
+      Minitar.pack(Dir.glob("#{source}/*"), tgz)
 
       out_file
     rescue SystemCallError => ex


### PR DESCRIPTION
### Description
The berkshelf gemspec allows minitar `>= 0.6`, but there's breaking changes in minitar 1.x

### Check List

- [x] All tests pass (at least the ones that were passing before)
